### PR TITLE
fix(gisday-angular-competitions): Fixed authentication flow

### DIFF
--- a/apps/gisday-competitions-angular/src/app/modules/routing/routing.module.ts
+++ b/apps/gisday-competitions-angular/src/app/modules/routing/routing.module.ts
@@ -81,7 +81,7 @@ WebFont.load({
     CommonNgxRouterModule,
     SettingsModule
   ],
-  providers: [{ provide: LocationStrategy, useClass: HashLocationStrategy }, AuthService],
+  providers: [AuthService],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/apps/gisday-competitions-angular/src/environments/environment.prod.ts
+++ b/apps/gisday-competitions-angular/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: true
 };
 
-import { LayerSource, LegendItem } from '@tamu-gisc/common/types';
+import { LayerSource } from '@tamu-gisc/common/types';
 import { SearchSource, SearchSourceQueryParamsProperties } from '@tamu-gisc/search';
 
 import { Connections, Definitions as d, Protocol, HostName } from './definitions';

--- a/apps/gisday-competitions-angular/src/environments/environment.ts
+++ b/apps/gisday-competitions-angular/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false
 };
 
-import { LayerSource, LegendItem } from '@tamu-gisc/common/types';
+import { LayerSource } from '@tamu-gisc/common/types';
 import { SearchSource, SearchSourceQueryParamsProperties } from '@tamu-gisc/search';
 
 import { Connections, Definitions as d, Protocol, HostName } from './definitions';
@@ -14,11 +14,11 @@ import { NotificationProperties } from '@tamu-gisc/common/ngx/ui/notification';
 
 export * from './definitions';
 
-export const LeaderboardUrl = `${Protocol}/${HostName}/gisday.tamu.edu/Rest/Leaderboard/Get`;
-export const SubmissionsUrl = `${Protocol}/${HostName}/gisday.tamu.edu/Rest/Signage/Get/Submissions/?&geoJSON=true`;
-export const SubmissionsPostUrl = `${Protocol}/${HostName}/gisday.tamu.edu/Rest/Signage/Push/Submissions/`;
+export const LeaderboardUrl = `${Protocol}/${HostName}/wap.gisday.tamu.edu/Rest/Leaderboard/Get`;
+export const SubmissionsUrl = `${Protocol}/${HostName}/wap.gisday.tamu.edu/Rest/Signage/Get/Submissions/?&geoJSON=true`;
+export const SubmissionsPostUrl = `${Protocol}/${HostName}/wap.gisday.tamu.edu/Rest/Signage/Push/Submissions/`;
 
-export const AuthLoginUrl = `${Protocol}/${HostName}/gisday.tamu.edu/Login?ret=${Protocol}/${HostName}/gisday.tamu.edu/Login`;
+export const AuthLoginUrl = `${Protocol}/${HostName}/wap.gisday.tamu.edu/Login?ret=${Protocol}/${HostName}/wap.gisday.tamu.edu/Login`;
 
 export const LocalStoreSettings = {
   subKey: 'gisday-app'


### PR DESCRIPTION
Fixed GIS Day user authentication redirects on localhost due to a change in the parent application hostname.