### PR TITLE
Fix duplicate URL params causing visual glitch

### DIFF
--- a/libs/maps/esri/src/lib/services/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map.service.ts
@@ -460,7 +460,7 @@ export class EsriMapService {
    * @memberof EsriMapService
    */
   public getFeatureListFromURL(): string[] {
-    // Diciontary of expected URL parameters that include a list of feature references
+    // Dictionary of expected URL parameters that include a list of feature references
     const buildingParameterDictionary = ['bldg', 'Bldg', 'BldgAbbrv', 'bldgabbrv'];
 
     // Parse the current URL into a URL tree
@@ -471,8 +471,10 @@ export class EsriMapService {
 
     // If there is a matching key in the dictionary and the current url tree,
     // then proceed submit queries to the search sources for matches.
-    if (keyExists && tree.queryParams[keyExists].strip().length > 0) {
-      return tree.queryParams[keyExists].split(',');
+    if (keyExists && tree.queryParams[keyExists].trim().length > 0) {
+      const rawParamList = tree.queryParams[keyExists].split(',');
+      // Filter out duplicate values
+      return rawParamList.filter((value, index, array) => array.indexOf(value) === index);
     } else {
       return [];
     }

--- a/libs/ui-kits/ngx/branding/src/lib/reveille-console-log/reveille-console-log.component.html
+++ b/libs/ui-kits/ngx/branding/src/lib/reveille-console-log/reveille-console-log.component.html
@@ -1,1 +1,0 @@
-<p>reveille-console-log works!</p>


### PR DESCRIPTION
When a building is specified multiple times in a URL param, the highlight "stacks" so that building is over-highlighted compared to other buildings. E.g. `bldg=ZACH,ZACH,ZACH,CHEN` CHEN has correct highlight, but ZACH has too much:

![Screenshot from 2019-11-07 12-26-18](https://user-images.githubusercontent.com/6403568/68417377-edb5fc80-015b-11ea-9b26-468ed7403aac.png)

While I was fixing this, I noticed that `strip` isn't a function, so I changed that to `trim`, fixed a typo in a comment, and removed the "reveille-console-log works!" default comment