### PR TITLE
Fixed no-op case in common-ngx-settings-service

### DIFF
--- a/libs/common/ngx/local-store/src/lib/services/common-ngx-local-store.service.ts
+++ b/libs/common/ngx/local-store/src/lib/services/common-ngx-local-store.service.ts
@@ -50,19 +50,6 @@ export class LocalStoreService {
   }
 
   /**
-   * Updates the entire storageKey value.
-   *
-   * @param config Config
-   */
-  public updateStorage(config: ValueConfig) {
-    const storeKey = config.primaryKey || STORAGE_KEY;
-
-    const stored = this.getStorage({ primaryKey: storeKey });
-
-    this.store.set(storeKey, { ...stored, ...config.subKey });
-  }
-
-  /**
    * Gets the value of a key in an optionally provided object stored in Local Storage referenced by storage key.
    * If no storage key reference is provided, the application default storage will be used.
    *

--- a/libs/common/ngx/settings/src/lib/services/common-ngx-settings.service.ts
+++ b/libs/common/ngx/settings/src/lib/services/common-ngx-settings.service.ts
@@ -172,14 +172,6 @@ export class SettingsService {
       const newStore = { ...storeSettings, ...providedMatching };
 
       this._Store.next(newStore);
-
-      // Reduce the store to only the settings that are marked as persistent.
-      const persistent = this.getPersistenCompoundtSettings(newStore);
-
-      // Create a flat simple settings tree from the persistent settings.
-      const flattened = this.compoundToSimpleSettingsTree(persistent);
-
-      this.storage.updateStorage({ ...this._localStorageSettings, value: flattened });
     }
 
     // If the length of the the keys in the provided settings and the service store settings differ, send


### PR DESCRIPTION
Removed some lines that lead to a no-op case when updating setting values in client local storage.

The operation was already being performed on setttings service state change.