### PR TITLE
feat(oidc-provider): Consent prompt styling

### DIFF
--- a/apps/oidc-provider-nest/src/assets/views/interaction.ejs
+++ b/apps/oidc-provider-nest/src/assets/views/interaction.ejs
@@ -7,7 +7,7 @@
 
   <% missingOIDCScope = new Set(details.missingOIDCScope); missingOIDCScope.delete('openid'); missingOIDCScope.delete('offline_access') %>
 <% if (missingOIDCScope.size) { %>
-  <li>scopes:</li>
+  <p><%= client.clientName %> is requesting the following:</p>
   <ul>
     <% missingOIDCScope.forEach((scope) => { %>
       <li><%= scope %></li>
@@ -24,7 +24,6 @@
     <% }) %>
   </ul>
 <% } %>
-<p><%= uid  %></p>
 
   <button autofocus type="submit" class="login login-submit">Continue</button>
 </form>

--- a/libs/oidc/provider/src/lib/controllers/interaction/interaction.controller.ts
+++ b/libs/oidc/provider/src/lib/controllers/interaction/interaction.controller.ts
@@ -41,13 +41,20 @@ export class InteractionController {
         }
 
         case 'consent': {
-          return res.render('interaction', {
+          const locals = {
             client,
             uid,
             details: prompt.details,
             params,
-            title: 'Authorize',
+            title: 'GeoInnovation Service Center SSO',
             session: session ? console.log(session) : undefined
+          };
+          return res.render('interaction', locals, (err, html) => {
+            if (err) throw err;
+            res.render('_layout-simple', {
+              ...locals,
+              body: html
+            });
           });
         }
 


### PR DESCRIPTION
The consent prompt from the IdP was... lacking. I've updated it to use the styled "parent" view `_layout-simple.ejs` to give it some visual flair.

![image](https://user-images.githubusercontent.com/5430492/171298462-5e00c269-9df5-4565-8e43-405c57911b9f.png)
