### PR TITLE
Counties api mod

### DIFF
--- a/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
+++ b/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
@@ -58,12 +58,15 @@ export class CountiesService extends BaseService<County> {
       const t: CountyStat = (acc[countyString] = {});
 
       t.claims = curr.claims.length;
+
       t.sites = curr.claims.reduce((a, c) => {
         return a + c.sites.length;
       }, 0);
+
       t.lockdowns = curr.claims.reduce((a, c) => {
         return a + c.lockdowns.length;
       }, 0);
+
       t.lockdownInfo = curr.claims.map((c) => {
         if (c.lockdowns[0] === undefined) {
           return null;

--- a/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
+++ b/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
@@ -56,6 +56,7 @@ export class CountiesService extends BaseService<County> {
       const countyString = curr.countyFips.toString().padStart(5, '0');
 
       const t: CountyStat = (acc[countyString] = {});
+
       t.claims = curr.claims.length;
       t.sites = curr.claims.reduce((a, c) => {
         return a + c.sites.length;
@@ -64,9 +65,19 @@ export class CountiesService extends BaseService<County> {
         return a + c.lockdowns.length;
       }, 0);
       t.lockdownInfo = curr.claims.map((c) => {
-        
-        return c.lockdowns[0];
-      }, null);
+        if (c.lockdowns[0] === undefined) {
+          return null;
+        } else {
+          const lockdownStat: LockdownStat = {
+            updated: c.lockdowns[0].updated,
+
+            created: c.lockdowns[0].created,
+
+            guid: c.lockdowns[0].guid
+          };
+          return lockdownStat;
+        }
+      });
 
       return acc;
     }, {});
@@ -79,13 +90,15 @@ interface ClaimWithData extends CountyClaim {
   sites: TestingSite[];
   lockdowns: Lockdown[];
 }
+
 interface CountyExtended extends County {
   claims: ClaimWithData[];
   statuses: EntityStatus[];
 }
+
 interface LockdownStat {
-  updated: string;
-  created: string;
+  updated: Date;
+  created: Date;
   guid: string;
 }
 
@@ -93,7 +106,7 @@ interface CountyStat {
   claims?: number;
   sites?: number;
   lockdowns?: number;
-  lockdownInfo?: LockdownStat;
+  lockdownInfo?: LockdownStat[];
 }
 
 export interface CountyStats {

--- a/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
+++ b/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
@@ -73,9 +73,7 @@ export class CountiesService extends BaseService<County> {
         } else {
           const lockdownStat: LockdownStat = {
             updated: c.lockdowns[0].updated,
-
             created: c.lockdowns[0].created,
-
             guid: c.lockdowns[0].guid
           };
           return lockdownStat;

--- a/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
+++ b/libs/covid/data-api/src/lib/modules/counties/counties.service.ts
@@ -56,7 +56,6 @@ export class CountiesService extends BaseService<County> {
       const countyString = curr.countyFips.toString().padStart(5, '0');
 
       const t: CountyStat = (acc[countyString] = {});
-
       t.claims = curr.claims.length;
       t.sites = curr.claims.reduce((a, c) => {
         return a + c.sites.length;
@@ -64,6 +63,10 @@ export class CountiesService extends BaseService<County> {
       t.lockdowns = curr.claims.reduce((a, c) => {
         return a + c.lockdowns.length;
       }, 0);
+      t.lockdownInfo = curr.claims.map((c) => {
+        
+        return c.lockdowns[0];
+      }, null);
 
       return acc;
     }, {});
@@ -80,11 +83,17 @@ interface CountyExtended extends County {
   claims: ClaimWithData[];
   statuses: EntityStatus[];
 }
+interface LockdownStat {
+  updated: string;
+  created: string;
+  guid: string;
+}
 
 interface CountyStat {
   claims?: number;
   sites?: number;
   lockdowns?: number;
+  lockdownInfo?: LockdownStat;
 }
 
 export interface CountyStats {


### PR DESCRIPTION
Modifying the "counties/stats/" endpoint to return lockdown information. This is so the map that track lockdowns can easily color code the counties based on lockdowns timestamps.