### PR TITLE
ci: Improved main pipeline job run parallelization

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,4 +26,3 @@ stages:
       - template: jobs/build.yml
         parameters:
           buildtype: production
-          DependsOn: build_development


### PR DESCRIPTION
Removed production dependsOn development build condition. This reduced the ability to parallelize jobs correctly causing super long build times. 