### PR TITLE
feat(oidc-provider-nest): NodeMailer can now use Gmail to send emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ libs/coverage
 .DS_Store
 Thumbs.db
 
+# NodeMailer Configurations
+mailerconfig.*
+
 # TypeORM Configurations
 ormconfig.*
 

--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -77,6 +77,13 @@ async function bootstrap() {
       type: 'string',
       nargs: 1
     })
+    .option('m', {
+      alias: 'email-provider',
+      description: 'The email provider (ethereal / tamu / gmail)',
+      type: 'string',
+      demandOption: true,
+      choices: ['ethereal', 'tamu', 'google']
+    })
     .help()
     .alias('help', 'h');
 
@@ -106,7 +113,9 @@ async function bootstrap() {
   const dir = join(__dirname, 'assets/views');
 
   // This will setup the Mailer (gmail or ethereal)
-  Mailer.build('gmail', mailerConfig);
+  // Mailer.build('gmail', mailerConfig);
+  Mailer.build('ethereal');
+  Mailer.sendPasswordResetConfirmationEmail('atharmon@tamu.edu');
 
   // This will set the default time step for otplib to 5 minutes
   TwoFactorAuthUtils.build();

--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -115,7 +115,6 @@ async function bootstrap() {
   // This will setup the Mailer (gmail or ethereal)
   // Mailer.build('gmail', mailerConfig);
   Mailer.build('ethereal');
-  Mailer.sendPasswordResetConfirmationEmail('atharmon@tamu.edu');
 
   // This will set the default time step for otplib to 5 minutes
   TwoFactorAuthUtils.build();

--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -18,11 +18,13 @@ import {
   RoleService,
   UserModule,
   UserService,
-  TwoFactorAuthUtils
+  TwoFactorAuthUtils,
+  Mailer
 } from '@tamu-gisc/oidc/common';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import { mailerConfig } from './environments/mailerconfig';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -102,6 +104,9 @@ async function bootstrap() {
   OpenIdProvider.provider.proxy = true;
 
   const dir = join(__dirname, 'assets/views');
+
+  // This will setup the Mailer (gmail or ethereal)
+  Mailer.build('gmail', mailerConfig);
 
   // This will set the default time step for otplib to 5 minutes
   TwoFactorAuthUtils.build();

--- a/libs/oidc/common/src/lib/utils/email/mailer.util.ts
+++ b/libs/oidc/common/src/lib/utils/email/mailer.util.ts
@@ -3,7 +3,7 @@ import Mail from 'nodemailer/lib/mailer';
 
 import { User, UserPasswordReset } from '@tamu-gisc/oidc/common';
 
-export type NodeMailerServices = 'ethereal' | 'gmail';
+export type NodeMailerServices = 'ethereal' | 'gmail' | 'tamu-relay';
 export class Mailer {
   private static transporter: Mail;
   private static service: NodeMailerServices;
@@ -33,6 +33,13 @@ export class Mailer {
             user: 'kaitlyn.schimmel@ethereal.email',
             pass: 'Pe6D9DhkgUDyqyBMeg'
           }
+        });
+        break;
+      case 'tamu-relay':
+        Mailer.transporter = nodemailer.createTransport({
+          host: 'relay.tamu.edu',
+          port: 25,
+          secure: false
         });
         break;
       case 'gmail':

--- a/libs/oidc/common/src/lib/utils/email/mailer.util.ts
+++ b/libs/oidc/common/src/lib/utils/email/mailer.util.ts
@@ -10,7 +10,16 @@ export class Mailer {
 
   // https://dev.to/chandrapantachhetri/sending-emails-securely-using-node-js-nodemailer-smtp-gmail-and-oauth2-g3a
   // 2LO https://nodemailer.com/smtp/oauth2/#oauth-2lo
-  public static build(service: NodeMailerServices, config?: {}) {
+  public static build(
+    service: NodeMailerServices,
+    config?: {
+      user: string;
+      accessToken: string;
+      clientId: string;
+      clientSecret: string;
+      refreshToken: string;
+    }
+  ) {
     Mailer.service = service;
 
     switch (service) {
@@ -51,11 +60,7 @@ export class Mailer {
         `<p>Your two-step verification code is: <b>${token}</b></p>` + `<p>Use this code to complete loggin in with GISC</p>`
     };
 
-    Mailer.transporter.sendMail(mailOptions).then((response) => {
-      if (Mailer.service == 'ethereal') {
-        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
-      }
-    });
+    Mailer.transporter.sendMail(mailOptions).then((response) => Mailer.emailToConsole(response));
   }
 
   public static sendPasswordResetRequestEmail(recipient: User, resetRequest: UserPasswordReset, location: string) {
@@ -72,11 +77,7 @@ export class Mailer {
         `<a href="">Report fraudulent reset request</a>`
     };
 
-    Mailer.transporter.sendMail(mailOptions).then((response) => {
-      if (Mailer.service == 'ethereal') {
-        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
-      }
-    });
+    Mailer.transporter.sendMail(mailOptions).then((response) => Mailer.emailToConsole(response));
   }
 
   public static sendPasswordResetConfirmationEmail(toEmail: string) {
@@ -88,11 +89,7 @@ export class Mailer {
       html: 'Your password to GeoInnovation Service Center has been reset.'
     };
 
-    Mailer.transporter.sendMail(mailOptions).then((response) => {
-      if (Mailer.service == 'ethereal') {
-        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
-      }
-    });
+    Mailer.transporter.sendMail(mailOptions).then((response) => Mailer.emailToConsole(response));
   }
 
   public static sendAccountConfirmationEmail(toEmail: string, sub: string) {
@@ -104,10 +101,12 @@ export class Mailer {
       html: `An account for GeoInnovation Service Center has been created with this email address. </br><a href="http://localhost:4001/user/register/${sub}">Verify email</a>`
     };
 
-    Mailer.transporter.sendMail(mailOptions).then((response) => {
-      if (Mailer.service == 'ethereal') {
-        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
-      }
-    });
+    Mailer.transporter.sendMail(mailOptions).then((response) => Mailer.emailToConsole(response));
+  }
+
+  public static emailToConsole(response) {
+    if (Mailer.service == 'ethereal') {
+      console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
+    }
   }
 }

--- a/libs/oidc/common/src/lib/utils/email/mailer.util.ts
+++ b/libs/oidc/common/src/lib/utils/email/mailer.util.ts
@@ -3,18 +3,43 @@ import Mail from 'nodemailer/lib/mailer';
 
 import { User, UserPasswordReset } from '@tamu-gisc/oidc/common';
 
+export type NodeMailerServices = 'ethereal' | 'gmail';
 export class Mailer {
-  private static user = 'kaitlyn.schimmel@ethereal.email';
-  private static password = 'Pe6D9DhkgUDyqyBMeg';
-  private static transporter: Mail = nodemailer.createTransport({
-    host: 'smtp.ethereal.email',
-    port: 587,
-    secure: false,
-    auth: {
-      user: Mailer.user,
-      pass: Mailer.password
+  private static transporter: Mail;
+  private static service: NodeMailerServices;
+
+  // https://dev.to/chandrapantachhetri/sending-emails-securely-using-node-js-nodemailer-smtp-gmail-and-oauth2-g3a
+  // 2LO https://nodemailer.com/smtp/oauth2/#oauth-2lo
+  public static build(service: NodeMailerServices, config?: {}) {
+    Mailer.service = service;
+
+    switch (service) {
+      case 'ethereal':
+        // use ethereal email and print out links to console (debugging / dev)
+        Mailer.transporter = nodemailer.createTransport({
+          host: 'smtp.ethereal.email',
+          port: 587,
+          secure: false,
+          auth: {
+            user: 'kaitlyn.schimmel@ethereal.email',
+            pass: 'Pe6D9DhkgUDyqyBMeg'
+          }
+        });
+        break;
+      case 'gmail':
+        // use gmail instead
+        Mailer.transporter = nodemailer.createTransport({
+          host: 'smtp.gmail.com',
+          port: 465,
+          secure: true,
+          auth: {
+            type: 'OAuth2',
+            ...config
+          }
+        });
+        break;
     }
-  });
+  }
 
   public static sendTokenByEmail(recipient: User, token: string) {
     const mailOptions = {
@@ -27,7 +52,9 @@ export class Mailer {
     };
 
     Mailer.transporter.sendMail(mailOptions).then((response) => {
-      console.log('2FA: ', Mailer.getTestMessageUrl(response));
+      if (Mailer.service == 'ethereal') {
+        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
+      }
     });
   }
 
@@ -46,7 +73,9 @@ export class Mailer {
     };
 
     Mailer.transporter.sendMail(mailOptions).then((response) => {
-      console.log('Verification email: ', Mailer.getTestMessageUrl(response));
+      if (Mailer.service == 'ethereal') {
+        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
+      }
     });
   }
 
@@ -60,7 +89,9 @@ export class Mailer {
     };
 
     Mailer.transporter.sendMail(mailOptions).then((response) => {
-      console.log('Verification email: ', Mailer.getTestMessageUrl(response));
+      if (Mailer.service == 'ethereal') {
+        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
+      }
     });
   }
 
@@ -74,14 +105,9 @@ export class Mailer {
     };
 
     Mailer.transporter.sendMail(mailOptions).then((response) => {
-      console.log('Verification email: ', Mailer.getTestMessageUrl(response));
+      if (Mailer.service == 'ethereal') {
+        console.log('Ethereal: ', nodemailer.getTestMessageUrl(response));
+      }
     });
-  }
-
-  public static getTestMessageUrl(response: string | {}) {
-    const testUrl = nodemailer.getTestMessageUrl(response);
-    console.log('TestURL: ', testUrl);
-
-    return testUrl;
   }
 }


### PR DESCRIPTION
Requires a `mailerconfig.ts` file in the environments directory with an exported member like:
`export const mailerConfig = {
  user: string (email you've setup Google API for,
  accessToken: string,
  clientId: string,
  clientSecret: string,
  refreshToken: string
};`
You'll need to go through some steps to setup `mailerConfig` for your own email or I can show you it in action with mine.