### PR TITLE
fix(oidc-provider): Enabled TLS offloading proxy trust

### DIFF
--- a/libs/oidc/provider/src/lib/services/provider/provider.service.ts
+++ b/libs/oidc/provider/src/lib/services/provider/provider.service.ts
@@ -25,6 +25,8 @@ export class OidcProviderService {
         if (this.enableDevLogs) {
           this.enableOIDCDebug();
         }
+
+        this.provider.proxy = true;
       });
     });
   }


### PR DESCRIPTION
Per documentation:

https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#trusting-tls-offloading-proxies

This fixes the OIDC well-known protocol from "http" => in "https" in urls which ultimately fixes authentication errors due to mixed content when the initiator originates from an https site and the client follows the http URL instead.