### PR TITLE
fix(nx-workspace): Fixed ues-sass lib definition format error

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -444,6 +444,9 @@
     },
     "ues-valves-nest": {
       "tags": []
+    },
+    "ues-sass": {
+      "tags": []
     }
   },
   "tasksRunnerOptions": {

--- a/workspace.json
+++ b/workspace.json
@@ -4823,11 +4823,11 @@
           }
         }
       }
+    },
+    "ues-sass": {
+      "projectType": "library",
+      "root": "libs/ues/sass"
     }
-  },
-  "ues-sass": {
-    "projectType": "library",
-    "root": "libs/ues/sass"
   },
   "cli": {
     "defaultCollection": "@nrwl/angular",


### PR DESCRIPTION
`ues-sass` lib was outside of the projects dictionary in workspace.json.

Also added in nx.json because it was missing completely causing workspace and nx JSON files to be out of sync.