### PR TITLE
fix(oidc-provider-nest): Added manual package.json for deployments

### DIFF
--- a/apps/oidc-provider-nest/project.json
+++ b/apps/oidc-provider-nest/project.json
@@ -12,6 +12,7 @@
         "tsConfig": "apps/oidc-provider-nest/tsconfig.app.json",
         "assets": [
           "apps/oidc-provider-nest/src/assets",
+          "apps/oidc-provider-nest/src/package.json",
           {
             "glob": "**/*",
             "input": "./libs/assets/powershell",
@@ -30,7 +31,7 @@
           "extractLicenses": false,
           "inspect": false,
           "optimization": true,
-          "generatePackageJson": true
+          "generatePackageJson": false
         },
         "development": {
           "fileReplacements": [
@@ -42,7 +43,7 @@
           "extractLicenses": false,
           "inspect": false,
           "optimization": false,
-          "generatePackageJson": true
+          "generatePackageJson": false
         }
       },
       "outputs": ["{options.outputPath}"]

--- a/apps/oidc-provider-nest/src/package.json
+++ b/apps/oidc-provider-nest/src/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "oidc-provider-nest-deploy",
+  "version": "0.0.1",
+  "dependencies": {
+    "@nestjs/common": "8.2.6",
+    "class-transformer": "0.3.1",
+    "class-validator": "0.13.2",
+    "reflect-metadata": "0.1.13",
+    "rxjs": "7.5.2",
+    "@nestjs/typeorm": "8.0.3",
+    "@nestjs/core": "8.2.6",
+    "@nestjs/platform-express": "8.2.6",
+    "typeorm": "0.2.41",
+    "better-sqlite3": "7.5.0",
+    "mssql": "6.4.0",
+    "@nestjs/passport": "8.1.0",
+    "passport": "0.4.1",
+    "openid-client": "3.15.10",
+    "otplib": "10.2.3",
+    "uuid": "8.3.2",
+    "deepmerge": "4.2.2",
+    "bcrypt": "5.0.1",
+    "jwks-rsa": "2.1.0",
+    "passport-jwt": "4.0.0",
+    "nodemailer": "6.7.2",
+    "multer": "1.4.4",
+    "oidc-provider": "7.11.0",
+    "node-jose": "2.1.1",
+    "tslib": "2.3.1",
+    "cookie-parser": "1.4.6"
+  },
+  "main": "main.js"
+}


### PR DESCRIPTION
The auto-generated version did not have pinned versions which was causing an initialization error due to a breaking change in one of the dependencies.

This is a recurring issue with some deployments and the ultimate solution is coming up with a script that goes through the package-lock tree and picks out all pinned dependency versions or better yet, creates a `package-lock.json` from the root package-lock.json otherwise we're going to keep getting non-deterministic builds between development machines and deployment environments.