### PR TITLE
feat(ci): Centralize Nx excluded projects

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ variables:
       value: origin/development~ # Affected base if build branch name is development
     ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
       value: origin/maser~ # Affected base if build branch name is master
+  - name: excludedProjects
+      value: 'signage-angular,trees-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,mailroom-nest'
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -23,15 +25,17 @@ stages:
     dependsOn: Dependencies
     jobs:
       - template: templates/jobs/buildTags.yml
-
+        parameters: 
+          excludedProjects: ${{variables.excludedProjects}}
       - template: templates/jobs/build.yml
         parameters:
           buildType: development
-
+          excludedProjects: ${{variables.excludedProjects}}
       - template: templates/jobs/build.yml
         parameters:
           buildType: staging
-
+          excludedProjects: ${{variables.excludedProjects}}
       - template: templates/jobs/build.yml
         parameters:
           buildType: production
+          excludedProjects: ${{variables.excludedProjects}}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,6 @@
 variables:
+  - name: excludedProjects
+    value: 'signage-angular,trees-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,mailroom-nest'
   - name: isDevelopment
     value: $[eq(variables['Build.SourceBranchName'], 'development')]
   - name: isMaster
@@ -10,8 +12,6 @@ variables:
       value: origin/development~ # Affected base if build branch name is development
     ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
       value: origin/maser~ # Affected base if build branch name is master
-  - name: excludedProjects
-      value: 'signage-angular,trees-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,mailroom-nest'
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -25,17 +25,17 @@ stages:
     dependsOn: Dependencies
     jobs:
       - template: templates/jobs/buildTags.yml
-        parameters: 
-          excludedProjects: ${{variables.excludedProjects}}
+        parameters:
+          excludedProjects: $(excludedProjects)
       - template: templates/jobs/build.yml
         parameters:
           buildType: development
-          excludedProjects: ${{variables.excludedProjects}}
+          excludedProjects: $(excludedProjects)
       - template: templates/jobs/build.yml
         parameters:
           buildType: staging
-          excludedProjects: ${{variables.excludedProjects}}
+          excludedProjects: $(excludedProjects)
       - template: templates/jobs/build.yml
         parameters:
           buildType: production
-          excludedProjects: ${{variables.excludedProjects}}
+          excludedProjects: $(excludedProjects)

--- a/templates/jobs/build.yml
+++ b/templates/jobs/build.yml
@@ -1,6 +1,7 @@
 parameters:
   buildType: ''
   DependsOn: []
+  excludedProjects: ''
 
 jobs:
   - job: ${{ parameters.buildType }}
@@ -105,7 +106,7 @@ jobs:
         displayName: 'Copying environment files to gisday-competitions-nest'
 
       - bash: |
-          npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=${{ parameters.buildType }} --exclude="signage-angular,trees-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,mailroom-nest"
+          npm run nx affected:build -- --base=$(affectedBase) --head=HEAD --configuration=${{ parameters.buildType }} --exclude=${{ parameters.excludedProjects }}
         displayName: 'Running build'
 
       - task: CopyFiles@2

--- a/templates/jobs/buildTags.yml
+++ b/templates/jobs/buildTags.yml
@@ -1,8 +1,10 @@
+parameters:
+  excludedProjects: ''
+
 jobs:
   - job: Tag
     steps:
       - template: ../tasks/cacheOrRestoreDependencies.yml
-
       - bash: |
-          npm run nx affected:apps -- --base=$(affectedBase) --head=HEAD --exclude="signage-angular,trees-angular,two-dashboard-angular,two-data-api-nest,two-angular,geoservices-angular,covid-data-api-nest,two-valup-nest,two-directory-nest,gisday-angular,gisday-nest,mailroom-nest" | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
+          npm run nx affected:apps -- --base=$(affectedBase) --head=HEAD --exclude=${{ parameters.excludedProjects }} | grep -E '( - )(\w|-|\d|_)+' | sed -E 's/ - /##vso[build.addbuildtag]/g'
         displayName: 'Add Build Tags for Affected Projects'


### PR DESCRIPTION
Excluded projects list is now passed down from entry yaml instead of residing in many files. This prevents desync between the various files as projects are added/removed from the exclusion list.