### PR TITLE
feat(ues-operations): Auth prompt routes

### DIFF
--- a/apps/oidc-admin-angular/src/app/app.module.ts
+++ b/apps/oidc-admin-angular/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { HttpClientModule } from '@angular/common/http';
 import * as WebFont from 'webfontloader';
 
 import { EnvironmentModule, env } from '@tamu-gisc/common/ngx/environment';
-import { AuthGuard, AuthProvider } from '@tamu-gisc/common/ngx/auth';
+import { AuthGuard, AuthInterceptorProvider } from '@tamu-gisc/common/ngx/auth';
 import { LocalStoreModule } from '@tamu-gisc/common/ngx/local-store';
 import { UILayoutModule } from '@tamu-gisc/ui-kits/ngx/layout';
 
@@ -87,7 +87,7 @@ export function getHighlightLanguages() {
       provide: env,
       useValue: environment
     },
-    AuthProvider
+    AuthInterceptorProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/apps/ues-angular/src/app/app.component.ts
+++ b/apps/ues-angular/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
-import { RouterHistoryService } from '@tamu-gisc/common/ngx/router';
 
 @Component({
   selector: 'tamu-gisc-root',
@@ -9,7 +8,7 @@ import { RouterHistoryService } from '@tamu-gisc/common/ngx/router';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  constructor(public analytics: Angulartics2GoogleAnalytics, private history: RouterHistoryService) {
+  constructor(public analytics: Angulartics2GoogleAnalytics) {
     analytics.startTracking();
   }
 }

--- a/apps/ues-angular/src/app/app.module.ts
+++ b/apps/ues-angular/src/app/app.module.ts
@@ -7,7 +7,6 @@ import { StorageServiceModule } from 'ngx-webstorage-service';
 import { AppRoutingModule } from '@tamu-gisc/ues/common/ngx';
 import { NotificationModule, notificationStorage } from '@tamu-gisc/common/ngx/ui/notification';
 import { env, EnvironmentModule } from '@tamu-gisc/common/ngx/environment';
-import { AuthProvider } from '@tamu-gisc/common/ngx/auth';
 
 import { AppComponent } from './app.component';
 import * as environment from '../environments/environment';
@@ -23,8 +22,7 @@ WebFont.load({
   declarations: [AppComponent],
   providers: [
     { provide: env, useValue: environment },
-    { provide: notificationStorage, useValue: 'ues-notifications' },
-    AuthProvider
+    { provide: notificationStorage, useValue: 'ues-notifications' }
   ],
   bootstrap: [AppComponent]
 })

--- a/apps/ues-effluent-angular/src/app/app.module.ts
+++ b/apps/ues-effluent-angular/src/app/app.module.ts
@@ -11,7 +11,7 @@ import { StorageServiceModule } from 'ngx-webstorage-service';
 import { NotificationModule, notificationStorage } from '@tamu-gisc/common/ngx/ui/notification';
 import { env, EnvironmentModule } from '@tamu-gisc/common/ngx/environment';
 import { CommonNgxRouterModule } from '@tamu-gisc/common/ngx/router';
-import { AuthGuard, AuthProvider } from '@tamu-gisc/common/ngx/auth';
+import { AuthGuard, AuthInterceptorProvider } from '@tamu-gisc/common/ngx/auth';
 
 import { AppComponent } from './app.component';
 import * as environment from '../environments/environment';
@@ -48,7 +48,7 @@ const routes: Routes = [
   ],
   declarations: [AppComponent],
   providers: [
-    AuthProvider,
+    AuthInterceptorProvider,
     { provide: env, useValue: environment },
     { provide: notificationStorage, useValue: 'ues-effluent-notifications' }
   ],

--- a/apps/ues-recycling-angular/src/app/app.module.ts
+++ b/apps/ues-recycling-angular/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { RouterModule } from '@angular/router';
 
 import * as WebFont from 'webfontloader';
 import { env, EnvironmentService } from '@tamu-gisc/common/ngx/environment';
-import { AuthGuard, AuthProvider } from '@tamu-gisc/common/ngx/auth';
+import { AuthGuard, AuthInterceptorProvider } from '@tamu-gisc/common/ngx/auth';
 
 import * as environment from '../environments/environment';
 import { AppComponent } from './app.component';
@@ -42,7 +42,7 @@ WebFont.load({
       provide: env,
       useValue: environment
     },
-    AuthProvider
+    AuthInterceptorProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/apps/ues-valves-angular/src/app/app.module.ts
+++ b/apps/ues-valves-angular/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import * as WebFont from 'webfontloader';
 import { env, EnvironmentService } from '@tamu-gisc/common/ngx/environment';
-import { AuthGuard, AuthProvider } from '@tamu-gisc/common/ngx/auth';
+import { AuthGuard, AuthInterceptorProvider } from '@tamu-gisc/common/ngx/auth';
 import { NotificationModule, notificationStorage } from '@tamu-gisc/common/ngx/ui/notification';
 
 import * as environment from '../environments/environment';
@@ -41,7 +41,7 @@ const routes: Routes = [
       provide: env,
       useValue: environment
     },
-    AuthProvider,
+    AuthInterceptorProvider,
     {
       provide: notificationStorage,
       useValue: 'aggiemap-notifications'

--- a/libs/common/ngx/auth/src/lib/guards/auth.guard.ts
+++ b/libs/common/ngx/auth/src/lib/guards/auth.guard.ts
@@ -32,7 +32,7 @@ export class AuthGuard implements CanActivate {
         }
 
         // If auth failed and a redirect route was provided, redirect to it.
-        const urlTree = this.router.parseUrl(params.redirectTo);
+        const urlTree = this.router.parseUrl(params.redirectTo + `?ret=${window.location.href}`);
 
         return urlTree;
       })

--- a/libs/common/ngx/auth/src/lib/guards/auth.guard.ts
+++ b/libs/common/ngx/auth/src/lib/guards/auth.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { AuthService } from '../services/auth.service';
 
@@ -8,12 +9,37 @@ import { AuthService } from '../services/auth.service';
   providedIn: 'root'
 })
 export class AuthGuard implements CanActivate {
-  constructor(private auth: AuthService) {}
+  constructor(private auth: AuthService, private router: Router) {}
 
   public canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return this.auth.isAuthenticated();
+    return this.auth.isAuthenticated().pipe(
+      map((result) => {
+        // Extract any provided route data.
+        const params: IGuardParams = route.data;
+
+        // If auth returns successful response, proceed
+        if (result.status) {
+          return true;
+        }
+
+        // If auth failed and there is not a redirection parameter passed,
+        // stop activation
+        if (params.redirectTo === undefined) {
+          return false;
+        }
+
+        // If auth failed and a redirect route was provided, redirect to it.
+        const urlTree = this.router.parseUrl(params.redirectTo);
+
+        return urlTree;
+      })
+    );
   }
+}
+
+interface IGuardParams {
+  redirectTo?: string;
 }

--- a/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+
 import {
   HttpErrorResponse,
   HttpEvent,
@@ -8,11 +8,9 @@ import {
   HttpRequest,
   HTTP_INTERCEPTORS
 } from '@angular/common/http';
-import { Injectable, Inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-
-import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 import { AuthService } from './auth.service';
 
@@ -20,11 +18,7 @@ import { AuthService } from './auth.service';
   providedIn: 'root'
 })
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(
-    @Inject(DOCUMENT) private document: Document,
-    private environment: EnvironmentService,
-    private auth: AuthService
-  ) {}
+  constructor(private auth: AuthService) {}
 
   public intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
@@ -34,16 +28,10 @@ export class AuthInterceptor implements HttpInterceptor {
         },
         (err) => {
           if (err instanceof HttpErrorResponse) {
-            if (err.status === 403 || err.status === 401) {
-              if (typeof this.auth.authOptions === 'string') {
-                this.document.location.href = `${this.auth.authOptions}/oidc/login`;
-              } else if (typeof this.auth.authOptions === 'object') {
-                this.document.location.href = `${this.auth.cleanUrl(this.auth.authOptions.url)}/oidc/login${
-                  this.auth.authOptions.attach_href === true ? '?ret=' + window.location.href : ''
-                }`;
-              } else {
-                throw new Error('Error resolving client auth API settings.');
-              }
+            if (err.status === 401) {
+              this.auth.redirect();
+            } else {
+              throw new Error('Error resolving client auth API settings.');
             }
           }
         }

--- a/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
@@ -28,7 +28,7 @@ export class AuthInterceptor implements HttpInterceptor {
         },
         (err) => {
           if (err instanceof HttpErrorResponse) {
-            if (err.status === 401) {
+            if (err.status === 401 || err.status === 403) {
               this.auth.redirect();
             } else {
               throw new Error('Error resolving client auth API settings.');

--- a/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth-interceptor.service.ts
@@ -40,7 +40,7 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 }
 
-export const AuthProvider: Provider = {
+export const AuthInterceptorProvider: Provider = {
   provide: HTTP_INTERCEPTORS,
   useClass: AuthInterceptor,
   multi: true

--- a/libs/common/ngx/auth/src/lib/services/auth.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -16,7 +17,7 @@ export class AuthService {
     attach_href: undefined
   };
 
-  constructor(private http: HttpClient, private env: EnvironmentService) {
+  constructor(@Inject(DOCUMENT) private document: Document, private http: HttpClient, private env: EnvironmentService) {
     if (this.env.value('auth_url', true)) {
       this.authOptions.url = this.env.value('auth_url', true);
     } else if (this.env.value('auth_options', true)) {
@@ -52,6 +53,16 @@ export class AuthService {
       return url.slice(0, url.length - 1);
     } else {
       return url;
+    }
+  }
+
+  public redirect() {
+    if (typeof this.authOptions === 'string') {
+      this.document.location.href = `${this.authOptions}/oidc/login`;
+    } else if (typeof this.authOptions === 'object') {
+      this.document.location.href = `${this.cleanUrl(this.authOptions.url)}/oidc/login${
+        this.authOptions.attach_href === true ? '?ret=' + window.location.href : ''
+      }`;
     }
   }
 }

--- a/libs/common/ngx/auth/src/lib/services/auth.service.ts
+++ b/libs/common/ngx/auth/src/lib/services/auth.service.ts
@@ -62,13 +62,24 @@ export class AuthService {
     }
   }
 
-  public redirect() {
+  /**
+   * Redirects to the auth url
+   *
+   * If auth options allow attaching a return URL, window location will be used by default
+   *
+   * @param {string} [returnUrl] Overwrite the default window location return url
+   */
+  public redirect(returnUrl?: string) {
     if (typeof this.authOptions === 'string') {
       this.document.location.href = `${this.authOptions}/oidc/login`;
     } else if (typeof this.authOptions === 'object') {
+      const ret = returnUrl ? returnUrl : window.location.href;
+
       this.document.location.href = `${this.cleanUrl(this.authOptions.url)}/oidc/login${
-        this.authOptions.attach_href === true ? '?ret=' + window.location.href : ''
+        this.authOptions.attach_href === true ? `?ret=${ret}` : ''
       }`;
+    } else {
+      console.warn('No auth url provided. Cannot redirect.');
     }
   }
 }

--- a/libs/ues/common/ngx/src/lib/modules/auth/auth.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/auth.module.ts
@@ -4,8 +4,10 @@ import { CommonModule } from '@angular/common';
 import { UserService } from './services/user.service';
 import { AuthGroupsPipe } from './pipes/auth-groups.pipe';
 
+import { SessionExpiredModule } from './pages/session-expired/session-expired.module';
+
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, SessionExpiredModule],
   declarations: [AuthGroupsPipe],
   providers: [UserService],
   exports: [AuthGroupsPipe]

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.html
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.html
@@ -1,0 +1,1 @@
+<p>session-expired works!</p>

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.html
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.html
@@ -1,1 +1,7 @@
-<p>session-expired works!</p>
+<tamu-gisc-ues-tamu-block class="trailer-2" [version]="'negative'"></tamu-gisc-ues-tamu-block>
+
+<h1 class="trailer-2">Your session has expired</h1>
+
+<p class="trailer-2">You will be automatically redirected to login in {{secondsLeft | async}} seconds. Use your apogee credentials to login.</p>
+
+<p id="manual-redirect"><span (click)="redirect()">Click here</span> if you are not redirected automatically.</p>

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.scss
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.scss
@@ -1,0 +1,30 @@
+@import 'libs/sass/mixins';
+
+:host {
+  height: 100%;
+  width: 100%;
+  background: radial-gradient(#500000, #410000);
+  @include flexbox();
+  @include flex-direction(column);
+  @include justify-content(center);
+  @include align-items(center);
+}
+
+h1,
+p {
+  color: #eeeeee;
+  text-align: center;
+}
+
+tamu-gisc-ues-tamu-block {
+  width: 20rem;
+}
+
+#manual-redirect {
+  font-size: 0.8rem;
+  font-style: italic;
+  span {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.spec.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SessionExpiredComponent } from './session-expired.component';
+
+describe('SessionExpiredComponent', () => {
+  let component: SessionExpiredComponent;
+  let fixture: ComponentFixture<SessionExpiredComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SessionExpiredComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SessionExpiredComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.ts
@@ -1,12 +1,36 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { interval, Observable } from 'rxjs';
+import { finalize, map, take } from 'rxjs/operators';
+
+import { AuthService } from '@tamu-gisc/common/ngx/auth';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'tamu-gisc-session-expired',
   templateUrl: './session-expired.component.html',
   styleUrls: ['./session-expired.component.scss']
 })
-export class SessionExpiredComponent implements OnInit {
-  constructor() {}
+export class SessionExpiredComponent {
+  constructor(private auth: AuthService, private route: ActivatedRoute) {}
 
-  public ngOnInit(): void {}
+  /**
+   * Seconds before redirect
+   */
+  private timeout = 7;
+
+  public secondsLeft: Observable<number> = interval(1000).pipe(
+    take(this.timeout + 1),
+    map((count) => {
+      return this.timeout - count;
+    }),
+    finalize(() => {
+      this.redirect();
+    })
+  );
+
+  public redirect() {
+    const incomingUrl = this.route.snapshot.queryParams.ret;
+
+    this.auth.redirect(incomingUrl);
+  }
 }

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-session-expired',
+  templateUrl: './session-expired.component.html',
+  styleUrls: ['./session-expired.component.scss']
+})
+export class SessionExpiredComponent implements OnInit {
+  constructor() {}
+
+  public ngOnInit(): void {}
+}

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+
+import { SessionExpiredComponent } from './session-expired.component';
+
+const routes: Routes = [
+  {
+    path: 'session/expired',
+    component: SessionExpiredComponent
+  }
+];
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(routes)],
+  declarations: [SessionExpiredComponent]
+})
+export class SessionExpiredModule {}

--- a/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/auth/pages/session-expired/session-expired.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 
 import { SessionExpiredComponent } from './session-expired.component';
+import { UESCoreUIModule } from '../../../core-ui/core-ui.module';
 
 const routes: Routes = [
   {
@@ -12,7 +13,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(routes)],
+  imports: [CommonModule, RouterModule.forChild(routes), UESCoreUIModule],
   declarations: [SessionExpiredComponent]
 })
 export class SessionExpiredModule {}

--- a/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
@@ -13,6 +13,8 @@ import { ResponsiveModule } from '@tamu-gisc/dev-tools/responsive';
 import { CommonNgxRouterModule } from '@tamu-gisc/common/ngx/router';
 import { TestingModule } from '@tamu-gisc/dev-tools/application-testing';
 
+import { AuthModule } from '../auth/auth.module';
+
 const hybridRoutes: Routes = [
   {
     path: '',
@@ -23,7 +25,7 @@ const hybridRoutes: Routes = [
     path: 'map',
     loadChildren: () => import('../map/map.module').then((m) => m.MapModule),
     canActivate: [AuthGuard],
-    data: { redirectTo: '/soemthing#thing' }
+    data: { redirectTo: '/session/expired' }
   }
 ];
 
@@ -37,7 +39,8 @@ const hybridRoutes: Routes = [
     ResponsiveModule,
     CommonNgxRouterModule,
     TestingModule,
-    UITamuBrandingModule
+    UITamuBrandingModule,
+    AuthModule
   ],
   declarations: [],
   providers: [],

--- a/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
@@ -12,7 +12,6 @@ import { AuthGuard } from '@tamu-gisc/common/ngx/auth';
 import { ResponsiveModule } from '@tamu-gisc/dev-tools/responsive';
 import { CommonNgxRouterModule } from '@tamu-gisc/common/ngx/router';
 import { TestingModule } from '@tamu-gisc/dev-tools/application-testing';
-
 import { AuthModule } from '../auth/auth.module';
 
 const hybridRoutes: Routes = [

--- a/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
@@ -22,7 +22,8 @@ const hybridRoutes: Routes = [
   {
     path: 'map',
     loadChildren: () => import('../map/map.module').then((m) => m.MapModule),
-    canActivate: [AuthGuard]
+    canActivate: [AuthGuard],
+    data: { redirectTo: '/soemthing#thing' }
   }
 ];
 


### PR DESCRIPTION
Introduces a "session expired" route that can be navigated to manually or automagically by auth guards to present the user with a pre-login instruction prompt. In the case of UES operations, it is used to remind users to use certain credentials in the login process.