### PR TITLE
Esri layer list extent filter

### DIFF
--- a/apps/aggiemap-angular/src/environments/environment.ts
+++ b/apps/aggiemap-angular/src/environments/environment.ts
@@ -74,7 +74,9 @@ export const LayerSources: LayerSource[] = [
       }
     ],
     native: {
-      ...commonLayerProps
+      ...commonLayerProps,
+      maxScale: 3000,
+      minScale: 25000
     }
   },
   {

--- a/apps/aggiemap-angular/src/environments/environment.ts
+++ b/apps/aggiemap-angular/src/environments/environment.ts
@@ -74,9 +74,7 @@ export const LayerSources: LayerSource[] = [
       }
     ],
     native: {
-      ...commonLayerProps,
-      maxScale: 3000,
-      minScale: 25000
+      ...commonLayerProps
     }
   },
   {

--- a/libs/maps/feature/layer-list/src/lib/components/layer-list-categorized/layer-list-categorized.component.html
+++ b/libs/maps/feature/layer-list/src/lib/components/layer-list-categorized/layer-list-categorized.component.html
@@ -8,7 +8,7 @@
     <tamu-gisc-accordion [expanded]="category.expanded">
       <tamu-gisc-accordion-header (click)="category.expanded = !category.expanded">{{category.title}}</tamu-gisc-accordion-header>
       <tamu-gisc-accordion-content>
-        <p *ngFor="let item of category.layers" class="layer-item" [ngClass]="{ loaded: item?.layer?.loaded && item?.layer?.visible }" (click)="toggleLayer(item)">
+        <p *ngFor="let item of category.layers" class="layer-item" [ngClass]="{ loaded: item?.layer?.loaded && item?.layer?.visible, hidden: item.outsideExtent }" (click)="toggleLayer(item)">
           {{ item.title }}
         </p>
       </tamu-gisc-accordion-content>

--- a/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.html
+++ b/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <p *ngFor="let item of layers | async" class="layer-item" [ngClass]="{ loaded: item?.layer?.loaded && item?.layer?.visible }" (click)="toggleLayer(item)">
+  <p *ngFor="let item of layers | async" class="layer-item" [ngClass]="{ loaded: item?.layer?.loaded && item?.layer?.visible, hidden: item.outsideExtent }" (click)="toggleLayer(item)">
     {{ item.title }}
   </p>
 </div>

--- a/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.scss
+++ b/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.scss
@@ -27,6 +27,10 @@
   &:last-child {
     padding-bottom: 0;
   }
+
+  &.hidden {
+    display: none;
+  }
 }
 
 .sidebar-component-content-container {

--- a/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
+++ b/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
@@ -10,17 +10,20 @@ import {
   of,
   forkJoin
 } from 'rxjs';
-import { mergeMap, filter, switchMap, scan, take, toArray, withLatestFrom } from 'rxjs/operators';
+import { mergeMap, filter, switchMap, scan, take, toArray, withLatestFrom, debounceTime } from 'rxjs/operators';
 
+import { LayerSource } from '@tamu-gisc/common/types';
 import { EsriMapService, EsriModuleProviderService, MapServiceInstance } from '@tamu-gisc/maps/esri';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
-import { LayerSource } from '@tamu-gisc/common/types';
 import esri = __esri;
 
 @Injectable()
 export class LayerListService implements OnDestroy {
   private _store: BehaviorSubject<LayerListItem<esri.Layer>[]> = new BehaviorSubject([]);
+
+  private _scale: BehaviorSubject<number> = new BehaviorSubject(undefined);
+  private _scaleThrottled: Observable<number>;
 
   private _handles: esri.Handles;
 
@@ -30,16 +33,16 @@ export class LayerListService implements OnDestroy {
     private environment: EnvironmentService
   ) {
     const LayerSources = this.environment.value('LayerSources');
+    this._scaleThrottled = this._scale.asObservable().pipe(debounceTime(250));
 
     forkJoin([from(this.moduleProvider.require(['Handles'])), this.mapService.store]).subscribe(
-      ([[HandlesConstructor], res]: [[esri.HandlesConstructor], MapServiceInstance]) => {
+      ([[HandlesConstructor], instance]: [[esri.HandlesConstructor], MapServiceInstance]) => {
         this._handles = new HandlesConstructor();
-
         // Perform a check against the map instance to add existing layers. Layers added after this
         // point will be handled by the change event.
 
         // Create a LayerListItem instance for each including the existing layer instance as a class property.
-        const existing: LayerListItem<esri.Layer>[] = res.map.allLayers
+        const existing: LayerListItem<esri.Layer>[] = instance.map.allLayers
           .filter((l) => {
             // Undefined value means "default" value, which is equal to "show"
             return l.listMode === undefined || l.listMode === 'show';
@@ -62,7 +65,7 @@ export class LayerListService implements OnDestroy {
         this._store.next([...existing, ...nonExisting]);
 
         // Event handler that listens for layer changes in the map instance
-        res.map.allLayers.on('change', (e) => {
+        instance.map.allLayers.on('change', (e) => {
           // Handle added layers case
           if (e.added) {
             // Each event only has the layers for that particular event. It does not include layers in
@@ -104,6 +107,10 @@ export class LayerListService implements OnDestroy {
 
             this._store.next(minusRemoved);
           }
+        });
+
+        instance.view.watch('scale', (scale) => {
+          this._scale.next(scale);
         });
       }
     );
@@ -169,7 +176,8 @@ export class LayerListService implements OnDestroy {
             }
           })
         ),
-        this._store
+        this._store,
+        this._scaleThrottled
       )
         // Normalize either emission by mapping to the exposed store observable.
         .pipe(
@@ -186,7 +194,7 @@ export class LayerListService implements OnDestroy {
    * emissions are different, they have to be normalized before any subscribers can process the value.
    *
    */
-  private mapLayerChangeEvent(): MonoTypeOperatorFunction<LayerListItem<esri.Layer>[] | esri.WatchCallback> {
+  private mapLayerChangeEvent(): MonoTypeOperatorFunction<LayerListItem<esri.Layer>[] | esri.WatchCallback | number> {
     return ($input) =>
       $input.pipe(
         switchMap((collection) => {
@@ -194,15 +202,21 @@ export class LayerListService implements OnDestroy {
           // One of two conditions must be met:
           //
           // Collection is of length zero, which means there are no layers added to the map yet. We still  want an emission out
-          // of an empty LayerListItem colleciton. In addition, if the collection is empty it cannot be an esri WatchCallback because
+          // of an empty LayerListItem collection. In addition, if the collection is empty it cannot be an esri WatchCallback because
           // the length of that array is known.
-          if (collection.length === 0 || (<LayerListItem<esri.Layer>[]>collection).some((i) => i instanceof LayerListItem)) {
+          if (
+            collection instanceof Array ||
+            (collection instanceof Array &&
+              (<LayerListItem<esri.Layer>[]>collection).some((i) => i instanceof LayerListItem))
+          ) {
             return of(collection);
+          } else if (typeof collection === 'number' || collection === undefined) {
+            return this._store.asObservable().pipe(take(1));
           } else {
             // If the collection is not a list of LayerListItem, then it is a collection with esri WatchCallback values.
             //
             // To avoid multiple emissions for every layer despite having a single WatchHandle event, limit the LayerListItem
-            // collection to be only the affeted LayerListItems
+            // collection to be only the affected LayerListItems
             return this._store.asObservable().pipe(
               take(1),
               switchMap((list) => from(list)),
@@ -230,15 +244,25 @@ export class LayerListService implements OnDestroy {
   private filterLayers(
     props: ILayerSubscriptionProperties,
     filterLazy: boolean
-  ): MonoTypeOperatorFunction<LayerListItem<esri.Layer>[]> {
+  ): MonoTypeOperatorFunction<Array<LayerListItem<esri.FeatureLayer | esri.GraphicsLayer>>> {
     return (input$) =>
       input$.pipe(
         switchMap((list) => {
           return from(list);
         }),
-        filter((item) => {
+        withLatestFrom(this._scale),
+        filter(([item, scale]) => {
           if (item.layer === undefined && filterLazy) {
             return false;
+          }
+
+          if (
+            (scale !== undefined && item.layer && item.layer.maxScale !== 0 && item.layer.maxScale >= scale) ||
+            (scale !== undefined && item.layer && item.layer.minScale !== 0 && item.layer.minScale <= scale)
+          ) {
+            item.outsideExtent = true;
+          } else {
+            item.outsideExtent = false;
           }
 
           if (props === undefined || props.layers === undefined) {
@@ -257,12 +281,12 @@ export class LayerListService implements OnDestroy {
         //
         // It's possible to achieve the same end-result with the scan operator that collects stream emissions over time.
         withLatestFrom(this._store),
-        scan((acc, [curr, store]) => {
+        scan((acc, [[layer], store]) => {
           // Diff the accumulated layers with the store and remove anything from the accumulated that doesn't exist in store.
           acc = store.map((sl) => acc.find((al) => al.id === sl.id)).filter((l) => l !== undefined);
 
           // Check if the accumulated value contains the current layer by id
-          const existingIndex = acc.findIndex((layer) => layer.id === curr.id);
+          const existingIndex = acc.findIndex((l) => l.id === layer.id);
 
           // If the existing index already has a defined layer, return the current accumulated value
           // Since layers will always be references, their state value is handled by the API.
@@ -276,10 +300,10 @@ export class LayerListService implements OnDestroy {
           //
           // If the existingIndex is out of bounds (-1), then the LayerListItem does not exist in the accumulator. In this case, add it.
           if (existingIndex > -1 && acc[existingIndex].layer === undefined) {
-            acc.splice(existingIndex, 1, curr);
+            acc.splice(existingIndex, 1, layer);
             return [...acc];
           } else {
-            return [...acc, curr];
+            return [...acc, layer];
           }
         }, [])
       );
@@ -291,6 +315,7 @@ export class LayerListItem<T extends esri.Layer> {
   public title: LayerSource['title'];
   public layer: T;
   public category: LayerSource['category'];
+  public outsideExtent: boolean;
 
   constructor(props: { id?: string; title?: string; layer?: T; category?: string }) {
     this.layer = props.layer;

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -2,12 +2,10 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
-import { LayerListItem, LayerListService } from '@tamu-gisc/maps/feature/layer-list';
-
+import { LayerListService } from '@tamu-gisc/maps/feature/layer-list';
 import { LayerSource, LegendItem } from '@tamu-gisc/common/types';
 
 import esri = __esri;
-import Layer = __esri.Layer;
 
 @Injectable()
 export class LegendService {
@@ -39,7 +37,7 @@ export class LegendService {
       if (layer.visible) {
         this.addMany((<LayerSource>(<unknown>layer)).legendItems);
       } else {
-        // If the layer visibilty is false, remove the legend item.
+        // If the layer visibility is false, remove the legend item.
         this.removeMany((<LayerSource>(<unknown>layer)).legendItems);
       }
     }

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -20,7 +20,7 @@ export class LegendService {
     // This does not handle removal on layer visibility change
     this.layerListService.layers({ watchProperties: 'visible' }).subscribe((value) => {
       const layersLegendItems = value
-        .filter((item) => item.layer && item.layer.visible)
+        .filter((item) => item.layer && item.layer.visible && item.outsideExtent === false)
         .filter((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
         .map((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
         .map((obj) => obj[0]);


### PR DESCRIPTION
Not the prettiest implementation but will suffice for now.

Better ways to do this: Layer list is handled by CSS, keeping in mind categorized layer lists and re-rendering on layer store changes. Would be better to handle all of this within the model and let the rendering to the structural directives just like the legend is rendering legend items.