### PR TITLE
fix(aggiemap-angular): Updated building popup proctor button URL

### DIFF
--- a/libs/aggiemap/src/lib/popups/components/building/building-popup.component.ts
+++ b/libs/aggiemap/src/lib/popups/components/building/building-popup.component.ts
@@ -32,7 +32,7 @@ export class BuildingPopupComponent extends BaseDirectionsComponent implements O
 
     const buildingNumber = this.data.attributes.Number.split('.')[0];
 
-    this.proctorURL = `https://proctorlist.tamu.edu/MainProctorBuildings/Details/${buildingNumber}?utm_source=aggiemap`;
+    this.proctorURL = `https://proctorlist.tamu.edu/?utm_source=aggiemap`;
   }
 
   public startDirections() {


### PR DESCRIPTION
Now points to the root URL of the website. Proctors website is undergoing changes and does not currently support linking to individual buildings.