### PR TITLE
feat:(oidc-ngx): Angular OIDC Flow Common Routes

### DIFF
--- a/libs/oidc/ngx/.eslintrc.json
+++ b/libs/oidc/ngx/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "tamuGisc",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "tamu-gisc",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/oidc/ngx/README.md
+++ b/libs/oidc/ngx/README.md
@@ -1,7 +1,51 @@
-# oidc-ngx
+# OIDC Ngx Common Routes
 
-This library was generated with [Nx](https://nx.dev).
+This library contains a couple of logic-less routes and components that can be imported into an Angular application that utilizes the `angular-auth-oidc-client` for certain authentication flows. It is meant to be used in conjunction with the built-in `angular-auth-oidc-client` router guards for auto-login and redirection.
 
-## Running unit tests
+## Motivation
 
-Run `nx test oidc-ngx` to execute the unit tests.
+SPA's implementing the implicit flow require a static callback/redirect uri that the IdP will return the client to once authentication has completed. The return point can be a simple lightweight component or on the other side of the spectrum, a component that renders many additional components before redirecting to the application url that initiated the authentication flow. By having common routes:
+
+- All applications can use the same callback/return/redirect URL (e.g. `/auth/callback`).
+- The component loaded by (`/auth/callback`) is purposefully lightweight to guarantee no wasted time loading unnecessary components and logic and reduce the time to application destination redirection.
+
+## Library Scope
+
+`@tamu-gisc/oidc/ngx`
+
+## Modules
+
+- AuthRoutingModule
+
+## Using
+
+In any angular application root (preferably in the same module that imports the `oidc-auth-oidc-client` `AuthModule`), import the `AuthRoutingModule`.
+
+```js
+import { AuthModule } from 'angular-auth-oidc-client';
+
+import { AuthRoutingModule } from '@tamu-gisc/oidc/ngx';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    AuthModule.forRoot({
+      config: {
+        redirectUrl: window.location.origin + '/auth/callback',
+        ...
+      }
+    }),
+    RouterModule.forRoot([...]),
+    AuthRoutingModule,
+  ],
+  declarations: [AppComponent],
+  bootstrap: [AppComponent]
+})
+
+```
+
+The `AuthRoutingModule` will add the following routes to the application and should therefore be reserved and not overwritten by other feature modules:
+
+- auth/
+  - callback

--- a/libs/oidc/ngx/README.md
+++ b/libs/oidc/ngx/README.md
@@ -1,0 +1,7 @@
+# oidc-ngx
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test oidc-ngx` to execute the unit tests.

--- a/libs/oidc/ngx/jest.config.js
+++ b/libs/oidc/ngx/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  displayName: 'oidc-ngx',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$'
+    }
+  },
+  coverageDirectory: '../../../coverage/libs/oidc/ngx',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular'
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment'
+  ]
+};

--- a/libs/oidc/ngx/project.json
+++ b/libs/oidc/ngx/project.json
@@ -1,0 +1,23 @@
+{
+  "projectType": "library",
+  "root": "libs/oidc/ngx",
+  "sourceRoot": "libs/oidc/ngx/src",
+  "prefix": "tamu-gisc",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/oidc/ngx"],
+      "options": {
+        "jestConfig": "libs/oidc/ngx/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["libs/oidc/ngx/src/**/*.ts", "libs/oidc/ngx/src/**/*.html"]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/oidc/ngx/src/index.ts
+++ b/libs/oidc/ngx/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/guards/logged-in/logged-in.guard';

--- a/libs/oidc/ngx/src/index.ts
+++ b/libs/oidc/ngx/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/guards/logged-in/logged-in.guard';
+export * from './lib/modules/auth-redirect/auth-routing.module';

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.html
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.spec.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.spec.ts
@@ -22,4 +22,3 @@ describe('AuthRoutingComponent', () => {
     expect(component).toBeTruthy();
   });
 });
-

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.spec.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AuthRoutingComponent } from './auth-routing.component';
+
+describe('AuthRoutingComponent', () => {
+  let component: AuthRoutingComponent;
+  let fixture: ComponentFixture<AuthRoutingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AuthRoutingComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AuthRoutingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.ts
@@ -6,4 +6,3 @@ import { Component } from '@angular/core';
   styleUrls: ['./auth-routing.component.scss']
 })
 export class AuthRoutingComponent {}
-

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-auth-routing',
+  templateUrl: './auth-routing.component.html',
+  styleUrls: ['./auth-routing.component.scss']
+})
+export class AuthRoutingComponent {}
+

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.module.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.module.ts
@@ -23,4 +23,3 @@ const routes: Routes = [
   declarations: [LoginPostComponent, AuthRoutingComponent]
 })
 export class AuthRoutingModule {}
-

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.module.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/auth-routing.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+
+import { LoginPostComponent } from './components/login-post/login-post.component';
+import { AuthRoutingComponent } from './auth-routing.component';
+
+const routes: Routes = [
+  {
+    path: 'auth',
+    component: AuthRoutingComponent,
+    children: [
+      {
+        path: 'callback',
+        component: LoginPostComponent
+      }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [CommonModule, RouterModule.forChild(routes)],
+  declarations: [LoginPostComponent, AuthRoutingComponent]
+})
+export class AuthRoutingModule {}
+

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.html
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.html
@@ -1,0 +1,2 @@
+<p>Verifying session...</p>
+

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.html
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.html
@@ -1,2 +1,1 @@
 <p>Verifying session...</p>
-

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.spec.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.spec.ts
@@ -8,9 +8,8 @@ describe('LoginPostComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ LoginPostComponent ]
-    })
-    .compileComponents();
+      declarations: [LoginPostComponent]
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.spec.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginPostComponent } from './login-post.component';
+
+describe('LoginPostComponent', () => {
+  let component: LoginPostComponent;
+  let fixture: ComponentFixture<LoginPostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoginPostComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginPostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-login-post',
+  templateUrl: './login-post.component.html',
+  styleUrls: ['./login-post.component.scss']
+})
+export class LoginPostComponent {}
+

--- a/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.ts
+++ b/libs/oidc/ngx/src/lib/modules/auth-redirect/components/login-post/login-post.component.ts
@@ -6,4 +6,3 @@ import { Component } from '@angular/core';
   styleUrls: ['./login-post.component.scss']
 })
 export class LoginPostComponent {}
-

--- a/libs/oidc/ngx/src/test-setup.ts
+++ b/libs/oidc/ngx/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/oidc/ngx/tsconfig.json
+++ b/libs/oidc/ngx/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/oidc/ngx/tsconfig.lib.json
+++ b/libs/oidc/ngx/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/oidc/ngx/tsconfig.spec.json
+++ b/libs/oidc/ngx/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -91,6 +91,7 @@
       "@tamu-gisc/oidc/admin/ngx": ["libs/oidc/admin/ngx/src/index.ts"],
       "@tamu-gisc/oidc/client": ["libs/oidc/client/src/index.ts"],
       "@tamu-gisc/oidc/common": ["libs/oidc/common/src/index.ts"],
+      "@tamu-gisc/oidc/ngx": ["libs/oidc/ngx/src/index.ts"],
       "@tamu-gisc/oidc/provider": ["libs/oidc/provider/src/index.ts"],
       "@tamu-gisc/signage": ["libs/signage/src/index.ts"],
       "@tamu-gisc/two/common": ["libs/two/common/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -97,6 +97,7 @@
     "oidc-admin-ngx": "libs/oidc/admin/ngx",
     "oidc-client": "libs/oidc/client",
     "oidc-common": "libs/oidc/common",
+    "oidc-ngx": "libs/oidc/ngx",
     "oidc-provider": "libs/oidc/provider",
     "oidc-provider-nest": "apps/oidc-provider-nest",
     "sass": "libs/sass",


### PR DESCRIPTION
Adds common  PnP routes for angular applications utilizing the `angular-auth-oidc-client`.

Details in lib README