### PR TITLE
feat(ues-angular): Removed the session expired view

### DIFF
--- a/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
+++ b/libs/ues/common/ngx/src/lib/modules/routing/routing.module.ts
@@ -6,7 +6,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { RouterModule, Routes } from '@angular/router';
 
 import { UITamuBrandingModule } from '@tamu-gisc/ui-kits/ngx/branding';
-import { AuthGuard } from '@tamu-gisc/common/ngx/auth';
+import { AuthGuard, AuthInterceptorProvider } from '@tamu-gisc/common/ngx/auth';
 
 // Services
 import { ResponsiveModule } from '@tamu-gisc/dev-tools/responsive';
@@ -23,8 +23,7 @@ const hybridRoutes: Routes = [
   {
     path: 'map',
     loadChildren: () => import('../map/map.module').then((m) => m.MapModule),
-    canActivate: [AuthGuard],
-    data: { redirectTo: '/session/expired' }
+    canActivate: [AuthGuard]
   }
 ];
 
@@ -42,7 +41,7 @@ const hybridRoutes: Routes = [
     AuthModule
   ],
   declarations: [],
-  providers: [],
+  providers: [AuthInterceptorProvider],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Will now once again automatically and immediately redirectto to MS login when a user's session is expired/non-existent.

All the redirection logic and views are still in the code base should they need to be used again in the future.