### PR TITLE
feat(oidc-provider / oidc-client): Support for back channel logout

### DIFF
--- a/apps/oidc-admin-nest/src/app/app.module.ts
+++ b/apps/oidc-admin-nest/src/app/app.module.ts
@@ -19,7 +19,8 @@ import {
   UserPasswordHistory,
   ClientMetadataModule,
   RoleModule,
-  UserModule
+  UserModule,
+  BackchannelLogoutUri
 } from '@tamu-gisc/oidc/common';
 import { AccessTokenModule, StatsModule } from '@tamu-gisc/oidc/admin-nest';
 
@@ -36,6 +37,7 @@ import { OIDC_IDP_ISSUER_URL } from '../environments/oidcconfig';
       entities: [
         AccessToken,
         Account,
+        BackchannelLogoutUri,
         ClientMetadata,
         GrantType,
         ResponseType,

--- a/apps/oidc-client-test/src/environments/oidcconfig.ts
+++ b/apps/oidc-client-test/src/environments/oidcconfig.ts
@@ -5,8 +5,7 @@ export const OIDC_CLIENT_METADATA_BASIC: ClientMetadata = {
   client_secret: 'pppssssssttttheykidwantsomekandy',
   redirect_uris: ['http://localhost:3001/oidc/auth/callback'],
   response_types: ['code'],
-  token_endpoint_auth_method: 'client_secret_basic',
-  post_logout_redirect_uris: ['http://localhost:3001/oidc/auth/logout']
+  token_endpoint_auth_method: 'client_secret_basic'
 };
 
 export const OIDC_CLIENT_METADATA_JWT: ClientMetadata = {

--- a/apps/oidc-client-test/src/environments/oidcconfig.ts
+++ b/apps/oidc-client-test/src/environments/oidcconfig.ts
@@ -5,7 +5,8 @@ export const OIDC_CLIENT_METADATA_BASIC: ClientMetadata = {
   client_secret: 'pppssssssttttheykidwantsomekandy',
   redirect_uris: ['http://localhost:3001/oidc/auth/callback'],
   response_types: ['code'],
-  token_endpoint_auth_method: 'client_secret_basic'
+  token_endpoint_auth_method: 'client_secret_basic',
+  post_logout_redirect_uris: ['http://localhost:3001/oidc/auth/logout']
 };
 
 export const OIDC_CLIENT_METADATA_JWT: ClientMetadata = {

--- a/apps/oidc-provider-nest/src/app/app.module.ts
+++ b/apps/oidc-provider-nest/src/app/app.module.ts
@@ -31,7 +31,8 @@ import {
   ClientMetadataModule,
   UserModule,
   RoleModule,
-  SecretQuestionController
+  SecretQuestionController,
+  BackchannelLogoutUri
 } from '@tamu-gisc/oidc/common';
 import { AccessTokenModule, InteractionModule, UserLoginModule } from '@tamu-gisc/oidc/provider-nestjs';
 
@@ -48,6 +49,7 @@ import { dbConfig } from '../environments/environment';
         Account,
         AccessToken,
         AuthorizationCode,
+        BackchannelLogoutUri,
         Client,
         ClientCredential,
         ClientMetadata,

--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -40,7 +40,7 @@ async function bootstrap() {
       alias: 'setup',
       description: 'Create default admin user and oidc-angular client metadata',
       type: 'boolean',
-      implies: ['n', 't', 'r', 'e', 'p']
+      implies: ['n', 't', 'r', 'b', 'e', 'p']
     })
     .option('x', {
       alias: 'dropSchema',
@@ -62,6 +62,12 @@ async function bootstrap() {
     .option('r', {
       alias: 'redirectUri',
       description: 'With -s, determines what to set the default client redirect_uri as',
+      type: 'string',
+      nargs: 1
+    })
+    .option('b', {
+      alias: 'backchannelLogoutUri',
+      description: 'With -s, determines what to set the default client post_logout_redirect_uris as',
       type: 'string',
       nargs: 1
     })
@@ -154,7 +160,7 @@ async function bootstrap() {
           // Insert default Token Auth Methods
           await clientMetadataService.insertDefaultTokenEndpointAuthMethods();
           // Create ClientMetadata for oidc-idp-admin (angular site)
-          await clientMetadataService.insertClientMetadataForAdminSite(argv.n, argv.t, argv.r);
+          await clientMetadataService.insertClientMetadataForAdminSite(argv.n, argv.t, argv.r, argv.b);
           // Insert default Roles
           await roleService.insertDefaultUserRoles();
           // Create Admin user with known password

--- a/libs/oidc/client/src/lib/auth/oidc-client.controller.ts
+++ b/libs/oidc/client/src/lib/auth/oidc-client.controller.ts
@@ -27,11 +27,6 @@ export class OidcClientController {
     res.redirect(`${endSessionUrl}&id_token_hint=${req.user.id_token}`);
   }
 
-  @Get('/auth/logout')
-  public async backchannelLogout(@Request() req, @Response() res) {
-    console.log('Backchannel logout called');
-  }
-
   @UseGuards(LoginGuard)
   @Get('/auth/callback')
   public authCallback(@Response() res, @Request() req) {

--- a/libs/oidc/client/src/lib/auth/oidc-client.controller.ts
+++ b/libs/oidc/client/src/lib/auth/oidc-client.controller.ts
@@ -22,8 +22,14 @@ export class OidcClientController {
   @Get('/logout')
   public async logout(@Request() req, @Response() res) {
     const endSessionUrl = await OpenIdClient.client.endSessionUrl();
+
     req.logout();
-    res.redirect(endSessionUrl);
+    res.redirect(`${endSessionUrl}&id_token_hint=${req.user.id_token}`);
+  }
+
+  @Get('/auth/logout')
+  public async backchannelLogout(@Request() req, @Response() res) {
+    console.log('Backchannel logout called');
   }
 
   @UseGuards(LoginGuard)

--- a/libs/oidc/common/src/lib/entities/all.entity.ts
+++ b/libs/oidc/common/src/lib/entities/all.entity.ts
@@ -41,6 +41,7 @@ export interface IClientMetadata {
   redirect_uris: string[];
   response_types: string[];
   token_endpoint_auth_method: string;
+  post_logout_redirect_uris: string[];
 }
 
 export interface INewRole {
@@ -768,6 +769,9 @@ export class ClientMetadata extends GuidIdentity {
   @OneToMany((type) => RedirectUri, (redirectUri) => redirectUri.clientMetadata)
   public redirectUris: RedirectUri[];
 
+  @OneToMany((type) => BackchannelLogoutUri, (backchannelLogoutUri) => backchannelLogoutUri.clientMetadata)
+  public backchannelLogoutUris: BackchannelLogoutUri[];
+
   @ManyToMany((type) => ResponseType, {
     cascade: true,
     onDelete: 'CASCADE',
@@ -811,6 +815,24 @@ export class GrantType extends GuidIdentity {
 })
 export class RedirectUri extends GuidIdentity {
   @ManyToOne((type) => ClientMetadata, (client) => client.redirectUris, {
+    cascade: true,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE'
+  })
+  public clientMetadata: ClientMetadata;
+
+  @Column({
+    type: 'varchar',
+    nullable: false
+  })
+  public url: string;
+}
+
+@Entity({
+  name: 'back_channel_logout_uris'
+})
+export class BackchannelLogoutUri extends GuidIdentity {
+  @ManyToOne((type) => ClientMetadata, (client) => client.backchannelLogoutUris, {
     cascade: true,
     onDelete: 'CASCADE',
     onUpdate: 'CASCADE'
@@ -1102,6 +1124,9 @@ export class GrantTypeRepo extends CommonRepo<GrantType> {}
 
 @EntityRepository(RedirectUri)
 export class RedirectUriRepo extends CommonRepo<RedirectUri> {}
+
+@EntityRepository(BackchannelLogoutUri)
+export class BackchannelLogoutUriRepo extends CommonRepo<BackchannelLogoutUri> {}
 
 @EntityRepository(ResponseType)
 export class ResponseTypeRepo extends CommonRepo<ResponseType> {}

--- a/libs/oidc/common/src/lib/modules/client-metadata/client-metadata.module.ts
+++ b/libs/oidc/common/src/lib/modules/client-metadata/client-metadata.module.ts
@@ -8,7 +8,8 @@ import {
   GrantTypeRepo,
   RedirectUriRepo,
   ResponseTypeRepo,
-  TokenEndpointAuthMethodRepo
+  TokenEndpointAuthMethodRepo,
+  BackchannelLogoutUriRepo
 } from '../../entities/all.entity';
 
 @Module({
@@ -18,7 +19,8 @@ import {
       GrantTypeRepo,
       RedirectUriRepo,
       ResponseTypeRepo,
-      TokenEndpointAuthMethodRepo
+      TokenEndpointAuthMethodRepo,
+      BackchannelLogoutUriRepo
     ])
   ],
   providers: [ClientMetadataService],

--- a/libs/oidc/common/src/lib/services/client-metadata/client-metadata.service.ts
+++ b/libs/oidc/common/src/lib/services/client-metadata/client-metadata.service.ts
@@ -67,10 +67,10 @@ export class ClientMetadataService {
       backchannelLogoutUris: [backchannelLogoutUri]
     };
     const grants = await this.findGrantTypeEntities(adminMetadata.grants);
-    const redirectUris = await this.createRedirectUriEntities(adminMetadata.redirectUris);
+    const redirectUris = this.createRedirectUriEntities(adminMetadata.redirectUris);
     const responseTypes = await this.findResponseTypeEntities(adminMetadata.responseTypes);
     const token_endpoint_auth_method = await this.findTokenEndpointAuthMethod(adminMetadata.token_endpoint_auth_method);
-    const backchannelUris = await this.createBackchannelLogoutUri(adminMetadata.backchannelLogoutUris);
+    const backchannelUris = this.createBackchannelLogoutUri(adminMetadata.backchannelLogoutUris);
 
     const _clientMetadata: Partial<ClientMetadata> = {
       clientName: adminMetadata.clientName,
@@ -88,13 +88,14 @@ export class ClientMetadataService {
   public async insertClientMetadata(_clientMetadata: Partial<ClientMetadata>) {
     const clientMetadata = this.clientMetadataRepo.create(_clientMetadata);
 
-    clientMetadata.redirectUris.map((redirectUri) => {
-      redirectUri.save();
-    });
-
-    clientMetadata.backchannelLogoutUris.map((backchannelUri) => {
-      backchannelUri.save();
-    });
+    await Promise.all([
+      clientMetadata.redirectUris.map((redirectUri) => {
+        redirectUri.save();
+      }),
+      clientMetadata.backchannelLogoutUris.map((backchannelUri) => {
+        backchannelUri.save();
+      })
+    ]);
 
     return this.clientMetadataRepo.save(clientMetadata);
   }
@@ -242,10 +243,10 @@ export class ClientMetadataService {
   }
 
   // RedirectUri functions
-  public async createRedirectUriEntities(_redirectUris: string[]) {
+  public createRedirectUriEntities(_redirectUris: string[]) {
     const redirectUris: RedirectUri[] = [];
 
-    _redirectUris.map((value, i) => {
+    _redirectUris.forEach((value, i) => {
       const redirectUriPartial: Partial<RedirectUri> = {
         url: value
       };
@@ -257,10 +258,10 @@ export class ClientMetadataService {
   }
 
   // BackchannelLogoutUri functions
-  public async createBackchannelLogoutUri(_backchannelLogoutUris: string[]) {
+  public createBackchannelLogoutUri(_backchannelLogoutUris: string[]) {
     const backchannelLogoutUris: BackchannelLogoutUri[] = [];
 
-    _backchannelLogoutUris.map((value, i) => {
+    _backchannelLogoutUris.forEach((value, i) => {
       const backchannelLogoutUri: Partial<BackchannelLogoutUri> = {
         url: value
       };


### PR DESCRIPTION
Enabled back channel logout support. 

Required adding some additional logic to the yargs initialization system as well as some additions to the mega client-metadata.service class. 

Added an additional route to the oidc-client lib which will logout the user.