### PR TITLE
testing(CPA): Unit tests added for CPA lib data-access services. 

### DIFF
--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -47,8 +47,7 @@ describe('ParticipantService', () => {
       expect(participants[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne(`${service.resource}/workshop`);
-    expect(req.request.method).toEqual('POST');
+    const req = httpTestingController.expectOne({ method: 'POST', url: `${service.resource}/workshop` });
     req.flush(dummyResponse);
   });
 
@@ -69,8 +68,7 @@ describe('ParticipantService', () => {
       expect(participants.length).toBe(1);
     });
 
-    const req = httpTestingController.expectOne(`${service.resource}/workshop/${dummyStringValue}`);
-    expect(req.request.method).toEqual('GET');
+    const req = httpTestingController.expectOne({ method: 'GET', url: `${service.resource}/workshop/${dummyStringValue}` });
     req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -1,16 +1,75 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { ParticipantService } from './participants.service';
+
+const spyEnvironment = {
+  value: jest.fn()
+};
 
 describe('ParticipantService', () => {
   let service: ParticipantService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(ParticipantService);
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ParticipantService,
+        {
+          provide: EnvironmentService,
+          useValue: spyEnvironment
+        }
+      ]
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    httpTestingController.verify();
   });
+
+  it('createParticipantForWorkshop()', fakeAsync(() => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    service = TestBed.inject(ParticipantService);
+
+    service.createParticipantForWorkshop(dummyStringValue, dummyStringValue).subscribe((participants) => {
+      expect(participants[0].name).toBe('Foo');
+    });
+
+    const req = httpTestingController.expectOne(`${service.resource}/workshop`, 'reee');
+    expect(req.request.method).toEqual('POST');
+    req.flush(dummyResponse);
+  }));
+
+  it('getParticipantsForWorkshop()', fakeAsync(() => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    service = TestBed.inject(ParticipantService);
+
+    service.getParticipantsForWorkshop(dummyStringValue).subscribe((participants) => {
+      expect(participants[0].name).toBe('Foo');
+      expect(participants.length).toBe(1);
+    });
+
+    const req = httpTestingController.expectOne(`${service.resource}/workshop/${dummyStringValue}`);
+    expect(req.request.method).toEqual('GET');
+    req.flush(dummyResponse);
+  }));
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -31,7 +31,7 @@ describe('ParticipantService', () => {
     httpTestingController.verify();
   });
 
-  it('createParticipantForWorkshop()', () => {
+  it('should call createParticipantForWorkshop() and return a new participant', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {
@@ -52,7 +52,7 @@ describe('ParticipantService', () => {
     req.flush(dummyResponse);
   });
 
-  it('getParticipantsForWorkshop()', () => {
+  it('should call getParticipantsForWorkshop() and return a list of participants', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {

--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -30,7 +30,7 @@ describe('ParticipantService', () => {
     httpTestingController.verify();
   });
 
-  it('createParticipantForWorkshop()', fakeAsync(() => {
+  it('createParticipantForWorkshop()', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {
@@ -46,12 +46,12 @@ describe('ParticipantService', () => {
       expect(participants[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne(`${service.resource}/workshop`, 'reee');
+    const req = httpTestingController.expectOne(`${service.resource}/workshop`);
     expect(req.request.method).toEqual('POST');
     req.flush(dummyResponse);
-  }));
+  });
 
-  it('getParticipantsForWorkshop()', fakeAsync(() => {
+  it('getParticipantsForWorkshop()', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {
@@ -71,5 +71,5 @@ describe('ParticipantService', () => {
     const req = httpTestingController.expectOne(`${service.resource}/workshop/${dummyStringValue}`);
     expect(req.request.method).toEqual('GET');
     req.flush(dummyResponse);
-  }));
+  });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';

--- a/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/participant/participants.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { ParticipantService } from './participants.service';
 
-const spyEnvironment = {
+const mockEnvironment = {
   value: jest.fn()
 };
 
@@ -19,7 +20,7 @@ describe('ParticipantService', () => {
         ParticipantService,
         {
           provide: EnvironmentService,
-          useValue: spyEnvironment
+          useValue: mockEnvironment
         }
       ]
     });
@@ -39,7 +40,7 @@ describe('ParticipantService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ParticipantService);
 
     service.createParticipantForWorkshop(dummyStringValue, dummyStringValue).subscribe((participants) => {
@@ -60,7 +61,7 @@ describe('ParticipantService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ParticipantService);
 
     service.getParticipantsForWorkshop(dummyStringValue).subscribe((participants) => {

--- a/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
@@ -31,7 +31,7 @@ describe('ResponseService', () => {
     httpTestingController.verify();
   });
 
-  it('createResponse()', () => {
+  it('should call createResponse() and return a new response', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {

--- a/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { ResponseService } from './response.service';
 
-const spyEnvironment = {
+const mockEnvironment = {
   value: jest.fn()
 };
 
@@ -19,7 +20,7 @@ describe('ResponseService', () => {
         ResponseService,
         {
           provide: EnvironmentService,
-          useValue: spyEnvironment
+          useValue: mockEnvironment
         }
       ]
     });
@@ -39,7 +40,7 @@ describe('ResponseService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ResponseService);
 
     service.createResponse({ shapes: { Foo: 'Foo' } }).subscribe((response) => {

--- a/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
@@ -30,8 +30,24 @@ describe('ResponseService', () => {
     httpTestingController.verify();
   });
 
-  it('should be created', () => {
+  it('createResponse()', () => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ResponseService);
-    expect(service).toBeTruthy();
+
+    service.createResponse({ shapes: { Foo: 'Foo' } }).subscribe((response) => {
+      expect(response[0].name).toBe('Foo');
+    });
+
+    const req = httpTestingController.expectOne(`${service.resource}`);
+    expect(req.request.method).toEqual('POST');
+    req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
@@ -1,25 +1,37 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { EnvironmentModule, env } from '@tamu-gisc/common/ngx/environment';
-
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { ResponseService } from './response.service';
 
+const spyEnvironment = {
+  value: jest.fn()
+};
+
 describe('ResponseService', () => {
-  beforeEach(() =>
+  let service: ResponseService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [EnvironmentModule, HttpClientTestingModule],
+      imports: [HttpClientTestingModule],
       providers: [
+        ResponseService,
         {
-          provide: env,
-          useValue: { api_url: 'https://' }
+          provide: EnvironmentService,
+          useValue: spyEnvironment
         }
       ]
-    })
-  );
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
 
   it('should be created', () => {
-    const service: ResponseService = TestBed.get(ResponseService);
+    service = TestBed.inject(ResponseService);
     expect(service).toBeTruthy();
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/response/response.service.spec.ts
@@ -47,8 +47,7 @@ describe('ResponseService', () => {
       expect(response[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne(`${service.resource}`);
-    expect(req.request.method).toEqual('POST');
+    const req = httpTestingController.expectOne({ method: 'POST', url: `${service.resource}` });
     req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
@@ -1,25 +1,36 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { EnvironmentModule, env } from '@tamu-gisc/common/ngx/environment';
-
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { ScenarioService } from './scenario.service';
 
+const spyEnvironment = {
+  value: jest.fn()
+};
+
 describe('ScenarioService', () => {
-  beforeEach(() =>
+  let service: ScenarioService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, EnvironmentModule],
+      imports: [HttpClientTestingModule],
       providers: [
+        ScenarioService,
         {
-          provide: env,
-          useValue: { api_url: 'https://' }
+          provide: EnvironmentService,
+          useValue: spyEnvironment
         }
       ]
-    })
-  );
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
 
+  afterEach(() => {
+    httpTestingController.verify();
+  });
   it('should be created', () => {
-    const service: ScenarioService = TestBed.get(ScenarioService);
+    service = TestBed.inject(ScenarioService);
     expect(service).toBeTruthy();
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
@@ -46,8 +46,7 @@ describe('ScenarioService', () => {
       expect(response[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne(`${'Fooscenarios'}`);
-    expect(req.request.method).toEqual('POST');
+    const req = httpTestingController.expectOne({ method: 'POST', url: `${'Fooscenarios'}` });
     req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { ScenarioService } from './scenario.service';
 
-const spyEnvironment = {
+const mockEnvironment = {
   value: jest.fn()
 };
 
@@ -19,7 +20,7 @@ describe('ScenarioService', () => {
         ScenarioService,
         {
           provide: EnvironmentService,
-          useValue: spyEnvironment
+          useValue: mockEnvironment
         }
       ]
     });
@@ -38,7 +39,7 @@ describe('ScenarioService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ScenarioService);
 
     service.create({}).subscribe((response) => {

--- a/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
@@ -29,8 +29,24 @@ describe('ScenarioService', () => {
   afterEach(() => {
     httpTestingController.verify();
   });
-  it('should be created', () => {
+  it('create()', () => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(ScenarioService);
-    expect(service).toBeTruthy();
+
+    service.create({}).subscribe((response) => {
+      expect(response[0].name).toBe('Foo');
+    });
+
+    const req = httpTestingController.expectOne(`${'Fooscenarios'}`);
+    expect(req.request.method).toEqual('POST');
+    req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/scenario/scenario.service.spec.ts
@@ -30,7 +30,7 @@ describe('ScenarioService', () => {
   afterEach(() => {
     httpTestingController.verify();
   });
-  it('create()', () => {
+  it('should call create() and return a new scenario', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {

--- a/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
@@ -47,8 +47,7 @@ describe('SnapshotService', () => {
       expect(response[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne('Foosnapshots');
-    expect(req.request.method).toEqual('POST');
+    const req = httpTestingController.expectOne({ method: 'POST', url: 'Foosnapshots' });
     req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { SnapshotService } from './snapshot.service';
 
-const spyEnvironment = {
+const mockEnvironment = {
   value: jest.fn()
 };
 
@@ -19,7 +20,7 @@ describe('SnapshotService', () => {
         SnapshotService,
         {
           provide: EnvironmentService,
-          useValue: spyEnvironment
+          useValue: mockEnvironment
         }
       ]
     });
@@ -39,7 +40,7 @@ describe('SnapshotService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(SnapshotService);
 
     service.create({}).subscribe((response) => {

--- a/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
@@ -30,8 +30,24 @@ describe('SnapshotService', () => {
     httpTestingController.verify();
     jest.resetAllMocks();
   });
-  it('should be created', () => {
+  it('create()', () => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(SnapshotService);
-    expect(service).toBeTruthy();
+
+    service.create({}).subscribe((response) => {
+      expect(response[0].name).toBe('Foo');
+    });
+
+    const req = httpTestingController.expectOne('Foosnapshots');
+    expect(req.request.method).toEqual('POST');
+    req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
@@ -1,25 +1,37 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { EnvironmentModule, env } from '@tamu-gisc/common/ngx/environment';
-
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { SnapshotService } from './snapshot.service';
 
+const spyEnvironment = {
+  value: jest.fn()
+};
+
 describe('SnapshotService', () => {
-  beforeEach(() =>
+  let service: SnapshotService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, EnvironmentModule],
+      imports: [HttpClientTestingModule],
       providers: [
+        SnapshotService,
         {
-          provide: env,
-          useValue: { api_url: 'https://' }
+          provide: EnvironmentService,
+          useValue: spyEnvironment
         }
       ]
-    })
-  );
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
 
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.resetAllMocks();
+  });
   it('should be created', () => {
-    const service: SnapshotService = TestBed.get(SnapshotService);
+    service = TestBed.inject(SnapshotService);
     expect(service).toBeTruthy();
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/snapshot/snapshot.service.spec.ts
@@ -31,7 +31,7 @@ describe('SnapshotService', () => {
     httpTestingController.verify();
     jest.resetAllMocks();
   });
-  it('create()', () => {
+  it('should call create() and return a new snapshot', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {

--- a/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
@@ -31,7 +31,7 @@ describe('WorkshopService', () => {
     httpTestingController.verify();
   });
 
-  it('createWorkshop()', () => {
+  it('should call createWorkshop() and return a new workshop', () => {
     const dummyStringValue = 'Foo';
     const dummyResponse = [
       {

--- a/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
@@ -2,9 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { WorkshopService } from './workshop.service';
 
-const spyEnvironment = {
+const mockEnvironment = {
   value: jest.fn()
 };
 
@@ -19,7 +20,7 @@ describe('WorkshopService', () => {
         WorkshopService,
         {
           provide: EnvironmentService,
-          useValue: spyEnvironment
+          useValue: mockEnvironment
         }
       ]
     });
@@ -39,7 +40,7 @@ describe('WorkshopService', () => {
       }
     ];
 
-    spyEnvironment.value.mockReturnValue(dummyStringValue);
+    mockEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(WorkshopService);
 
     service.createWorkshop({ guid: 'bruh' }).subscribe((response) => {

--- a/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
@@ -1,25 +1,37 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { EnvironmentModule, env } from '@tamu-gisc/common/ngx/environment';
-
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { WorkshopService } from './workshop.service';
 
+const spyEnvironment = {
+  value: jest.fn()
+};
+
 describe('WorkshopService', () => {
-  beforeEach(() =>
+  let service: WorkshopService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, EnvironmentModule],
+      imports: [HttpClientTestingModule],
       providers: [
+        WorkshopService,
         {
-          provide: env,
-          useValue: { api_url: 'https://' }
+          provide: EnvironmentService,
+          useValue: spyEnvironment
         }
       ]
-    })
-  );
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
 
   it('should be created', () => {
-    const service: WorkshopService = TestBed.get(WorkshopService);
+    service = TestBed.inject(WorkshopService);
     expect(service).toBeTruthy();
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
@@ -47,8 +47,7 @@ describe('WorkshopService', () => {
       expect(response[0].name).toBe('Foo');
     });
 
-    const req = httpTestingController.expectOne('Fooworkshops');
-    expect(req.request.method).toEqual('POST');
+    const req = httpTestingController.expectOne({ method: 'POST', url: 'Fooworkshops' });
     req.flush(dummyResponse);
   });
 });

--- a/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
+++ b/libs/cpa/ngx/data-access/src/lib/services/workshop/workshop.service.spec.ts
@@ -30,8 +30,24 @@ describe('WorkshopService', () => {
     httpTestingController.verify();
   });
 
-  it('should be created', () => {
+  it('createWorkshop()', () => {
+    const dummyStringValue = 'Foo';
+    const dummyResponse = [
+      {
+        name: 'Foo',
+        workshops: []
+      }
+    ];
+
+    spyEnvironment.value.mockReturnValue(dummyStringValue);
     service = TestBed.inject(WorkshopService);
-    expect(service).toBeTruthy();
+
+    service.createWorkshop({ guid: 'bruh' }).subscribe((response) => {
+      expect(response[0].name).toBe('Foo');
+    });
+
+    const req = httpTestingController.expectOne('Fooworkshops');
+    expect(req.request.method).toEqual('POST');
+    req.flush(dummyResponse);
   });
 });


### PR DESCRIPTION
The following PR was for getting back into the groove of testing. Establishing how to test services with dependencies on other services and Http Client. 

### **Process for testing a service dependent on another service:** 
1. Create a skeleton mock. 
`const spyForDependentService= { someFunction: jest.fn() }`
 2. In the beforeEach establish the providers array:
```
beforeEach(() => {
  TestBed.configureTestingModule({
    providers: [
      ServiceToBeTested,
        {
          provide: DependentService,
          useValue: spyForDependentService
        }
      ]
    });
});
```
3. If the logic of the service has different actions based on a value condition of the dependent service, don't inject the service being tested in the beforeEach configureTestingModule statement. Instead inject it in the individual test cases after mocking the return value for said dependent services function call. 

### **Process for testing a HttpClient request (based on https://angular-training-guide.rangle.io/testing/services/http/using-httptestingmodule):** 
1. Import HttpClientTestingModule and HttpTestingController
` import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';`
2. Declare HttpTestingController in the outer describe statement, import HttpClientTestingModule in the configureTestingModule statement, and inject the HttpTestingController into the testbed. 
```
beforeEach(() => {
  TestBed.configureTestingModule({
    imports: [HttpClientTestingModule],
    providers: [
      ServiceToBeTested,
    ]
  });
  httpTestingController = TestBed.inject(HttpTestingController);
});
```
3. Make a dummy response and value, call the function in the service to be tested that makes a HttpClient call, subscribe to it, listen for specific response. 
```
const dummyValue = whatever value needed for function call;
const dummyResponse = [
  {
    whateverneeded: 'Foo',
  }
];

service.functionbeingtested(dummyValue).subscribe((interface/object) => {
  expect(interface/object.whateverneeded).toBe('Foo');
});
```
4. Call the httpTestingController with the expected API url the response will be made on, test the http method, and flush the response. 
```
const req = httpTestingController.expectOne(APIURL);
expect(req.request.method).toEqual('GET/POST/Whatever');
req.flush(dummyResponse);
```

