### PR TITLE
Updated with date-less basemap url

### DIFF
--- a/apps/aggiemap-angular/src/environments/definitions.ts
+++ b/apps/aggiemap-angular/src/environments/definitions.ts
@@ -1,7 +1,7 @@
 import { Popups } from '@tamu-gisc/aggiemap';
 
 export const Connections = {
-  basemapUrl: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/BaseMap_20200123/MapServer',
+  basemapUrl: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/TAMU_BaseMap/MapServer',
   inforUrl: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer',
   accessibleUrl: 'https://fc-gis.tamu.edu/arcgis/rest/services/FCOR/ADA_120717/MapServer/0',
   constructionUrl: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/Construction_2018/MapServer',


### PR DESCRIPTION
MSI no longer uses a date stamped basemap service name. The basemap service which was last used by aggiemap was taken down and basically broke it.

Updating the basemap to use the new static named basemap service.