### PR TITLE
fix(oidc-admin-nest): Added production environment DB config export 

### DIFF
--- a/apps/oidc-admin-nest/src/environments/environment.prod.ts
+++ b/apps/oidc-admin-nest/src/environments/environment.prod.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: true,
   port: 27000,
-  globalPrefix: 'api'
+  globalPrefix: ''
 };
+
+export { productionDbConfig as dbConfig } from './ormconfig';


### PR DESCRIPTION
Production environment did not have a db export which caused the build to fail.