### PR TITLE
chore(deps): Installed arcgis js types explicit version 4.19

### DIFF
--- a/libs/maps/feature/draw/src/lib/components/base/base.component.ts
+++ b/libs/maps/feature/draw/src/lib/components/base/base.component.ts
@@ -18,9 +18,9 @@ export class BaseDrawComponent implements OnInit, OnDestroy {
   public reference: string;
 
   @Input()
-  public defaultUpdateTool = 'transform';
+  public defaultUpdateTool: 'transform' | 'move' | 'reshape' = 'transform';
 
-  public activeUpdateTool: string;
+  public activeUpdateTool: 'transform' | 'move' | 'reshape';
 
   /**
    * Describes the emission format for the drawn features. By default (`false`) the component
@@ -187,7 +187,7 @@ export class BaseDrawComponent implements OnInit, OnDestroy {
   /**
    * Calls the model graphic create method with the provided tool name.
    */
-  public create(tool: string) {
+  public create(tool) {
     this.activeUpdateTool = undefined;
 
     this.model.create(tool);
@@ -207,7 +207,7 @@ export class BaseDrawComponent implements OnInit, OnDestroy {
    * Additionally, if the model is active from another tool that is not an update tool (point, polygon, etc),
    * cancel that action.
    */
-  public setUpdateTool(tool: string) {
+  public setUpdateTool(tool) {
     if (this.model.activeTool === 'reshape' || this.model.activeTool === 'transform') {
       this.model.toggleUpdateTool();
     } else {

--- a/nx.json
+++ b/nx.json
@@ -3,6 +3,7 @@
   "implicitDependencies": {
     "workspace.json": "*",
     "package.json": "*",
+    "package-lock.json": "*",
     "tslint.json": "*",
     "nx.json": "*",
     "tsconfig.base.json": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8408,9 +8408,9 @@
       }
     },
     "@types/arcgis-js-api": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.21.0.tgz",
-      "integrity": "sha512-PHGWSJuIbxcJXDslDkn+yPeZQN/BN6S3Pz4sh/fgp3aKVcxWAW7fHBLnADgfuE1HcejGcBpxqcaf+/xs0buelQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.19.0.tgz",
+      "integrity": "sha512-r/DC3tpStrjlk6yOLbaJS5+7p/7s+Jk831EsABYXxkfGRtPj5ptlGr8Lqf63ShAvrcAItdvkb06M7ADv51j3Qw==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@nrwl/web": "11.0.16",
     "@nrwl/workspace": "11.0.16",
     "@schematics/angular": "10.1.7",
-    "@types/arcgis-js-api": "^4.12.0",
+    "@types/arcgis-js-api": "~4.19.0",
     "@types/chart.js": "^2.9.3",
     "@types/clipboard": "2.0.1",
     "@types/jest": "26.0.8",


### PR DESCRIPTION
Previous dep package lock had automatically installed 4.21 due to semver syntax and was breaking builds.

Updated a single file from map drawing component. Before the initial package lock update that broke builds, all esri mapping applications were running on esri loader 3.1.0 which loaded arcgis js 4.19 but the typings that were being used were for arcgis js api v  4.15.0.  This update brings both typings and api version in line with each other.