### PR TITLE
ci: Pinned Node version to 16.15.0 which fixes npm ci failure in dep cache task

### DIFF
--- a/templates/tasks/cacheOrRestoreDependencies.yml
+++ b/templates/tasks/cacheOrRestoreDependencies.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '16.x'
+      versionSpec: '16.15.0'
     displayName: 'Install Node.js 16.x'
 
   - task: Cache@2


### PR DESCRIPTION
Latest LTS version of Node as of this PR is 16.15.1 which updates NPM to 8.11.0 which causes `npm ci` to fail with an error suggesting `package.json` and `package-lock.json` are out of sync.

Last known working version of Node that includes a working version of NPM is 16.15.0 and has been pinned in the cache dep task until the issue is resolved upstream.