### PR TITLE
fix(workspace): Updated the workspace typescript library path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,5 @@
   ],
   "jest.autoEnable": false,
   "cSpell.enabled": true,
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Path was invalid in OSX environments which prevented tslint from starting up correctly.

Fixed path works on both OSX and Windows.