### PR TITLE
feat(oidc-provider): Added TAMU smtp-relay support for nodemailer

### DIFF
--- a/apps/oidc-provider-nest/src/main.ts
+++ b/apps/oidc-provider-nest/src/main.ts
@@ -118,9 +118,20 @@ async function bootstrap() {
 
   const dir = join(__dirname, 'assets/views');
 
-  // This will setup the Mailer (gmail or ethereal)
-  // Mailer.build('gmail', mailerConfig);
-  Mailer.build('ethereal');
+  // This will setup the Mailer (gmail, ethereal, or tamu-relay)
+  if (argv.m) {
+    switch (argv.m) {
+      case 'gmail':
+        Mailer.build('gmail');
+        break;
+      case 'ethereal':
+        Mailer.build('ethereal');
+        break;
+      case 'tamu':
+        Mailer.build('tamu-relay');
+        break;
+    }
+  }
 
   // This will set the default time step for otplib to 5 minutes
   TwoFactorAuthUtils.build();

--- a/libs/oidc/common/src/lib/oidc-common.ts
+++ b/libs/oidc/common/src/lib/oidc-common.ts
@@ -15,7 +15,6 @@ export * from './services/role/role.service';
 export * from './services/user/user.service';
 
 // utils
-export * from './utils/auth/auth.util';
 export * from './utils/web/url-utils';
 export * from './utils/web/jwt.util';
 export * from './utils/security/sha1hash.util';

--- a/libs/oidc/common/src/lib/utils/email/mailer.util.ts
+++ b/libs/oidc/common/src/lib/utils/email/mailer.util.ts
@@ -37,9 +37,10 @@ export class Mailer {
         break;
       case 'tamu-relay':
         Mailer.transporter = nodemailer.createTransport({
-          host: 'relay.tamu.edu',
+          host: 'smtp-relay.tamu.edu',
           port: 25,
-          secure: false
+          secure: false,
+          ignoreTLS: true
         });
         break;
       case 'gmail':


### PR DESCRIPTION
https://it.tamu.edu/services/email-messaging-and-collaboration/campus-email-services/mail-relay-resources/#service-service-details

Added this provider to nodemailer. Works when you ignore TLS in nodemailer options and use port 25. Must be connected to TAMU VPN.