### PR TITLE
fix(oidc-provider-nest): Fix OIDC provider race condition on defaults setup

### DIFF
--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -127,27 +127,34 @@ async function bootstrap() {
   await app.listen(environment.port, () => {
     console.log('Listening at http://localhost:' + environment.port + '/' + environment.globalPrefix);
 
-    setTimeout(() => {
+    setTimeout(async () => {
       if (argv.setup) {
         const clientMetadataService = app.select(ClientMetadataModule).get(ClientMetadataService, { strict: true });
         const roleService = app.select(RoleModule).get(RoleService, { strict: true });
         const userService = app.select(UserModule).get(UserService, { strict: true });
 
-        // Insert default Grant Types
-        clientMetadataService.insertDefaultGrantTypes();
-        // Insert default Responses Types
-        clientMetadataService.insertDefaultResponseTypes();
-        // Insert default Token Auth Methods
-        clientMetadataService.insertDefaultTokenEndpointAuthMethods();
-        // Create ClientMetadata for oidc-idp-admin (angular site)
-        clientMetadataService.insertClientMetadataForAdminSite(argv.n, argv.t, argv.r);
-        // Insert default Roles
-        roleService.insertDefaultUserRoles();
-        // Create Admin user with known password
-        userService.insertDefaultAdmin(argv.e, argv.p);
-        // Insert the secret questions for others to register
-        userService.insertDefaultSecretQuestions();
-        // TODO: Add field to User that will prompt a user to change their password on next login
+        try {
+          // Insert default Grant Types
+          await clientMetadataService.insertDefaultGrantTypes();
+          // Insert default Responses Types
+          await clientMetadataService.insertDefaultResponseTypes();
+          // Insert default Token Auth Methods
+          await clientMetadataService.insertDefaultTokenEndpointAuthMethods();
+          // Create ClientMetadata for oidc-idp-admin (angular site)
+          await clientMetadataService.insertClientMetadataForAdminSite(argv.n, argv.t, argv.r);
+          // Insert default Roles
+          await roleService.insertDefaultUserRoles();
+          // Create Admin user with known password
+          await userService.insertDefaultAdmin(argv.e, argv.p);
+          // Insert the secret questions for others to register
+          await userService.insertDefaultSecretQuestions();
+          // TODO: Add field to User that will prompt a user to change their password on next login
+
+          console.log('Defaults setup complete');
+        } catch (err) {
+          console.log(err);
+          throw new Error('Error setting up defaults.');
+        }
       }
     }, 3000);
   });

--- a/libs/oidc/common/src/lib/services/client-metadata/client-metadata.service.ts
+++ b/libs/oidc/common/src/lib/services/client-metadata/client-metadata.service.ts
@@ -85,7 +85,9 @@ export class ClientMetadataService {
   }
 
   public async loadClientMetadaForOidcSetup() {
-    const clients = await this.clientMetadataRepo.findAllDeep();
+    const clients = await this.clientMetadataRepo.find({
+      relations: ['grantTypes', 'redirectUris', 'responseTypes', 'tokenEndpointAuthMethod']
+    });
     const flattenedClients: IClientMetadata[] = this.flattenClientMetadataForReturn(clients);
 
     return flattenedClients;
@@ -199,17 +201,18 @@ export class ClientMetadataService {
     // https://stackoverflow.com/questions/51403066/grant-type-vs-response-type-in-oauth2-0-oidc
     // 'refresh_token', 'authorization_code'
 
-    this.insertGrantType({
-      type: 'refresh_token',
-      name: 'Refresh',
-      details: 'Allows you to get a Refresh Token back'
-    });
-
-    this.insertGrantType({
-      type: 'authorization_code',
-      name: 'Authorization',
-      details: 'Authorization'
-    });
+    return Promise.all([
+      this.insertGrantType({
+        type: 'refresh_token',
+        name: 'Refresh',
+        details: 'Allows you to get a Refresh Token back'
+      }),
+      this.insertGrantType({
+        type: 'authorization_code',
+        name: 'Authorization',
+        details: 'Authorization'
+      })
+    ]);
   }
 
   public async insertGrantType(_grant: Partial<GrantType>) {
@@ -243,15 +246,16 @@ export class ClientMetadataService {
   public async insertDefaultResponseTypes() {
     // https://tools.ietf.org/html/rfc6749#section-3.1.1
 
-    this.insertResponseType({
-      details: 'Authorization Code',
-      type: 'code'
-    });
-
-    this.insertResponseType({
-      details: 'Authorization Token',
-      type: 'token'
-    });
+    return Promise.all([
+      this.insertResponseType({
+        details: 'Authorization Code',
+        type: 'code'
+      }),
+      this.insertResponseType({
+        details: 'Authorization Token',
+        type: 'token'
+      })
+    ]);
   }
 
   public async insertResponseType(_responseType: Partial<ResponseType>) {
@@ -307,15 +311,16 @@ export class ClientMetadataService {
 
   public async insertDefaultTokenEndpointAuthMethods() {
     // client_secret_basic, client_secret_jwt
-    this.insertTokenEndpointAuthMethod({
-      type: 'client_secret_basic',
-      details: 'Allows usage of the bearer token header'
-    });
-
-    this.insertTokenEndpointAuthMethod({
-      type: 'client_secret_jwt',
-      details: 'Allows usage of JWTs'
-    });
+    return Promise.all([
+      this.insertTokenEndpointAuthMethod({
+        type: 'client_secret_basic',
+        details: 'Allows usage of the bearer token header'
+      }),
+      this.insertTokenEndpointAuthMethod({
+        type: 'client_secret_jwt',
+        details: 'Allows usage of JWTs'
+      })
+    ]);
   }
 
   public async insertTokenEndpointAuthMethod(_tokenEndpointMethod: Partial<TokenEndpointAuthMethod>) {


### PR DESCRIPTION
When using the `-s` flag and providing the default values would sometimes create a race condition where some necessary steps had not completed executing (db insertions) before other subsequent steps did.

Also setup now waits on previous steps to complete before proceeding to the next.