### PR TITLE
fix(aggiemap-angular): Fixed mobile search backdrop overflow

### DIFF
--- a/libs/aggiemap/src/lib/modules/mobile-ui/animations/elements.ts
+++ b/libs/aggiemap/src/lib/modules/mobile-ui/animations/elements.ts
@@ -1,4 +1,4 @@
-import { trigger, state, style, animate, transition, query, animateChild, group } from '@angular/animations';
+import { trigger, state, style, animate, transition, sequence } from '@angular/animations';
 
 export const offCanvasSlideUpFromTop = trigger('offCanvasSlideUpFromTop', [
   state(
@@ -16,18 +16,22 @@ export const offCanvasSlideUpFromTop = trigger('offCanvasSlideUpFromTop', [
   transition('* => *', [animate('250ms cubic-bezier(0.25, 0, 0.25, 1)')])
 ]);
 
+const animationTransitionFn = '200ms 50ms cubic-bezier(0.25, 0, 0.25, 1)';
 export const offCanvasSlideInFromBottom = trigger('offCanvasSlideInFromBottom', [
   state(
     'true',
     style({
-      transform: 'translateY(0%)'
+      transform: 'translateY(0%)',
+      display: 'initial'
     })
   ),
   state(
     'false',
     style({
-      transform: 'translateY(100%)'
+      transform: 'translateY(100%)',
+      display: 'none'
     })
   ),
-  transition('* => *', [animate('200ms cubic-bezier(0.25, 0, 0.25, 1)')])
+  transition('false => true', [sequence([style({ display: 'initial' }), animate(animationTransitionFn)])]),
+  transition('true => false', [animate(animationTransitionFn)])
 ]);

--- a/libs/aggiemap/src/lib/modules/mobile-ui/components/omnisearch/omnisearch.component.scss
+++ b/libs/aggiemap/src/lib/modules/mobile-ui/components/omnisearch/omnisearch.component.scss
@@ -21,5 +21,4 @@ tamu-gisc-search-mobile {
 tamu-gisc-backdrop {
   z-index: -1;
   top: 100% !important;
-  @include transform(translateY(100%));
 }

--- a/libs/aggiemap/src/lib/modules/mobile-ui/components/omnisearch/omnisearch.component.ts
+++ b/libs/aggiemap/src/lib/modules/mobile-ui/components/omnisearch/omnisearch.component.ts
@@ -23,9 +23,9 @@ import esri = __esri;
 })
 export class OmnisearchComponent implements OnInit, OnDestroy {
   /**
-   * Determines when the backdrop component will be visible
+   * Determines the backdrop visibility
    */
-  public backdropVisible: boolean;
+  public backdropVisible = false;
 
   /**
    * Determines when the search bar will slide out of view.


### PR DESCRIPTION
Now applies initial display properties so that the backdrop is hidden on init state and sequentially applies an initial display property to show the backdrop before the animation is started. This preserves the original animation while preventing user scrolling when using a page element to scroll.

Fixes #155 