### PR TITLE
ci: Added  conditional affected base variable for nx commands

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,6 +13,12 @@
         "semi": true,
         "parser": "html"
       }
+    },
+    {
+      "files": "*.yml",
+      "options": {
+        "printWidth": 9999
+      }
     }
   ]
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,20 +1,20 @@
 variables:
   - name: isDevelopment
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/development')]
+    value: $[eq(variables['Build.SourceBranchName'], 'development')]
   - name: isMaster
-    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+    value: $[eq(variables['Build.SourceBranchName'], 'master')]
   - name: affectedBase
-    value: 'origin/development'
-    ${{ if eq(variables.isDevelopment, false) }}:
-      value: 'origin/development~1'
-    ${{ if eq(variables.isMaster, false) }}:
-      value: 'origin/master~1'
+    ${{ if and(ne(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.SourceBranchName'], 'development')) }}:
+      value: origin/development # Default affected base base
+    ${{ if eq(variables['Build.SourceBranchName'], 'development') }}:
+      value: origin/development~ # Affected base if build branch name is development
+    ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+      value: origin/maser~ # Affected base if build branch name is master
 
 pool:
   vmImage: 'ubuntu-latest'
 stages:
   - stage: Development
-    condition: or(eq(variables.isMaster, false), eq(variables.isDevelopment, false))
     jobs:
       - job: Build
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,14 @@
+variables:
+  isDevelopment: $[eq(variables['Build.SourceBranch'], 'refs/heads/development')]
+  isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+
 pool:
   vmImage: 'ubuntu-latest'
 stages:
   - stage: Development
+    condition: or(eq(variables.isMain, false), eq(variables.isDevelopment, false))
     jobs:
-      - job: Development
+      - job: Build
         steps:
           - task: NodeTool@0
             inputs:
@@ -69,9 +74,9 @@ stages:
             displayName: 'Publish Artifacts'
 
   - stage: Production
-    dependsOn: []
+    dependsOn: Development
     jobs:
-      - job: Prodcution
+      - job: Build
         steps:
           - task: NodeTool@0
             inputs:
@@ -136,10 +141,10 @@ stages:
               ArtifactName: 'js-monorepo-production' # output artifact named www
             displayName: 'Publish Artifacts'
 
-  - stage: buildTags
-    dependsOn: []
+  - stage: AssignBuildTags
+    dependsOn: Development
     jobs:
-      - job: buildTags
+      - job: Tag
         steps:
           - task: NodeTool@0
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,20 @@
 variables:
-  isDevelopment: $[eq(variables['Build.SourceBranch'], 'refs/heads/development')]
-  isMaster: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  - name: isDevelopment
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/development')]
+  - name: isMaster
+    value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  - name: affectedBase
+    value: 'origin/development'
+    ${{ if eq(variables.isDevelopment, false) }}:
+      value: 'origin/development~1'
+    ${{ if eq(variables.isMaster, false) }}:
+      value: 'origin/master~1'
 
 pool:
   vmImage: 'ubuntu-latest'
 stages:
   - stage: Development
-    condition: or(eq(variables.isMain, false), eq(variables.isDevelopment, false))
+    condition: or(eq(variables.isMaster, false), eq(variables.isDevelopment, false))
     jobs:
       - job: Build
         steps:
@@ -58,7 +66,7 @@ stages:
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
           - bash: |
-              npm run nx affected:build -- --base=origin/development --head=HEAD --configuration=development --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
+              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=development --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
             displayName: 'Running build for development'
 
           - task: CopyFiles@2
@@ -126,7 +134,7 @@ stages:
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
           - bash: |
-              npm run nx affected:build -- --base=origin/development --head=HEAD --configuration=production --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
+              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=production --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
             displayName: 'Running build for production'
 
           - task: CopyFiles@2
@@ -194,5 +202,5 @@ stages:
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
           - bash: |
-              npm run nx affected:apps --  --base=origin/development --head=HEAD --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes" | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
+              npm run nx affected:apps -- --base=$(affectedBase) --head=HEAD --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes" | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
             displayName: 'add affected apps as buildtags'


### PR DESCRIPTION
Added conditional affected base that correctly sets the `base` for nx commands so that builds calculate calculate changes correctly and avoid the case where `head` and `target` are the same on `development` branch.

Added production stage dependency on development since if development does not build, neither should production. Both use the same build options, just different configs.

Added tag assignment stage depedency on development and production since both  must pass for any release trigger.

This PR was initially only added a condition on the Dev build stage that prevented builds from running on `development` or `master` branches. However, this would cause PR merges to never be tested and the CI checks would be missing from github commit history. The goal of the PR changed to come up with a proper solution to the problem instead of implementing a stop-gap solution.