### PR TITLE
chore(deps): Bumped and pinned nodemailer for deployment apps

### DIFF
--- a/apps/oidc-admin-nest/src/package.json
+++ b/apps/oidc-admin-nest/src/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^8.5.0",
     "mssql": "^6.0.1",
     "jwt-decode": "^3.1.2",
-    "nodemailer": "^6.4.16",
+    "nodemailer": "6.7.2",
     "oidc-provider": "^6.21.0",
     "openid-client": "^3.15.3",
     "otplib": "^10.2.3",

--- a/apps/oidc-provider-nest/src/package.json
+++ b/apps/oidc-provider-nest/src/package.json
@@ -21,7 +21,7 @@
     "helmet": "3.23.3",
     "jsonwebtoken": "8.5.0",
     "mssql": "6.2.0",
-    "nodemailer": "6.4.16",
+    "nodemailer": "6.7.2",
     "oidc-provider": "6.28.0",
     "openid-client": "3.15.9",
     "otplib": "10.2.3",


### PR DESCRIPTION
Affects:

- oidc-admin-nest
- oidc-provider-nest

Updated nodemailer version to latest non-vulnerable on the deployment package.json's and also pinned the version


Addresses CVE-2021-23400

https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/security/dependabot/9