### PR TITLE
refactor(maps-feature-legend): Esri legend component rewrite

### DIFF
--- a/libs/common/ngx/environment/src/lib/services/environment.service.ts
+++ b/libs/common/ngx/environment/src/lib/services/environment.service.ts
@@ -8,7 +8,7 @@ export class EnvironmentService {
 
   constructor(@Optional() @Inject(env) private environment) {
     if (environment) {
-      this._config = this.environment;
+      this._config = JSON.parse(JSON.stringify(this.environment));
     } else {
       throw new Error(`Environment module expects an 'env' token value. None provided.`);
     }
@@ -30,6 +30,14 @@ export class EnvironmentService {
       } else {
         throw new Error(`Environment does not contain a '${property}' token.`);
       }
+    }
+  }
+
+  public update(property: string, value: unknown) {
+    if (this._config[property] !== undefined) {
+      this._config[property] = value;
+    } else {
+      console.warn(`Could not set value. Environment does not contain ${property} token.`);
     }
   }
 }

--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -263,6 +263,14 @@ export type LayerSource = LayerSourceType & {
   layerIndex?: number;
 
   category?: string;
+
+  /**
+   * Describes if the layer source was added at runtime and not statically defined in application environments.
+   *
+   * This is used internally to manage side-effects until a better solution is implemented. This property will be
+   * removed in the future.
+   */
+  runtimeAdded?: boolean;
 };
 
 export interface LegendItem {

--- a/libs/maps/esri/src/lib/components/esri-map/esri-map.component.ts
+++ b/libs/maps/esri/src/lib/components/esri-map/esri-map.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, ViewChild, ElementRef, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
+
 import { EsriMapService, MapConfig, MapServiceInstance } from '../../services/map.service';
 
 @Component({
@@ -6,7 +7,7 @@ import { EsriMapService, MapConfig, MapServiceInstance } from '../../services/ma
   templateUrl: './esri-map.component.html',
   styleUrls: ['./esri-map.component.scss']
 })
-export class EsriMapComponent implements OnInit {
+export class EsriMapComponent implements OnInit, OnDestroy {
   @Input()
   public config: MapConfig;
 
@@ -30,5 +31,9 @@ export class EsriMapComponent implements OnInit {
     this.mapService.store.subscribe((store) => {
       this.loaded.emit(store);
     });
+  }
+
+  public ngOnDestroy() {
+    this.mapService.destroy();
   }
 }

--- a/libs/maps/esri/src/lib/services/module-provider.service.ts
+++ b/libs/maps/esri/src/lib/services/module-provider.service.ts
@@ -179,6 +179,10 @@ export class EsriModuleProviderService {
     {
       class: 'esri/widgets/Sketch/SketchViewModel',
       name: 'SketchViewModel'
+    },
+    {
+      class: 'esri/widgets/Legend/LegendViewModel',
+      name: 'LegendViewModel'
     }
   ];
 

--- a/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
+++ b/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
@@ -35,7 +35,7 @@ export class LayerListService implements OnDestroy {
     const LayerSources = this.environment.value('LayerSources');
     this._scaleThrottled = this._scale.asObservable().pipe(debounceTime(250));
 
-    forkJoin([from(this.moduleProvider.require(['Handles'])), this.mapService.store.pipe(take(1))]).subscribe(
+    forkJoin([from(this.moduleProvider.require(['Handles'])), this.mapService.store]).subscribe(
       ([[HandlesConstructor], instance]: [[esri.HandlesConstructor], MapServiceInstance]) => {
         this._handles = new HandlesConstructor();
         // Perform a check against the map instance to add existing layers. Layers added after this

--- a/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
+++ b/libs/maps/feature/layer-list/src/lib/services/layer-list.service.ts
@@ -35,7 +35,7 @@ export class LayerListService implements OnDestroy {
     const LayerSources = this.environment.value('LayerSources');
     this._scaleThrottled = this._scale.asObservable().pipe(debounceTime(250));
 
-    forkJoin([from(this.moduleProvider.require(['Handles'])), this.mapService.store]).subscribe(
+    forkJoin([from(this.moduleProvider.require(['Handles'])), this.mapService.store.pipe(take(1))]).subscribe(
       ([[HandlesConstructor], instance]: [[esri.HandlesConstructor], MapServiceInstance]) => {
         this._handles = new HandlesConstructor();
         // Perform a check against the map instance to add existing layers. Layers added after this

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
@@ -4,10 +4,16 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <div class="legend-item" *ngFor="let item of legend | async" (click)="analyticsReport(item)">
-    <div class="image-container">
-      <img [src]="item.src" [alt]="item.title" />
+  <div class="legend-group" *ngFor="let group of legendItems | async">
+    <div class="layer-parent">{{ group.title }}</div>
+
+    <div class="legend-elements">
+      <div *ngFor="let elements of group.legendElements">
+        <div class="legend-info" *ngFor="let info of elements.infos">
+          <div class="image-container" [elementInsert]="info.preview"></div>
+          <div>{{info.value}}</div>
+        </div>
+      </div>
     </div>
-    <div>{{ item.title }}</div>
   </div>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
@@ -4,16 +4,27 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <div class="legend-group" *ngFor="let group of legendItems | async">
-    <div class="layer-parent">{{ group.title }}</div>
+  <div class="legend-collection" *ngFor="let group of legendItems | async">
+    <div class="legend-element" *ngFor="let element of group.legendElements">
+      <!-- If there is only one legend element, don't apply a group title. Will apply the parent label on the 
+    single child so that there aren't groups with a single child, because it will break the cleanliness
+    of the table -->
+      <div class="element-parent-name" *ngIf="element.infos.length > 1">{{ group.title }}</div>
 
-    <div class="legend-elements">
-      <div *ngFor="let elements of group.legendElements">
-        <div class="legend-info" *ngFor="let info of elements.infos">
-          <div class="image-container" [elementInsert]="info.preview"></div>
-          <div>{{info.value}}</div>
+      <!-- Switch through the different element types. The default is a "not supported" message printout. -->
+      <ng-container [ngSwitch]="element.type">
+        <!-- For SymbolTable element type -->
+        <div *ngSwitchCase="'symbol-table'" class="element-group">
+          <div class="legend-info" *ngFor="let info of element.infos">
+            <div class="image-container" [elementInsert]="info.preview"></div>
+            <!-- Apply the legend item from the parent group or child -->
+            <div>{{element.infos.length === 1 ? group?.title: info?.label}}</div>
+          </div>
         </div>
-      </div>
+
+        <!-- Default printout -->
+        <div *ngSwitchDefault>Unsupported legend element type: {{element.type}}</div>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.scss
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.scss
@@ -1,13 +1,14 @@
 @import 'libs/sass/components/sidebar';
 @import 'libs/sass/mixins';
 
-.layer-parent {
+.element-parent-name {
   font-weight: 500;
   margin-bottom: 0.5rem;
-}
 
-.legend-elements {
-  margin-left: 0.5rem;
+  // Add a left margin to any subsequent info group
+  & ~ div {
+    margin-left: 0.75rem;
+  }
 }
 
 .legend-info {
@@ -16,12 +17,14 @@
   @include align-items(center);
 }
 
-.legend-group {
+.legend-collection {
   @include flexbox();
   @include flex-direction(column);
-
-  margin-bottom: 0.8rem;
   font-size: 0.875rem;
+}
+
+.legend-info {
+  margin-bottom: 0.5rem;
 }
 
 .image-container {

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.scss
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.scss
@@ -1,9 +1,24 @@
 @import 'libs/sass/components/sidebar';
+@import 'libs/sass/mixins';
 
-.legend-item {
+.layer-parent {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.legend-elements {
+  margin-left: 0.5rem;
+}
+
+.legend-info {
   @include flexbox();
   @include flex-direction(row);
   @include align-items(center);
+}
+
+.legend-group {
+  @include flexbox();
+  @include flex-direction(column);
 
   margin-bottom: 0.8rem;
   font-size: 0.875rem;
@@ -11,8 +26,6 @@
 
 .image-container {
   margin-right: 0.5rem;
-  width: 1.4rem;
-  height: 1.4rem;
 }
 
 img {

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -41,7 +41,7 @@ export class LegendComponent implements OnInit, OnDestroy {
 
   public ngOnInit() {
     this.legend = this.legendService.store;
-    this.legendItems = this.legendService.legendItems;
+    this.legendItems = this.legendService.legend();
 
     this.responsive = this.responsiveService.snapshot;
 

--- a/libs/maps/feature/legend/src/lib/maps-feature-legend.module.ts
+++ b/libs/maps/feature/legend/src/lib/maps-feature-legend.module.ts
@@ -1,11 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { UIStructuralLayoutModule } from '@tamu-gisc/ui-kits/ngx/layout/structural';
+
 import { LegendService } from './services/legend.service';
 import { LegendComponent } from './components/legend/legend.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, UIStructuralLayoutModule],
   providers: [LegendService],
   declarations: [LegendComponent],
   exports: [LegendComponent]

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -13,18 +13,21 @@ export class LegendService {
   public store: Observable<LegendItem[]> = this._store.asObservable();
 
   constructor(private layerListService: LayerListService, private environment: EnvironmentService) {
-    const LegendSources = this.environment.value('LegendSources');
+    const LegendSources = this.environment.value('LegendSources', true);
     // Handle automatic layer addition and removal legend item display.
     // This does not handle removal on layer visibility change
-    this.layerListService.layers({ watchProperties: 'visible' }).subscribe((value) => {
-      const layersLegendItems = value
-        .filter((item) => item.layer && item.layer.visible && item.outsideExtent === false)
-        .filter((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
-        .map((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
-        .map((obj) => obj[0]);
 
-      this._store.next([...LegendSources, ...layersLegendItems]);
-    });
+    if (LegendSources) {
+      this.layerListService.layers({ watchProperties: 'visible' }).subscribe((value) => {
+        const layersLegendItems = value
+          .filter((item) => item.layer && item.layer.visible && item.outsideExtent === false)
+          .filter((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
+          .map((lyr) => (<LayerSource>(<unknown>lyr.layer)).legendItems)
+          .map((obj) => obj[0]);
+
+        this._store.next([...LegendSources, ...layersLegendItems]);
+      });
+    }
   }
 
   /**

--- a/libs/ui-kits/ngx/layout/structural/src/index.ts
+++ b/libs/ui-kits/ngx/layout/structural/src/index.ts
@@ -1,2 +1,4 @@
 export * from './lib/ui-kits-ngx-layout-structural.module';
+
 export * from './lib/directives/render-host/render-host.directive';
+export * from './lib/directives/element-insert/element-insert.directive';

--- a/libs/ui-kits/ngx/layout/structural/src/lib/directives/element-insert/element-insert.directive.spec.ts
+++ b/libs/ui-kits/ngx/layout/structural/src/lib/directives/element-insert/element-insert.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ElementInsertDirective } from './element-insert.directive';
+
+describe('ElementInsertDirective', () => {
+  it('should create an instance', () => {
+    const directive = new ElementInsertDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/libs/ui-kits/ngx/layout/structural/src/lib/directives/element-insert/element-insert.directive.ts
+++ b/libs/ui-kits/ngx/layout/structural/src/lib/directives/element-insert/element-insert.directive.ts
@@ -1,0 +1,16 @@
+import { AfterContentInit, Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+
+@Directive({
+  // tslint:disable-next-line: directive-selector
+  selector: '[elementInsert]'
+})
+export class ElementInsertDirective implements AfterContentInit {
+  @Input()
+  public elementInsert: Element;
+
+  constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
+
+  public ngAfterContentInit() {
+    this.renderer.appendChild(this.elementRef.nativeElement, this.elementInsert);
+  }
+}

--- a/libs/ui-kits/ngx/layout/structural/src/lib/ui-kits-ngx-layout-structural.module.ts
+++ b/libs/ui-kits/ngx/layout/structural/src/lib/ui-kits-ngx-layout-structural.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { RenderHostDirective } from './directives/render-host/render-host.directive';
+import { ElementInsertDirective } from './directives//element-insert/element-insert.directive';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [RenderHostDirective],
-  exports: [RenderHostDirective]
+  declarations: [RenderHostDirective, ElementInsertDirective],
+  exports: [RenderHostDirective, ElementInsertDirective]
 })
 export class UIStructuralLayoutModule {}


### PR DESCRIPTION
Legend component now uses Esri's legend view model which adds the ability to render the symbol previews. This will remove the necessity to manually include all of the application's legend items in the environments. However, there will be some issues in other applications in which legend overrides. However services which do not have correct renderers for which we have provided overrides. For example Aggiemap buildings legend item is transparent from the service, and a replacement is provided in the legend. These legend items will be rendered as-is using the legend view model preview property, but we'll need to assimilate some of the old service logic to allow legend item overrides.

Example:

![image](https://user-images.githubusercontent.com/3969818/112206393-de661080-8be3-11eb-8199-76da738c1e2a.png)

Currently, the legend component only supports `SymbolTableElement`'s.