### PR TITLE
chore(deps): Fixed esri-loader package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10501,6 +10501,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
@@ -14400,9 +14410,9 @@
       }
     },
     "esri-loader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/esri-loader/-/esri-loader-3.3.0.tgz",
-      "integrity": "sha512-ptg11ANOVFJ/VPSQWNBHRo62Gkq82Z7c6Wu0ZFDxplm4lAs97kQ+6GRkLQPnWXE6jpHK2XEIW3Pq1iMBPMsdgg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/esri-loader/-/esri-loader-3.1.0.tgz",
+      "integrity": "sha512-TwC9hDZxDWScXPt0nAz90aFJ10+X4Jh+cJTB2tbtWEzqibEEO50xLDkcQ0N+EHv9aRWRRxrSQssH+meqgM9sBg=="
     },
     "estraverse": {
       "version": "4.3.0",
@@ -15015,6 +15025,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filelist": {
       "version": "1.0.2",
@@ -29046,6 +29063,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -29769,6 +29787,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "date-and-time": "^0.14.2",
     "deepmerge": "^4.2.2",
     "document-register-element": "1.13.1",
-    "esri-loader": "^3.1.0",
+    "esri-loader": "~3.1.0",
     "express-rate-limit": "^5.1.3",
     "express-session": "^1.17.0",
     "form-data": "^4.0.0",


### PR DESCRIPTION
Was using syntax that installed latest minor version but esri-loader defaults to api releases on the minor version updates which resulted in a mismatch between the installed typings and the actual api loaded.

Latest esri-laoder loads ArcGIS JS API 4.21 instead of the known working 4.19 and 4.20 has several API deprecations that have not been tested and definitely break some things on aggiemap.