### PR TITLE
fix(aggiemap): additional scoring for building searches

### DIFF
--- a/apps/aggiemap-angular/src/environments/environment.prod.ts
+++ b/apps/aggiemap-angular/src/environments/environment.prod.ts
@@ -259,7 +259,7 @@ export const LayerSources: LayerSource[] = [
     id: d.BIKE_LOCATIONS.layerId,
     title: d.BIKE_LOCATIONS.name,
     url: d.BIKE_LOCATIONS.url,
-    listMode: 'show',
+    listMode: 'hide',
     loadOnInit: false,
     visible: true,
     native: {
@@ -361,10 +361,10 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER', 'UPPER', 'UPPER']
       },
       scoringWhere: {
-        keys: ['BldgName'],
-        operators: ['LIKE'],
-        wildcards: ['startsWith'],
-        transformations: ['UPPER']
+        keys: ['BldgName', 'BldgAbbr'],
+        operators: ['LIKE', 'LIKE'],
+        wildcards: ['startsWith', 'startsWith'],
+        transformations: ['UPPER', 'UPPER']
       }
     },
     scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],

--- a/apps/aggiemap-angular/src/environments/environment.ts
+++ b/apps/aggiemap-angular/src/environments/environment.ts
@@ -259,7 +259,7 @@ export const LayerSources: LayerSource[] = [
     id: d.BIKE_LOCATIONS.layerId,
     title: d.BIKE_LOCATIONS.name,
     url: d.BIKE_LOCATIONS.url,
-    listMode: 'show',
+    listMode: 'hide',
     loadOnInit: false,
     visible: true,
     native: {
@@ -361,10 +361,10 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER', 'UPPER', 'UPPER']
       },
       scoringWhere: {
-        keys: ['BldgName'],
-        operators: ['LIKE'],
-        wildcards: ['startsWith'],
-        transformations: ['UPPER']
+        keys: ['BldgName', 'BldgAbbr'],
+        operators: ['LIKE', 'LIKE'],
+        wildcards: ['startsWith', 'startsWith'],
+        transformations: ['UPPER', 'UPPER']
       }
     },
     scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],

--- a/libs/aggiemap/src/lib/modules/sidebar/sidebar.component.html
+++ b/libs/aggiemap/src/lib/modules/sidebar/sidebar.component.html
@@ -8,7 +8,7 @@ We are injecting application-specific sidebar tabs and content -->
 
     <tamu-gisc-sidebar-tab [title]="'Directions'" [description]="'Toggle directions controls (routing and way-finding)'" [material_icon]="'directions'" [route]="'trip'"></tamu-gisc-sidebar-tab>
 
-    <tamu-gisc-sidebar-tab [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'"></tamu-gisc-sidebar-tab>
+    <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'"></tamu-gisc-sidebar-tab>
   </div>
 
   <div class="content">

--- a/libs/aggiemap/src/lib/modules/sidebar/sidebar.component.ts
+++ b/libs/aggiemap/src/lib/modules/sidebar/sidebar.component.ts
@@ -1,10 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 @Component({
   selector: 'tamu-gisc-aggiemap-sidebar',
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })
-export class AggiemapSidebarComponent {
-  constructor() {}
+export class AggiemapSidebarComponent implements OnInit {
+  public isDev: Observable<boolean>;
+
+  constructor(private devTools: TestingService) {}
+
+  public ngOnInit() {
+    this.isDev = this.devTools.get('isTesting');
+  }
 }

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.html
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.html
@@ -11,7 +11,7 @@
 <div class="options-container">
   <div>
     <!-- Trip from and to input components. By default, two blanks are automatically generated given that a trip has a minimum of two points -->
-    <tamu-gisc-trip-planner-time-picker></tamu-gisc-trip-planner-time-picker>
+    <tamu-gisc-trip-planner-time-picker *ngIf="(isDev | async) === true"></tamu-gisc-trip-planner-time-picker>
   </div>
 
   <div>

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.ts
@@ -1,20 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 import { TripPlannerService } from '../../../../services//trip-planner.service';
+import { pluck, take } from 'rxjs/operators';
 
 @Component({
   selector: 'tamu-gisc-trip-planner-mode-picker',
   templateUrl: './base.component.html',
   styleUrls: ['./base.component.scss']
 })
-export class TripPlannerModePickerComponent {
-  constructor(private plannerService: TripPlannerService) {}
+export class TripPlannerModePickerComponent implements OnInit {
+  public isDev: Observable<boolean>;
+
+  constructor(private plannerService: TripPlannerService, private devTools: TestingService) {}
+
+  public ngOnInit() {
+    this.isDev = this.devTools.get('isTesting');
+  }
+
   /**
    * Calls the trip planner service and sets accessible travel mode based on the provided value
-   *
-   * @param {value} value `true` to set accessible routing mode, `false` to disable it
    */
-  public set accessibleTravel(value: boolean) {
-    this.plannerService.updateTravelOptions({ accessible: value });
+  public toggleAccessibleTravel() {
+    this.plannerService.TravelOptions.pipe(
+      take(1),
+      pluck('accessible')
+    ).subscribe((current) => {
+      this.plannerService.updateTravelOptions({ accessible: !current });
+    });
   }
 }

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/base/base.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
+import { pluck, take } from 'rxjs/operators';
 
 import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 import { TripPlannerService } from '../../../../services//trip-planner.service';
-import { pluck, take } from 'rxjs/operators';
 
 @Component({
   selector: 'tamu-gisc-trip-planner-mode-picker',

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/mobile/mobile.component.html
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/mobile/mobile.component.html
@@ -13,8 +13,15 @@
 
   <tamu-gisc-trip-planner-mode-toggle [activeModes]="[5, 6]" [iconName]="'directions_bus'" [name]="'Bus'" [label]="'Routing Mode: Bus'"></tamu-gisc-trip-planner-mode-toggle>
 
-  <!-- TODO: Determine a travel options UI for mobile -->
-  <!-- <div class="filled" id="direction-accessible-mode" title="ADA Accessible Requirement" alt="Option: ADA Accessible Requirement" type="domElement" [ngClass]="{ disabled: !verifyInputValidity() && accessible, active: accessible }" (click)="verifyInputValidity() ? (accessibleTravel = !accessible) : null" tabindex="0">
-    <i class="material-icons">accessible</i>
-  </div> -->
+  <ng-container *ngIf="(isAccessibleMode | async) === true; else noAdaClick">
+    <div class="filled" id="direction-accessible-mode" title="ADA Accessible Requirement" alt="Option: ADA Accessible Requirement" type="domElement" [ngClass]="{ active: (accessible | async) === true }" (click)="toggleAccessibleTravel()" tabindex="0">
+      <i class="material-icons">accessible</i>
+    </div>
+  </ng-container>
+
+  <ng-template #noAdaClick
+    ><div class="filled" id="direction-accessible-mode" title="ADA Accessible Requirement" alt="Option: ADA Accessible Requirement" type="domElement" [ngClass]="{ active: (accessible | async) === true }" tabindex="0">
+      <i class="material-icons">accessible</i>
+    </div></ng-template
+  >
 </div>

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/mobile/mobile.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-mode-picker/containers/mobile/mobile.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
+import { pluck, map } from 'rxjs/operators';
+
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 import { TripPlannerService } from '../../../../services/trip-planner.service';
 import { TripPlannerModePickerComponent } from '../base/base.component';
@@ -12,19 +15,21 @@ import { TripPlannerModePickerComponent } from '../base/base.component';
 export class TripPlannerModePickerMobileComponent extends TripPlannerModePickerComponent implements OnInit, OnDestroy {
   private _destroy$: Subject<boolean> = new Subject();
 
-  public accessible: boolean;
+  public accessible: Observable<boolean>;
+  public isAccessibleMode: Observable<boolean>;
 
-  constructor(private tps: TripPlannerService) {
-    super(tps);
+  constructor(private tps: TripPlannerService, private dts: TestingService) {
+    super(tps, dts);
   }
 
   public ngOnInit() {
-    //
-    // TODO: Might be able to be removed, depending on new mobile travel options  UI requirements
-    //
-    // this.tps.Accessible.pipe(takeUntil(this._destroy$)).subscribe((value) => {
-    //   this.accessible = value;
-    // });
+    this.accessible = this.tps.TravelOptions.pipe(pluck('accessible'));
+    this.isAccessibleMode = this.tps.TravelOptions.pipe(
+      pluck('travel_mode'),
+      map((mode) => {
+        return this.tps.verifyRuleAccessibility();
+      })
+    );
   }
 
   public ngOnDestroy() {

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/base/base.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/base/base.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { pluck } from 'rxjs/operators';
 
 import { Angulartics2 } from 'angulartics2';
 import { v4 as guid } from 'uuid';
-import { CompoundSettings } from '@tamu-gisc/common/ngx/settings';
+
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 import { TripPlannerRuleMode, TripPlannerService } from '../../../../services/trip-planner.service';
 
@@ -12,7 +13,7 @@ import { TripPlannerRuleMode, TripPlannerService } from '../../../../services/tr
   selector: 'tamu-gisc-trip-planner-options-base',
   template: ''
 })
-export class TripPlannerOptionsBaseComponent {
+export class TripPlannerOptionsBaseComponent implements OnInit {
   /**
    * Data injected by the trip planner parking options component factory.
    */
@@ -20,7 +21,13 @@ export class TripPlannerOptionsBaseComponent {
 
   public travelOptions = this.tripPlanner.TravelOptions;
 
-  constructor(private anl: Angulartics2, private tripPlanner: TripPlannerService) {}
+  public isDev: Observable<boolean>;
+
+  constructor(private anl: Angulartics2, private tripPlanner: TripPlannerService, private devTools: TestingService) {}
+
+  public ngOnInit() {
+    this.isDev = this.devTools.get('isTesting');
+  }
 
   /**
    * Invokes the trip planner options service which updates the local store value,
@@ -42,7 +49,7 @@ export class TripPlannerOptionsBaseComponent {
     let opts;
 
     // If key is an object, then it is a `TripPlannerRuleMode`.
-    // Determine if there are any configure effects and udpate store
+    // Determine if there are any configure effects and update store
     // with created options object based on effect and value.
     if (key instanceof Object) {
       const effect = key.effect;
@@ -76,7 +83,7 @@ export class TripPlannerOptionsBaseComponent {
    * Get a key value from the  options service which values are a
    * reflection of the local store.
    */
-  public getOptionValue(key): Observable<CompoundSettings> {
+  public getOptionValue(key: string) {
     return this.travelOptions.pipe(pluck(key));
   }
 }

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/biking/trip-planner-biking-options.component.html
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/biking/trip-planner-biking-options.component.html
@@ -1,9 +1,9 @@
-<div>
+<div *ngIf="(isDev | async) === true">
   <div class="sidebar-component-name">
     <p>Biking Settings</p>
   </div>
 
   <div class="sidebar-component-content-container">
-    <tamu-gisc-checkbox *ngFor="let option of (settings | async)" [disabled]="false" [label]="option.displayName" [description]="option.description" [checked]="(getOptionValue(option.effect) | async) == true" (changed)="setOptionValue(option, $event)"></tamu-gisc-checkbox>
+    <tamu-gisc-checkbox *ngFor="let option of (settings | async)" [disabled]="false" [label]="option.displayName" [description]="option.description" [checked]="(getOptionValue(option.effect) | async) === true" (changed)="setOptionValue(option, $event)"></tamu-gisc-checkbox>
   </div>
 </div>

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/biking/trip-planner-biking-options.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/biking/trip-planner-biking-options.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Angulartics2 } from 'angulartics2';
+
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 import { TripPlannerOptionsBaseComponent } from '../base/base.component';
 import { TripPlannerService } from '../../../../services/trip-planner.service';
@@ -10,7 +12,7 @@ import { TripPlannerService } from '../../../../services/trip-planner.service';
   styleUrls: ['../../containers/base/base.component.scss']
 })
 export class TripPlannerBikingOptionsComponent extends TripPlannerOptionsBaseComponent {
-  constructor(private analytics: Angulartics2, private tp: TripPlannerService) {
-    super(analytics, tp);
+  constructor(private analytics: Angulartics2, private tp: TripPlannerService, private dts: TestingService) {
+    super(analytics, tp, dts);
   }
 }

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/parking/trip-planner-parking-options.component.html
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/parking/trip-planner-parking-options.component.html
@@ -1,15 +1,11 @@
-<div>
+<div *ngIf="(isDev | async) === true">
   <div class="sidebar-component-name">
     <p>Driving Settings</p>
   </div>
 
   <div class="sidebar-component-content-container">
-    <tamu-gisc-checkbox *ngFor="let option of settings | async" [disabled]="false" [label]="option.displayName"
-      [description]="option.description" [checked]="(getOptionValue(option.effect) | async) == true"
-      (changed)="setOptionValue(option, $event)"></tamu-gisc-checkbox>
+    <tamu-gisc-checkbox *ngFor="let option of settings | async" [disabled]="false" [label]="option.displayName" [description]="option.description" [checked]="(getOptionValue(option.effect) | async) == true" (changed)="setOptionValue(option, $event)"></tamu-gisc-checkbox>
 
-    <tamu-gisc-select [value]="getOptionValue('parking_pass_permit') | async" [data]="parkingFeatures | async"
-      [displayTemplate]="'attributes.FAC_CODE'" [valueTemplate]="'attributes.FAC_CODE'"
-      (changed)="setOptionValue('parking_pass_permit', $event)" [placeholder]="'Select Your Permit'"></tamu-gisc-select>
+    <tamu-gisc-select [value]="getOptionValue('parking_pass_permit') | async" [data]="parkingFeatures | async" [displayTemplate]="'attributes.FAC_CODE'" [valueTemplate]="'attributes.FAC_CODE'" (changed)="setOptionValue('parking_pass_permit', $event)" [placeholder]="'Select Your Permit'"></tamu-gisc-select>
   </div>
 </div>

--- a/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/parking/trip-planner-parking-options.component.ts
+++ b/libs/maps/feature/trip-planner/src/lib/components/trip-planner-options/components/parking/trip-planner-parking-options.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 
 import { Angulartics2 } from 'angulartics2';
 
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
+
 import { ParkingService } from '../../../../services/transportation/drive/parking.service';
 import { TripPlannerOptionsBaseComponent } from '../base/base.component';
 import { TripPlannerService } from '../../../../services/trip-planner.service';
@@ -23,8 +25,9 @@ export class TripPlannerParkingOptionsComponent extends TripPlannerOptionsBaseCo
   constructor(
     private analytics: Angulartics2,
     private tp: TripPlannerService,
+    private dts: TestingService,
     private parking: ParkingService<esri.Graphic>
   ) {
-    super(analytics, tp);
+    super(analytics, tp, dts);
   }
 }

--- a/libs/maps/feature/trip-planner/src/lib/services/trip-planner.service.ts
+++ b/libs/maps/feature/trip-planner/src/lib/services/trip-planner.service.ts
@@ -1322,9 +1322,9 @@ export class TripPlannerService implements OnDestroy {
 
                           if (modeSwitch.type === 'not_walking') {
                             switch (this.getRuleForModes([parseInt(travelMode, 10)])) {
-                              case this.rule_bus:
-                                return this.busService.annotateBusGraphic(modeSwitch);
-                              case this.rule_drive:
+                              // case this.rule_bus:
+                              //   return this.busService.annotateBusGraphic(modeSwitch);
+                              // case this.rule_drive:
                               // TODO this.inrixService.annotateDriveFeature(graphic, modeSwitch, dateToHere).subscribe((f_new: esri.Graphic) => res(f_new)); break;
                               default:
                                 return of(modeSwitch);


### PR DESCRIPTION
A building search with the keyword "MIST" which is the building abbreviation for Mitchell Inst for Fundamental Phys & Astronomy building returned instead Bioche*mist*ry/Biophysics Building building. This was caused by a first-order query result as a result of incoming visits from student schedule pages from Howdy.

This implements a secondary scoring where lookup that will consider cases where the the input keyword and scores all results based on the combined results.

Because this will be the first public release of the project based on the new monorepo structure, I have hidden many of the development/experimental features unless they're on a development host.