### PR TITLE
feat(cpa-angular): Map image layer support

### DIFF
--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -184,6 +184,12 @@ export interface GeoJSONLayerSourceProperties extends IRemoteLayerService {
   native?: Omit<esri.GeoJSONLayerProperties, 'renderer'> & { renderer?: RendererAutoCastNativeOptions };
 }
 
+export interface MapImageLayerSourceProperties extends IRemoteLayerService {
+  type: 'map-image';
+
+  native?: esri.MapImageLayerProperties;
+}
+
 export interface CSVLayerSourceProperties extends IRemoteLayerService {
   type: 'csv';
 
@@ -247,6 +253,7 @@ export type LayerSourceType =
   | CSVLayerSourceProperties
   | GraphicLayerSourceProperties
   | GroupLayerSourceProperties
+  | MapImageLayerSourceProperties
   | PortalMapServerLayerSourceProperties;
 
 /**

--- a/libs/common/utils/geometry/esri/src/lib/common-utils-geometry-esri.ts
+++ b/libs/common/utils/geometry/esri/src/lib/common-utils-geometry-esri.ts
@@ -239,7 +239,8 @@ export type IPortalLayer = IPortalFeatureLayer | IPortalGroupLayer;
 
 export type AutocastableLayer =
   | { type: 'group'; layers: Array<AutocastableLayer>; title?: string }
-  | { type: 'feature'; url: string; title?: string };
+  | { type: 'feature'; url: string; title?: string }
+  | { type: 'map-image'; title?: string };
 
 /**
  * JSON Portal representation for a Graphic class.

--- a/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
+++ b/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
@@ -438,10 +438,10 @@ export class ParticipantComponent implements OnInit, OnDestroy {
               id: l.info.layerId,
               url: url.join('/'),
               title: l.info.name,
+              opacity: l.info.drawingInfo.opacity,
               sublayers: [
                 {
                   id: id,
-                  opacity: l.info.drawingInfo.opacity,
                   listMode: 'hide'
                 }
               ]

--- a/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
+++ b/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
@@ -72,6 +72,7 @@ export class ParticipantComponent implements OnInit, OnDestroy {
     graphicsLayer: esri.GraphicsLayerConstructor;
     groupLayer: esri.GroupLayerConstructor;
     graphic: esri.GraphicConstructor;
+    mapImageLayer: esri.MapImageLayerConstructor;
   };
   private _map: esri.Map;
   private _view: esri.MapView;
@@ -204,9 +205,9 @@ export class ParticipantComponent implements OnInit, OnDestroy {
     combineLatest([
       this.snapshotHistory,
       this.ms.store,
-      from(this.mp.require(['FeatureLayer', 'GraphicsLayer', 'GroupLayer', 'Graphic', 'Extent']))
+      from(this.mp.require(['FeatureLayer', 'GraphicsLayer', 'GroupLayer', 'Graphic', 'Extent', 'MapImageLayer']))
     ]).subscribe(
-      ([snapshotHistory, instances, [FeatureLayer, GraphicsLayer, GroupLayer, Graphic, Extent]]: [
+      ([snapshotHistory, instances, [FeatureLayer, GraphicsLayer, GroupLayer, Graphic, Extent, MapImageLayer]]: [
         TypedSnapshotOrScenario[],
         MapServiceInstance,
         [
@@ -214,14 +215,16 @@ export class ParticipantComponent implements OnInit, OnDestroy {
           esri.GraphicsLayerConstructor,
           esri.GroupLayerConstructor,
           esri.GraphicConstructor,
-          esri.ExtentConstructor
+          esri.ExtentConstructor,
+          esri.MapImageLayerConstructor
         ]
       ]) => {
         this._modules = {
           featureLayer: FeatureLayer,
           graphic: Graphic,
           graphicsLayer: GraphicsLayer,
-          groupLayer: GroupLayer
+          groupLayer: GroupLayer,
+          mapImageLayer: MapImageLayer
         };
 
         this._map = instances.map;
@@ -427,6 +430,22 @@ export class ParticipantComponent implements OnInit, OnDestroy {
             });
           } else if (l.info.type === 'group') {
             return this._generateGroupLayers(l.layers, l.info.name);
+          } else if (l.info.type === 'map-image') {
+            const url = l.url.split('/');
+            const id = parseInt(url.pop(), 10);
+
+            return new this._modules.mapImageLayer({
+              id: l.info.layerId,
+              url: url.join('/'),
+              title: l.info.name,
+              opacity: l.info.drawingInfo.opacity,
+              sublayers: [
+                {
+                  id: id,
+                  listMode: 'hide'
+                }
+              ]
+            });
           } else if (l.info.type === 'graphics') {
             const g = l.graphics.map((g) => {
               return this._modules.graphic.fromJSON(g);

--- a/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
+++ b/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
@@ -438,10 +438,10 @@ export class ParticipantComponent implements OnInit, OnDestroy {
               id: l.info.layerId,
               url: url.join('/'),
               title: l.info.name,
-              opacity: l.info.drawingInfo.opacity,
               sublayers: [
                 {
                   id: id,
+                  opacity: l.info.drawingInfo.opacity,
                   listMode: 'hide'
                 }
               ]

--- a/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
+++ b/libs/cpa/common/ngx/src/lib/modules/forms/components/participant/participant.component.ts
@@ -413,13 +413,14 @@ export class ParticipantComponent implements OnInit, OnDestroy {
   }
 
   private _generateGroupLayers(definitions: Array<CPALayer>, snapOrScenTitle: string): esri.Layer {
-    const idHash = this._generateGroupLayerId(definitions);
+    const reversedLayers = [...definitions].reverse();
+    const idHash = this._generateGroupLayerId(reversedLayers);
 
     const groupLayer = new this._modules.groupLayer({
       id: idHash,
       title: snapOrScenTitle,
       visibilityMode: 'independent',
-      layers: definitions
+      layers: reversedLayers
         .map((l) => {
           if (l.info.type === 'feature') {
             return new this._modules.featureLayer({
@@ -472,7 +473,8 @@ export class ParticipantComponent implements OnInit, OnDestroy {
    * used to remove all of the resolved layers from the map if they exist.
    */
   private _removeTimelineEventLayers(event: TypedSnapshotOrScenario): void {
-    const idHash = this._generateGroupLayerId(event.layers);
+    const reversedLayers = [...event.layers].reverse();
+    const idHash = this._generateGroupLayerId(reversedLayers);
 
     const prevLayers = event.layers
       .map((l) => {

--- a/libs/maps/esri/src/lib/services/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map.service.ts
@@ -277,6 +277,14 @@ export class EsriMapService {
         // Create and return new feature layer
         return new FeatureLayer(props as esri.FeatureLayerProperties);
       });
+    } else if (source.type === 'map-image') {
+      return this.moduleProvider.require(['MapImageLayer']).then(([ImageLayer]: [esri.MapImageLayerConstructor]) => {
+        // Delete the type property as it cannot be set on layer creation.
+        delete props.type;
+
+        // Create and return new map image layer
+        return new ImageLayer(props as esri.MapImageLayerProperties);
+      });
     } else if (source.type === 'scene') {
       return this.moduleProvider.require(['SceneLayer']).then(([SceneLayer]: [esri.SceneLayerConstructor]) => {
         // Delete the type property as it cannot be set on layer creation.

--- a/libs/maps/esri/src/lib/services/module-provider.service.ts
+++ b/libs/maps/esri/src/lib/services/module-provider.service.ts
@@ -211,6 +211,10 @@ export class EsriModuleProviderService {
     {
       class: 'esri/geometry/Extent',
       name: 'Extent'
+    },
+    {
+      class: 'esri/layers/MapImageLayer',
+      name: 'MapImageLayer'
     }
   ];
 

--- a/libs/maps/feature/forms/src/lib/components/layer-configuration/layer-configuration.component.ts
+++ b/libs/maps/feature/forms/src/lib/components/layer-configuration/layer-configuration.component.ts
@@ -161,11 +161,7 @@ export class LayerConfigurationComponent implements OnInit, OnDestroy, OnChanges
       )
       .subscribe((res: ILayerConfiguration) => {
         if (this.layer) {
-          if (this.layer.type === 'feature') {
-            this.layer.opacity = res.drawingInfo.opacity;
-          } else if (this.layer.type === 'map-image') {
-            this.layer.allSublayers.forEach((l) => (l.opacity = res.drawingInfo.opacity));
-          }
+          this.layer.opacity = res.drawingInfo.opacity;
         }
       });
   }
@@ -184,7 +180,7 @@ export class LayerConfigurationComponent implements OnInit, OnDestroy, OnChanges
   }
 
   public ngOnChanges(changes: SimpleChanges) {
-    if (changes.index.previousValue !== changes.index.currentValue && this.layer !== undefined) {
+    if (changes.index && changes.index.previousValue !== changes.index.currentValue && this.layer !== undefined) {
       this.ms.store.pipe(take(1)).subscribe((instances) => {
         instances.map.reorder(this.layer, this.index);
       });
@@ -200,6 +196,7 @@ export class LayerConfigurationComponent implements OnInit, OnDestroy, OnChanges
 
 export class LayerConfiguration {
   public form: FormGroup;
+  public info: FormGroup;
 
   constructor(public fb: FormBuilder, args: ILayerConfiguration | FormGroup) {
     if (args !== undefined) {

--- a/libs/maps/feature/forms/src/lib/components/layer-configuration/layer-configuration.component.ts
+++ b/libs/maps/feature/forms/src/lib/components/layer-configuration/layer-configuration.component.ts
@@ -234,8 +234,8 @@ export class LayerConfiguration {
       return 'graphics';
     } else if (type === 'Group Layer') {
       return 'group';
-    } else if (type === 'Raster Layer') {
-      return 'raster';
+    } else if (type === 'Map Layer') {
+      return 'map-image';
     } else {
       return type as ILayerConfiguration['type'];
     }
@@ -367,7 +367,7 @@ export interface ILayerConfiguration {
 
   layerId?: string;
 
-  type?: 'feature' | 'graphics' | 'group' | 'raster';
+  type?: 'feature' | 'graphics' | 'group' | 'map-image';
 
   description?: string;
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -11,7 +11,7 @@ of the table -->
       <div class="legend-info" *ngFor="let info of element.infos">
         <ng-container [ngSwitch]="info.preview !== undefined">
           <div *ngSwitchCase="true" class="image-container" [elementInsert]="info.preview"></div>
-          <img *ngSwitchCase="false" class="image-container" [src]="info.src" alt="" />
+          <img *ngSwitchCase="false" class="image-container" [src]="info.src" [ngStyle]="{opacity: info.opacity}" />
         </ng-container>
         <!-- Apply the legend item from the parent group or child -->
         <div>{{element.infos.length === 1 ? groupTitle: info?.label}}</div>

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -9,7 +9,10 @@ of the table -->
     <!-- For SymbolTable element type -->
     <div *ngSwitchCase="'symbol-table'" class="element-group">
       <div class="legend-info" *ngFor="let info of element.infos">
-        <div class="image-container" [elementInsert]="info.preview"></div>
+        <ng-container [ngSwitch]="info.preview !== undefined">
+          <div *ngSwitchCase="true" class="image-container" [elementInsert]="info.preview"></div>
+          <img *ngSwitchCase="false" class="image-container" [src]="info.src" alt="" />
+        </ng-container>
         <!-- Apply the legend item from the parent group or child -->
         <div>{{element.infos.length === 1 ? groupTitle: info?.label}}</div>
       </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.scss
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.scss
@@ -21,8 +21,3 @@
 .image-container {
   margin-right: 0.5rem;
 }
-
-img {
-  height: 100%;
-  width: 100%;
-}


### PR DESCRIPTION
The snapshot builder and participant component now support map image layer types with raster sources. 

The change extends deeper into the map service to support layer source auto-casting.