### PR TITLE
feat: Environment access library for NestJS apps/libs

### DIFF
--- a/libs/common/nest/environment/.babelrc
+++ b/libs/common/nest/environment/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/common/nest/environment/.eslintrc.json
+++ b/libs/common/nest/environment/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/common/nest/environment/README.md
+++ b/libs/common/nest/environment/README.md
@@ -1,0 +1,57 @@
+# TAMU GISC NestJS Environment
+
+This library contains a module and a service that can be used in NestJS applications to manage and centralize environment variable access downstream from applications to libraries.
+
+## Library Scope
+
+`@tamu-gisc/common/nest/environment`
+
+### Modules
+
+- EnvironmentModule
+
+### Services
+
+- EnvironmentService
+
+### Tokens
+
+- ENVIRONMENT
+
+## Setup
+
+In a root module of a NestJS application, import the `EnvironmentModule` and pass in the desired environment config using the `forRoot` static method to globally register the `EnvironmentService`.
+
+```js
+import { Module } from '@nestjs/common';
+
+import { EnvironmentModule } from '@tamu-gisc/common/nest/environment';
+
+import * as env from '../environments/environment';
+
+@Module({
+  imports: [EnvironmentModule.forRoot(env)]
+})
+export class AppModule {}
+```
+
+## Utilization
+
+Once the `EnvironmentModule` has been registered, the `EnvironmentService` can be injected into any class that is registered on the global DI container.
+
+The `EnvironmentService` exposes one public method `value()` which accepts the token of a config property. If it is found in the configured environment object, it will return its value and `undefined` otherwise.
+
+```js
+import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
+
+@Injectable()
+export class SomeService {
+  constructor(private readonly env: EnvironmentService) {
+    super(repo);
+  }
+}
+
+public doWork(){
+  const valueFromEnv = this.env.value('somePropertyInRegisteredEnv');
+}
+```

--- a/libs/common/nest/environment/README.md
+++ b/libs/common/nest/environment/README.md
@@ -47,7 +47,7 @@ import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
 @Injectable()
 export class SomeService {
   constructor(private readonly env: EnvironmentService) {
-    super(repo);
+    doWork();
   }
 }
 

--- a/libs/common/nest/environment/jest.config.js
+++ b/libs/common/nest/environment/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'common-nest-environment',
+  preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/common/nest/environment'
+};

--- a/libs/common/nest/environment/project.json
+++ b/libs/common/nest/environment/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/common/nest/environment",
+  "sourceRoot": "libs/common/nest/environment/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/common/nest/environment/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/common/nest/environment"],
+      "options": {
+        "jestConfig": "libs/common/nest/environment/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/common/nest/environment/src/index.ts
+++ b/libs/common/nest/environment/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/services/environment/environment.service';
+
+export * from './lib/environment.module';
+
+export * from './lib/tokens/environment.token';

--- a/libs/common/nest/environment/src/lib/environment.module.ts
+++ b/libs/common/nest/environment/src/lib/environment.module.ts
@@ -1,7 +1,6 @@
 import { DynamicModule, Module } from '@nestjs/common';
 
-import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
-
+import { EnvironmentService } from './services/environment/environment.service';
 import { ENVIRONMENT } from './tokens/environment.token';
 
 @Module({})

--- a/libs/common/nest/environment/src/lib/environment.module.ts
+++ b/libs/common/nest/environment/src/lib/environment.module.ts
@@ -1,0 +1,23 @@
+import { DynamicModule, Module } from '@nestjs/common';
+
+import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
+
+import { ENVIRONMENT } from './tokens/environment.token';
+
+@Module({})
+export class EnvironmentModule {
+  public static forRoot(env): DynamicModule {
+    return {
+      global: true,
+      module: EnvironmentModule,
+      providers: [
+        EnvironmentService,
+        {
+          provide: ENVIRONMENT,
+          useValue: env
+        }
+      ],
+      exports: [EnvironmentService]
+    };
+  }
+}

--- a/libs/common/nest/environment/src/lib/services/environment/environment.service.spec.ts
+++ b/libs/common/nest/environment/src/lib/services/environment/environment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EnvironmentService } from './environment.service';
+
+describe('EnvironmentService', () => {
+  let service: EnvironmentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EnvironmentService]
+    }).compile();
+
+    service = module.get<EnvironmentService>(EnvironmentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/common/nest/environment/src/lib/services/environment/environment.service.ts
+++ b/libs/common/nest/environment/src/lib/services/environment/environment.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EnvironmentService {
+  constructor(@Inject('ENV') private readonly env) {}
+
+  /**
+   * Returns value of a token in a provided environment value.
+   *
+   * Returns `undefined` if value does not exist.
+   */
+  public value(property: string) {
+    if (this.env[property] !== undefined) {
+      const value = this.env[property];
+      return value;
+    } else {
+      console.warn(`${property} token not found in app environment.`);
+
+      return undefined;
+    }
+  }
+}

--- a/libs/common/nest/environment/src/lib/services/environment/environment.service.ts
+++ b/libs/common/nest/environment/src/lib/services/environment/environment.service.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
 
+import { ENVIRONMENT } from '../../tokens/environment.token';
+
 @Injectable()
 export class EnvironmentService {
-  constructor(@Inject('ENV') private readonly env) {}
+  constructor(@Inject(ENVIRONMENT) private readonly env) {}
 
   /**
    * Returns value of a token in a provided environment value.

--- a/libs/common/nest/environment/src/lib/tokens/environment.token.ts
+++ b/libs/common/nest/environment/src/lib/tokens/environment.token.ts
@@ -1,0 +1,1 @@
+export const ENVIRONMENT = 'ENVIRONMENT';

--- a/libs/common/nest/environment/tsconfig.json
+++ b/libs/common/nest/environment/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/common/nest/environment/tsconfig.lib.json
+++ b/libs/common/nest/environment/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/common/nest/environment/tsconfig.spec.json
+++ b/libs/common/nest/environment/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
       "@tamu-gisc/aggiemap/ngx/ui/desktop": ["libs/aggiemap/ngx/ui/desktop/src/index.ts"],
       "@tamu-gisc/aggiemap/ngx/ui/mobile": ["libs/aggiemap/ngx/ui/mobile/src/index.ts"],
       "@tamu-gisc/aggiemap/ngx/ui/shared": ["libs/aggiemap/ngx/ui/shared/src/index.ts"],
+      "@tamu-gisc/common/nest/environment": ["libs/common/nest/environment/src/index.ts"],
       "@tamu-gisc/common/nest/guards": ["libs/common/nest/guards/src/index.ts"],
       "@tamu-gisc/common/ngx/auth": ["libs/common/ngx/auth/src/index.ts"],
       "@tamu-gisc/common/ngx/environment": ["libs/common/ngx/environment/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -9,6 +9,7 @@
     "aggiemap-ngx-ui-mobile": "libs/aggiemap/ngx/ui/mobile",
     "aggiemap-ngx-ui-shared": "libs/aggiemap/ngx/ui/shared",
     "assets": "libs/assets",
+    "common-nest-environment": "libs/common/nest/environment",
     "common-nest-guards": "libs/common/nest/guards",
     "common-ngx-auth": "libs/common/ngx/auth",
     "common-ngx-environment": "libs/common/ngx/environment",


### PR DESCRIPTION
This is the NestJS counterpart of the existing Angular environment service that allows registering environment variables in a single place and having them accessible through a service for apps/libs.