### PR TITLE
fix(ngx-auth): Fixed auth redirection sensitivity

### DIFF
--- a/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
@@ -38,7 +38,7 @@ export class AuthInterceptor implements HttpInterceptor {
               if (typeof this.auth.authOptions === 'string') {
                 this.document.location.href = `${this.auth.authOptions}/oidc/login`;
               } else if (typeof this.auth.authOptions === 'object') {
-                this.document.location.href = `${this.auth.authOptions.url}/oidc/login${
+                this.document.location.href = `${this.auth.cleanUrl(this.auth.authOptions.url)}/oidc/login${
                   this.auth.authOptions.attach_href === true ? '?ret=' + window.location.href : ''
                 }`;
               } else {

--- a/libs/common/ngx/auth/src/lib/services/auth.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth.service.ts
@@ -34,7 +34,7 @@ export class AuthService {
    * This method works best with HTTP interceptors to redirect to login if a 401/403 is returned.
    */
   public isAuthenticated() {
-    return this.http.get(this.authOptions.url + '/oidc/userinfo', { withCredentials: true }).pipe(
+    return this.http.get(this.cleanUrl(this.authOptions.url) + '/oidc/userinfo', { withCredentials: true }).pipe(
       map((result) => {
         return true;
       }),
@@ -42,5 +42,16 @@ export class AuthService {
         return of(false);
       })
     );
+  }
+
+  /**
+   * Cleans the trailing end of the auth url to fix any api routing issues.
+   */
+  public cleanUrl(url: string): string {
+    if (url.endsWith('/')) {
+      return url.slice(0, url.length - 1);
+    } else {
+      return url;
+    }
   }
 }


### PR DESCRIPTION
The auth service now cleans the auth URL before making XHR requests or redirecting to prevent 404 routing issues due to a malformed URL (double slash between host name and route name).

Example: https://domain.com//route/to/resource