### PR TITLE
feat(oidc-common): JWT auth module

### DIFF
--- a/libs/oidc/common/README.md
+++ b/libs/oidc/common/README.md
@@ -1,7 +1,53 @@
-# oidc-common
+# TAMU GISC OIDC Common
 
-This library was generated with [Nx](https://nx.dev).
+This library contains a series of utilities used in the OIDC provider NestJS application and some more generic authentication utilities for use in back-end data NestJS-based data API's .
 
-## Running unit tests
+## Library Scope
 
-Run `ng test oidc-common` to execute the unit tests via [Jest](https://jestjs.io).
+`@tamu-gisc/oidc/common`
+
+### Modules
+
+- AuthModule
+
+### Guards
+
+- JwtGuard
+
+## Setup
+
+In a root module of a NestJS application, import the `AuthModule` and provide the OIDC JWKS endpoint using the `forRoot` static method.
+
+```js
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '@tamu-gisc/common/oidc';
+
+import * as env from '../environments/environment';
+
+@Module({
+  imports: [AuthModule.forRoot({ jwksUrl: env.jwksUrl })]
+})
+export class AppModule {}
+```
+
+This configuration takes care of initializing passport and registering a global JWT passport strategy that is implemented by the `JwtGuard`.
+
+## Utilization
+
+Apply the `JwtGuard` to any endpoints that should require a validated against the registered `AuthModule` public keys endpoint.
+
+```js
+import { Controller, Get, UseGuards } from '@nestjs/common';
+
+import { JwtGuard } from '@tamu-gisc/oidc/common';
+
+@Controller('puppies')
+export class PuppiesController {
+  @UseGuards(JwtGuard)
+  @Get('')
+  public getAllPuppies() {
+    return [...] // Returns list of adorable puppies
+  }
+}
+```

--- a/libs/oidc/common/README.md
+++ b/libs/oidc/common/README.md
@@ -21,7 +21,7 @@ In a root module of a NestJS application, import the `AuthModule` and provide th
 ```js
 import { Module } from '@nestjs/common';
 
-import { AuthModule } from '@tamu-gisc/common/oidc';
+import { AuthModule } from '@tamu-gisc/oidc/common';
 
 import * as env from '../environments/environment';
 
@@ -35,7 +35,7 @@ This configuration takes care of initializing passport and registering a global 
 
 ## Utilization
 
-Apply the `JwtGuard` to any endpoints that should require a validated against the registered `AuthModule` public keys endpoint.
+Apply the `JwtGuard` to any endpoints that should be validated against the registered `AuthModule` public keys endpoint.
 
 ```js
 import { Controller, Get, UseGuards } from '@nestjs/common';

--- a/libs/oidc/common/src/index.ts
+++ b/libs/oidc/common/src/index.ts
@@ -1,1 +1,5 @@
 export * from './lib/oidc-common';
+
+export * from './lib/modules/auth/auth.module';
+export * from './lib/strategies/jwt/jwt.strategy';
+export * from './lib/guards/jwt/jwt.guard';

--- a/libs/oidc/common/src/lib/guards/jwt/jwt.guard.spec.ts
+++ b/libs/oidc/common/src/lib/guards/jwt/jwt.guard.spec.ts
@@ -1,0 +1,7 @@
+import { JwtGuard } from './jwt.guard';
+
+describe('JwtGuard', () => {
+  it('should be defined', () => {
+    expect(new JwtGuard()).toBeDefined();
+  });
+});

--- a/libs/oidc/common/src/lib/guards/jwt/jwt.guard.ts
+++ b/libs/oidc/common/src/lib/guards/jwt/jwt.guard.ts
@@ -1,0 +1,19 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtGuard extends AuthGuard('jwt') {
+  public canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+
+  public handleRequest(err, user, info) {
+    if (err || !user) {
+      console.warn(info);
+
+      throw err || new UnauthorizedException();
+    }
+
+    return user;
+  }
+}

--- a/libs/oidc/common/src/lib/modules/auth/auth.module.ts
+++ b/libs/oidc/common/src/lib/modules/auth/auth.module.ts
@@ -1,0 +1,21 @@
+import { DynamicModule, Module } from '@nestjs/common';
+
+import { JwtStrategy } from '../../strategies/jwt/jwt.strategy';
+import { JWKS_URL } from '../tokens/jwks_url.token';
+
+@Module({})
+export class AuthModule {
+  public static forRoot(options: { jwksUrl: string }): DynamicModule {
+    return {
+      module: AuthModule,
+      providers: [
+        JwtStrategy,
+        {
+          provide: JWKS_URL,
+          useValue: options.jwksUrl
+        }
+      ],
+      global: true
+    };
+  }
+}

--- a/libs/oidc/common/src/lib/modules/tokens/jwks_url.token.ts
+++ b/libs/oidc/common/src/lib/modules/tokens/jwks_url.token.ts
@@ -1,0 +1,1 @@
+export const JWKS_URL = 'JWKS_URL';

--- a/libs/oidc/common/src/lib/strategies/jwt/jwt.strategy.spec.ts
+++ b/libs/oidc/common/src/lib/strategies/jwt/jwt.strategy.spec.ts
@@ -1,0 +1,7 @@
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtGuard', () => {
+  it('should be defined', () => {
+    expect(new JwtStrategy()).toBeDefined();
+  });
+});

--- a/libs/oidc/common/src/lib/strategies/jwt/jwt.strategy.ts
+++ b/libs/oidc/common/src/lib/strategies/jwt/jwt.strategy.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+
+import { passportJwtSecret } from 'jwks-rsa';
+import { Strategy, ExtractJwt } from 'passport-jwt';
+
+import { JWKS_URL } from '../../modules/tokens/jwks_url.token';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(@Inject(JWKS_URL) private readonly url: string) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKeyProvider: passportJwtSecret({
+        cache: true,
+        rateLimit: true,
+        jwksRequestsPerMinute: 5,
+        jwksUri: url
+      })
+    });
+  }
+
+  public validate(payload) {
+    return payload;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "papaparse": "^5.3.0",
         "passport": "^0.4.1",
         "passport-http-bearer": "^1.0.1",
+        "passport-jwt": "^4.0.0",
         "qrcode": "^1.4.4",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0",
@@ -23274,6 +23275,15 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "dependencies": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
       }
     },
     "node_modules/passport-strategy": {
@@ -47450,6 +47460,15 @@
       "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
       "requires": {
         "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
       }
     },
     "passport-strategy": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "papaparse": "^5.3.0",
     "passport": "^0.4.1",
     "passport-http-bearer": "^1.0.1",
+    "passport-jwt": "^4.0.0",
     "qrcode": "^1.4.4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.0.0",


### PR DESCRIPTION
Implements a generic authentication module that can be applied to existing nestjs applications. Exposes a JWT auth guard that validates a request's bearer JWT against a public key endpoint. 

Documentation on the root of the library.

libs\oidc\common\README.md