### PR TITLE
fix(mailroom-nest): Fixed routes used to send emails

### DIFF
--- a/apps/mailroom-nest/README.md
+++ b/apps/mailroom-nest/README.md
@@ -24,7 +24,7 @@ export interface IMailroomEmailOutbound {
 
 This structure is used by the internal `NodeMailer` lib.
 
-To send an email without any attachments, use a standard POST request to the root route:
+You can send a plain email without attachments using a standard POST request to the root route (json or url encoded body):
 
 ```
 {
@@ -36,7 +36,7 @@ To send an email without any attachments, use a standard POST request to the roo
 }
 ```
 
-To send an email _with_ attachments, use a POST multipart/form-data request to the `/attachments` route:
+You can use multipart/form-data to send a plain email or one _with_ attachments so long as you send the request to `/form`:
 
 ```
 {

--- a/apps/mailroom-nest/src/app/app.controller.ts
+++ b/apps/mailroom-nest/src/app/app.controller.ts
@@ -15,7 +15,7 @@ export class AppController {
 
   @Post()
   @UseFilters(MailroomExceptionFilter)
-  @UseInterceptors(LogToDatabaseInterceptor)
+  @UseInterceptors(AnyFilesInterceptor(), LogToDatabaseInterceptor)
   public async sendEmail(@Body() body: IMailroomEmailOutbound) {
     return Mailer.sendEmail(body);
   }

--- a/apps/mailroom-nest/src/app/app.controller.ts
+++ b/apps/mailroom-nest/src/app/app.controller.ts
@@ -15,15 +15,15 @@ export class AppController {
 
   @Post()
   @UseFilters(MailroomExceptionFilter)
-  @UseInterceptors(AnyFilesInterceptor(), LogToDatabaseInterceptor)
+  @UseInterceptors(LogToDatabaseInterceptor)
   public async sendEmail(@Body() body: IMailroomEmailOutbound) {
     return Mailer.sendEmail(body);
   }
 
-  @Post('attachments')
+  @Post('form')
   @UseFilters(MailroomExceptionFilter)
   @UseInterceptors(AnyFilesInterceptor(), LogToDatabaseInterceptor)
-  public async sendEmailWithAttachments(
+  public async sendEmailFromFormWithAttachments(
     @UploadedFiles() files: Array<Express.Multer.File>,
     @Body() body: IMailroomEmailOutbound
   ) {


### PR DESCRIPTION
Made it so mailroom-nest can utilize multipart/form-data, json encoded, and url encoded bodies. Fixes issue #254.