### PR TITLE
refactor(cpa): Refactored snapshot setting logic

### DIFF
--- a/libs/cpa/common/entities/src/lib/base/all.entity.ts
+++ b/libs/cpa/common/entities/src/lib/base/all.entity.ts
@@ -56,7 +56,7 @@ export class Workshop extends CPABaseEntity implements IWorkshop {
   @Column({ nullable: true })
   public date: Date;
 
-  @OneToMany((type) => WorkshopSnapshot, (s) => s.workshop)
+  @OneToMany((type) => WorkshopSnapshot, (s) => s.workshop, { cascade: true })
   public snapshots: WorkshopSnapshot[];
 
   @OneToMany((type) => WorkshopScenario, (s) => s.workshop)

--- a/libs/cpa/data-api/src/lib/modules/workshops/workshops.service.ts
+++ b/libs/cpa/data-api/src/lib/modules/workshops/workshops.service.ts
@@ -71,16 +71,14 @@ export class WorkshopsService extends BaseService<Workshop> {
 
       await workshop.save();
 
-      const promised = body.snapshotGuids.map((guid) => {
-        return getRepository(WorkshopSnapshot)
-          .create({
-            workshop: workshop,
-            snapshot: snapshots.find((r) => r.guid === guid)
-          })
-          .save();
+      workshop.snapshots = body.snapshotGuids.map((guid) => {
+        return getRepository(WorkshopSnapshot).create({
+          workshop: workshop,
+          snapshot: snapshots.find((s) => s.guid === guid)
+        });
       });
 
-      await Promise.all(promised);
+      await workshop.save();
 
       try {
         return await this.getWorkshop(body.workshopGuid, true, false, false, false);


### PR DESCRIPTION
Old logic was causing different order snapshots for a workshop on an update due to a promise race condition when inserting snapshots for a workshop.

New logic passes on the saving responsibility to the ORM which in fact preserves the correct order for snapshots.