### PR TITLE
feat(mailroom-nest): mailroom-nest now should work on dev vm

### DIFF
--- a/apps/mailroom-nest/src/environments/environment.dev.ts
+++ b/apps/mailroom-nest/src/environments/environment.dev.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  dev: true,
   port: 27000,
   globalPrefix: ''
 };

--- a/apps/mailroom-nest/src/environments/environment.prod.ts
+++ b/apps/mailroom-nest/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  dev: false,
   port: 27000,
   globalPrefix: ''
 };

--- a/apps/mailroom-nest/src/environments/environment.ts
+++ b/apps/mailroom-nest/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
+  dev: true,
   port: 3333,
   globalPrefix: ''
 };

--- a/apps/mailroom-nest/src/main.ts
+++ b/apps/mailroom-nest/src/main.ts
@@ -16,7 +16,7 @@ async function bootstrap() {
 
   const port = environment.port || 3333;
 
-  Mailer.build('tamu-relay');
+  Mailer.build('tamu-relay', environment.dev);
 
   await app.listen(port, () => {
     Logger.log('Listening at http://localhost:' + port);

--- a/libs/oidc/common/src/lib/utils/email/mailer.util.ts
+++ b/libs/oidc/common/src/lib/utils/email/mailer.util.ts
@@ -13,16 +13,7 @@ export class Mailer {
 
   // https://dev.to/chandrapantachhetri/sending-emails-securely-using-node-js-nodemailer-smtp-gmail-and-oauth2-g3a
   // 2LO https://nodemailer.com/smtp/oauth2/#oauth-2lo
-  public static build(
-    service: NodeMailerServices,
-    config?: {
-      user: string;
-      accessToken: string;
-      clientId: string;
-      clientSecret: string;
-      refreshToken: string;
-    }
-  ) {
+  public static build(service: NodeMailerServices, dev: boolean) {
     Mailer.service = service;
 
     switch (service) {
@@ -40,7 +31,7 @@ export class Mailer {
         break;
       case 'tamu-relay':
         Mailer.transporter = nodemailer.createTransport({
-          host: 'smtp-relay.tamu.edu',
+          host: dev ? 'relay.tamu.edu' : 'smtp-relay.tamu.edu',
           port: 25,
           secure: false,
           ignoreTLS: true
@@ -54,7 +45,13 @@ export class Mailer {
           secure: true,
           auth: {
             type: 'OAuth2',
-            ...config
+            config: {
+              user: '',
+              accessToken: '',
+              clientId: '',
+              clientSecret: '',
+              refreshToken: ''
+            }
           }
         });
         break;


### PR DESCRIPTION
Changed the code to use `relay.tamu.edu` or `smtp-relay.tamu.edu` based on an environment value. We should now be able to use `mailroom-nest` in the dev VM whereas before it didn't work because it was not a part of the TAMU network (or something like that).