### PR TITLE
refactor(maps-esri): Map service group layer source auto-cast support

### DIFF
--- a/libs/aggiemap/src/lib/popups/components/base-directions/base-directions.component.html
+++ b/libs/aggiemap/src/lib/popups/components/base-directions/base-directions.component.html
@@ -1,5 +1,5 @@
 <div class="popup-section">
-  <div class="feature-style-1" tabindex="0">{{ data?.layer?.id }}</div>
+  <div class="feature-style-1" tabindex="0" [title]="data?.layer?.id">{{ data?.layer?.title }}</div>
   <div class="feature-style-2" tabindex="0"><span *ngIf="data.attributes.Address">{{ data?.attributes?.Address }},</span> College Station, TX 77843</div>
 </div>
 

--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -235,7 +235,8 @@ interface PortalMapServerLayerSourceProperties {
     /**
      * Default feature layer properties appended to all feature layers found in the service.
      */
-    defaultFeatureLayerProperties?: esri.FeatureLayerProperties;
+    // tslint:disable-next-line: no-any
+    defaultFeatureLayerProperties?: esri.FeatureLayerProperties & { popupComponent?: any };
   };
 }
 

--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -163,7 +163,7 @@ export interface IRemoteLayerService {
 // Layer Source Type Typings
 //
 
-interface FeatureLayerSourceProperties extends IRemoteLayerService {
+export interface FeatureLayerSourceProperties extends IRemoteLayerService {
   type: 'feature';
 
   native?: Omit<esri.FeatureLayerProperties, 'renderer' | 'labelingInfo'> & {
@@ -172,25 +172,25 @@ interface FeatureLayerSourceProperties extends IRemoteLayerService {
   };
 }
 
-interface SceneLayerSourceProperties extends IRemoteLayerService {
+export interface SceneLayerSourceProperties extends IRemoteLayerService {
   type: 'scene';
 
   native?: Omit<esri.SceneLayerProperties, 'renderer'> & { renderer?: RendererAutoCastNativeOptions };
 }
 
-interface GeoJSONLayerSourceProperties extends IRemoteLayerService {
+export interface GeoJSONLayerSourceProperties extends IRemoteLayerService {
   type: 'geojson';
 
   native?: Omit<esri.GeoJSONLayerProperties, 'renderer'> & { renderer?: RendererAutoCastNativeOptions };
 }
 
-interface CSVLayerSourceProperties extends IRemoteLayerService {
+export interface CSVLayerSourceProperties extends IRemoteLayerService {
   type: 'csv';
 
   native?: Omit<esri.CSVLayerProperties, 'renderer'> & { renderer?: RendererAutoCastNativeOptions };
 }
 
-interface GraphicLayerSourceProperties {
+export interface GraphicLayerSourceProperties {
   type: 'graphic';
 
   /**
@@ -200,11 +200,17 @@ interface GraphicLayerSourceProperties {
   native?: esri.GraphicsLayerProperties;
 }
 
-interface GroupLayerSourceProperties {
+export interface GroupLayerSourceProperties {
   type: 'group';
 
   /**
-   * Graphics used in the creation of the layer
+   * Collection of layer sources that will be casted into their respective layer types and added to the
+   * group layer construction.
+   */
+  sources?: LayerSource[];
+
+  /**
+   * Native group layer properties.
    */
   native?: esri.GroupLayerProperties;
 }
@@ -296,6 +302,8 @@ export type LayerSource = LayerSourceType & {
 
   /**
    * Legend items that are shown disabled in the legend as the layer visibility is on/off
+   *
+   * @deprecated Legend items are now rendered through the legend view model
    */
   legendItems?: LegendItem[];
 
@@ -305,6 +313,11 @@ export type LayerSource = LayerSourceType & {
    */
   layerIndex?: number;
 
+  /**
+   * String used to categorize layers in like groups.
+   *
+   * @deprecated Categorization is now done through group layers
+   */
   category?: string;
 };
 

--- a/libs/maps/feature/popup/src/lib/services/popup.service.ts
+++ b/libs/maps/feature/popup/src/lib/services/popup.service.ts
@@ -3,21 +3,18 @@ import { BehaviorSubject } from 'rxjs';
 
 import { HitTestSnapshot } from '@tamu-gisc/maps/esri';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
-import { LayerSource } from '@tamu-gisc/common/types';
+
+import esri = __esri;
 
 @Injectable({ providedIn: 'root' })
 export class PopupService {
-  private layers: LayerSource[];
-
   private _show: BehaviorSubject<boolean> = new BehaviorSubject(true);
   public show = this._show.asObservable();
 
   private _suppressed: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public suppressed = this._suppressed.asObservable();
 
-  constructor(private environment: EnvironmentService) {
-    this.layers = this.environment.value('LayerSources');
-  }
+  constructor(private environment: EnvironmentService) {}
 
   /**
    * Determine component ID by one of two methods:
@@ -40,22 +37,14 @@ export class PopupService {
       const validGraphics = snapshot.graphics.filter((g) => g.layer && g.layer.id);
 
       // Layer source ID for the first graphic in the collection
-      const graphicLayerId = validGraphics[0].layer.id;
-
-      // Determined layer source by graphicLayerId
-      const source = this.layers.find((src) => src.id === graphicLayerId);
-
-      // Check if there is a source match
-      if (!source) {
-        return;
-      }
+      const graphicLayer = (validGraphics[0].layer as unknown) as ILayerWithPopupComponent;
 
       // Check if the source has a component declaration
-      if (!source.popupComponent) {
+      if (!graphicLayer.popupComponent) {
         return;
       }
 
-      return source.popupComponent;
+      return graphicLayer.popupComponent;
     }
   }
 
@@ -74,4 +63,9 @@ export class PopupService {
   public enablePopups() {
     this._suppressed.next(false);
   }
+}
+
+interface ILayerWithPopupComponent extends esri.Layer {
+  // tslint:disable-next-line: no-any
+  popupComponent: any;
 }


### PR DESCRIPTION
Depends on #103 

While the esri doc's state that the group layer constructor can auto-cast layers, this has not been the case with the current version of the arcgis js api. I tested with newer versions and the same remains true. So the Esri map service now correctly processes layer sources with type `group`.