### PR TITLE
 ci: PM2 launch on windows start-up via NSSM, as well as restart if crash. 

### DIFF
--- a/libs/assets/batch/startup.bat
+++ b/libs/assets/batch/startup.bat
@@ -1,0 +1,9 @@
+sc query "PM2" | find "RUNNING"
+
+if "%ERRORLEVEL%"=="0" (
+    echo Already Running
+    pause
+) else (
+    pm2 resurrect
+    pause
+)

--- a/libs/assets/batch/startup.bat
+++ b/libs/assets/batch/startup.bat
@@ -1,9 +1,8 @@
-sc query "PM2" | find "RUNNING"
+pm2 status | find /i "Current process list running is not in sync with saved list. App effluent-api dispatch-api recycling-api operations-api differs. Type 'pm2 save' to synchronize."
 
-if "%ERRORLEVEL%"=="0" (
-    echo Already Running
-    pause
+if not errorlevel 1 (
+    pm2 kill
+    pm2 resurect 
 ) else (
-    pm2 resurrect
-    pause
+    echo Already Running
 )

--- a/libs/assets/batch/startup.bat
+++ b/libs/assets/batch/startup.bat
@@ -1,4 +1,4 @@
-pm2 status | find /i "Current process list running is not in sync with saved list. App effluent-api dispatch-api recycling-api operations-api differs. Type 'pm2 save' to synchronize."
+pm2 status | find /i "Current process list running is not in sync with saved list."
 
 if not errorlevel 1 (
     pm2 kill


### PR DESCRIPTION
Created a startup.batch file in the monorepo which contains the start-up procedure for NSSM. Modified said procedure to query if PM2 was already running, and if so don't attempt to resurrect. This was done to mitigate an issue with the resurrect command in which it was stuck in a infinite loop crashing/slowing down the server. 