### PR TITLE
fix(aggiemap-angular): Fixed the mobile popup initial visibility

### DIFF
--- a/libs/maps/feature/popup/src/lib/containers/mobile/mobile.component.html
+++ b/libs/maps/feature/popup/src/lib/containers/mobile/mobile.component.html
@@ -1,4 +1,4 @@
-<div class="popup draggable" [ngClass]="{ hidden: !show }" draggable [draggableIdentifier]="identifier">
+<div class="popup draggable" [ngClass]="{ hidden: !(show | async) }" draggable [draggableIdentifier]="identifier">
   <div class="handle"></div>
 
   <ng-template render-host></ng-template>


### PR DESCRIPTION
The popup container should not be visible at all unless there is a component to render.

Fixes #152 