### PR TITLE
ci: Added a loop and event scenario if PM2 crashes to startup.bat file

### DIFF
--- a/libs/assets/batch/startup.bat
+++ b/libs/assets/batch/startup.bat
@@ -1,8 +1,14 @@
-pm2 status | find /i "Current process list running is not in sync with saved list."
+:loop
+pm2 status | find /i "Current process list"
 
 if not errorlevel 1 (
     pm2 kill
-    pm2 resurect 
+    timeout /t 5 /nobreak 
+    pm2 resurrect
+    EVENTCREATE /T ERROR /L APPLICATION /so nssmCheck /ID 100 /D "Pm2 resurected."  
+    timeout /t 300 /nobreak > NUL 
+    goto loop
 ) else (
-    echo Already Running
+    timeout /t 300 /nobreak > NUL
+    goto loop
 )


### PR DESCRIPTION
Added a loop that is set on five minute intervals to the startup batch file for the PM2 window service that allows for NSSM to monitor whether or not PM2 has crashed. If PM2 has crashed it will attempt to resurrect and will publish an event in the logs entitled "nssmCheck".