### PR TITLE
fix(oidc-apps): Production configurations and fixes

### DIFF
--- a/apps/oidc-admin-angular/src/app/app.component.html
+++ b/apps/oidc-admin-angular/src/app/app.component.html
@@ -43,7 +43,7 @@
 
       <div class="menu-item">
         <span class="material-icons">login</span>
-        <a href="http://localhost:3000/oidc/login">Login</a>
+        <a [href]="loginUrl">Login</a>
       </div>
     </div>
   </div>

--- a/apps/oidc-admin-angular/src/app/app.component.ts
+++ b/apps/oidc-admin-angular/src/app/app.component.ts
@@ -1,10 +1,18 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 @Component({
   selector: 'tamu-gisc-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
-  public title = 'oidc-admin-angular';
+export class AppComponent implements OnInit {
+  public loginUrl: string;
+
+  constructor(private env: EnvironmentService) {}
+
+  public ngOnInit() {
+    this.loginUrl = this.env.value('api_url') + '/oidc/login';
+  }
 }

--- a/apps/oidc-admin-angular/src/environments/environment.ts
+++ b/apps/oidc-admin-angular/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  api_url: 'http://localhost:3000'
+  api_url: 'http://localhost:27000'
 };
 
 /*
@@ -15,4 +15,4 @@ export const environment = {
  * on performance if an error is thrown.
  */
 // import 'zone.js/dist/zone-error';  // Included with Angular CLI.
-export const api_url = `http://localhost:3000`;
+export const api_url = `http://localhost:27000`;

--- a/apps/oidc-admin-nest/src/environments/environment.prod.ts
+++ b/apps/oidc-admin-nest/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
 export const environment = {
-  production: true
+  production: true,
+  port: 27000,
+  globalPrefix: 'api'
 };

--- a/apps/oidc-admin-nest/src/environments/environment.ts
+++ b/apps/oidc-admin-nest/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: false,
-  port: 4001
+  port: 27000,
+  globalPrefix: ''
 };
 
 export { localDbConfig as dbConfig } from './ormconfig';

--- a/apps/oidc-admin-nest/src/main.ts
+++ b/apps/oidc-admin-nest/src/main.ts
@@ -2,12 +2,15 @@ import { NestFactory } from '@nestjs/core';
 
 import passport from 'passport';
 import session from 'express-session';
-const SQLiteStore = require('connect-sqlite3')(session);
+import * as sqliteStore from 'connect-sqlite3';
 
 import { OpenIdClient } from '@tamu-gisc/oidc/client';
 
 import { AppModule } from './app/app.module';
 import { OIDC_CLIENT_METADATA, OIDC_CLIENT_PARAMS, OIDC_IDP_ISSUER_URL } from './environments/oidcconfig';
+import { environment } from './environments/environment';
+
+const SQLiteStore = sqliteStore(session);
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -39,7 +42,9 @@ async function bootstrap() {
 
   app.use(passport.initialize());
   app.use(passport.session());
-  await app.listen(3000);
+  await app.listen(environment.port, () => {
+    console.log('Listening at http://localhost:' + environment.port + '/' + environment.globalPrefix);
+  });
 }
 
 OpenIdClient.build(OIDC_CLIENT_METADATA, OIDC_CLIENT_PARAMS, OIDC_IDP_ISSUER_URL)

--- a/apps/oidc-provider-nest/src/app/app.module.ts
+++ b/apps/oidc-provider-nest/src/app/app.module.ts
@@ -81,6 +81,4 @@ import { dbConfig } from '../environments/environment';
   controllers: [AppController, SecretQuestionController],
   providers: [AppService]
 })
-export class AppModule {
-  constructor() {}
-}
+export class AppModule {}

--- a/apps/oidc-provider-nest/src/environments/environment.prod.ts
+++ b/apps/oidc-provider-nest/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
-  port: 4001
+  port: 4001,
+  globalPrefix: ''
 };
 
 export { productionDbConfig as dbConfig } from './ormconfig';

--- a/apps/oidc-provider-nest/src/environments/environment.ts
+++ b/apps/oidc-provider-nest/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: false,
-  port: 4001
+  port: 4001,
+  globalPrefix: ''
 };
 
 export { localDbConfig as dbConfig } from './ormconfig';

--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -50,7 +50,9 @@ async function bootstrap() {
   app.use(cookieParser());
   app.use('/oidc', OpenIdProvider.provider.callback);
 
-  await app.listenAsync(environment.port);
+  await app.listen(environment.port, () => {
+    console.log('Listening at http://localhost:' + environment.port + '/' + environment.globalPrefix);
+  });
 }
 
 bootstrap();


### PR DESCRIPTION
The applications needed several environment configuration changes and fixes to prepare them for production. Still a few more things to get through but this should put us one step closer:

- IDP Angular application sidebar login now references the environment `api_url`, instead of fixed url.
- Re-added server listening printouts for `oidc-admin-nest` and `oidc-provider-nest` so we can see which port they're running on. It was impossible to tell beforehand.
- Added assets folder and dummy file to `oidc-admin-nest/src` that weren't there before and prevented local serving
- Added production configuration for `oidc-admin-nest` and `oidc-provider-nest` including `port` and `globalPrefix`