### PR TITLE
ci: Included CPA projects in the ci pipeline

### DIFF
--- a/apps/ues-recycling-angular/src/environments/environment.prod.ts
+++ b/apps/ues-recycling-angular/src/environments/environment.prod.ts
@@ -6,7 +6,7 @@ export const environment = {
 
 export * from './definitions';
 
-export const apiUrl = 'https://ues.geoservices.tamu.edu/api/ues/recycling/';
+export const apiUrl = 'https://ues.geoservices.tamu.edu/api/recycling/';
 export const auth_options: AuthOptions = {
   url: `https://ues.geoservices.tamu.edu/api/recycling`,
   attach_href: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,8 +65,15 @@ stages:
               Contents: '*'
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
+          - task: CopyFiles@2
+            displayName: 'Copying environment files to cpa-nest'
+            inputs:
+              SourceFolder: $(Agent.TempDirectory)/app_configs/cpa-nest
+              Contents: '*'
+              TargetFolder: $(System.DefaultWorkingDirectory)/apps/cpa-nest/src/environments
+
           - bash: |
-              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=development --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
+              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=development --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
             displayName: 'Running build for development'
 
           - task: CopyFiles@2
@@ -133,8 +140,15 @@ stages:
               Contents: '*'
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
+          - task: CopyFiles@2
+            displayName: 'Copying environment files to cpa-nest'
+            inputs:
+              SourceFolder: $(Agent.TempDirectory)/app_configs/cpa-nest
+              Contents: '*'
+              TargetFolder: $(System.DefaultWorkingDirectory)/apps/cpa-nest/src/environments
+
           - bash: |
-              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=production --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
+              npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=production --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes"
             displayName: 'Running build for production'
 
           - task: CopyFiles@2
@@ -202,5 +216,5 @@ stages:
               TargetFolder: $(System.DefaultWorkingDirectory)/apps/ues-operations-nest/src/environments
 
           - bash: |
-              npm run nx affected:apps -- --base=$(affectedBase) --head=HEAD --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,cpa-angular,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,cpa-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes" | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
+              npm run nx affected:apps -- --base=$(affectedBase) --head=HEAD --exclude="aggiemap-angular,signage-angular,trees-angular,bikeshare,gisday-competitions-angular,oidc-admin-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,oidc-provider-express,oidc-provider-nest,oidc-admin-nest,oidc-client-test,oidc-provider-angular,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,common-ngx-ui-notification,common-ngx-local-store,common-ngx-settings,common-ngx-pipes" | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
             displayName: 'add affected apps as buildtags'

--- a/workspace.json
+++ b/workspace.json
@@ -1963,7 +1963,15 @@
             "outputPath": "dist/apps/cpa-nest",
             "main": "apps/cpa-nest/src/main.ts",
             "tsConfig": "apps/cpa-nest/tsconfig.app.json",
-            "assets": ["apps/cpa-nest/src/assets", "apps/cpa-nest/src/package.json"]
+            "assets": [
+              "apps/cpa-nest/src/assets",
+              "apps/cpa-nest/src/package.json",
+              {
+                "glob": "**/*",
+                "input": "./libs/assets/powershell",
+                "output": "./assets/powershell"
+              }
+            ]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
Integrated the CPA website and API into the CI/CD system by setting up a deployment pipeline in Azure and by modifying the CI Yaml to remove the applications from the ignore list. Also added the assets section to the CPA API section on the workspace JSON, and edited the production environment file for ues-recycling-angular to have the correct API url. 