### PR TITLE
feat(mailroom-data-api): Added mailroom data-api lib

### DIFF
--- a/libs/mailroom/data-api/.babelrc
+++ b/libs/mailroom/data-api/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/mailroom/data-api/.eslintrc.json
+++ b/libs/mailroom/data-api/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/mailroom/data-api/README.md
+++ b/libs/mailroom/data-api/README.md
@@ -1,0 +1,7 @@
+# mailroom-data-api
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test mailroom-data-api` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/mailroom/data-api/jest.config.js
+++ b/libs/mailroom/data-api/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'mailroom-data-api',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/mailroom/data-api'
+};

--- a/libs/mailroom/data-api/project.json
+++ b/libs/mailroom/data-api/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/mailroom/data-api",
+  "sourceRoot": "libs/mailroom/data-api/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/mailroom/data-api/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/mailroom/data-api"],
+      "options": {
+        "jestConfig": "libs/mailroom/data-api/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/mailroom/data-api/src/lib/email/email.controller.spec.ts
+++ b/libs/mailroom/data-api/src/lib/email/email.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmailController } from './email.controller';
+
+describe('EmailController', () => {
+  let controller: EmailController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EmailController]
+    }).compile();
+
+    controller = module.get<EmailController>(EmailController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/libs/mailroom/data-api/src/lib/email/email.controller.ts
+++ b/libs/mailroom/data-api/src/lib/email/email.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('email')
+export class EmailController {}

--- a/libs/mailroom/data-api/src/lib/email/email.module.ts
+++ b/libs/mailroom/data-api/src/lib/email/email.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { EmailService } from './email.service';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [EmailService],
+  exports: []
+})
+export class EmailModule {}

--- a/libs/mailroom/data-api/src/lib/email/email.service.spec.ts
+++ b/libs/mailroom/data-api/src/lib/email/email.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmailService } from './email.service';
+
+describe('EmailService', () => {
+  let service: EmailService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmailService]
+    }).compile();
+
+    service = module.get<EmailService>(EmailService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/mailroom/data-api/src/lib/email/email.service.ts
+++ b/libs/mailroom/data-api/src/lib/email/email.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EmailService {}

--- a/libs/mailroom/data-api/tsconfig.json
+++ b/libs/mailroom/data-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/mailroom/data-api/tsconfig.lib.json
+++ b/libs/mailroom/data-api/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/mailroom/data-api/tsconfig.spec.json
+++ b/libs/mailroom/data-api/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -73,6 +73,7 @@
       "@tamu-gisc/kissingbug/ngx": ["libs/kissingbug/ngx/src/index.ts"],
       "@tamu-gisc/mailroom/common": ["libs/mailroom/common/src/index.ts"],
       "@tamu-gisc/mailroom/data-access": ["libs/mailroom/data-access/src/index.ts"],
+      "@tamu-gisc/mailroom/data-api": ["libs/mailroom/data-api/src/index.ts"],
       "@tamu-gisc/mailroom/ngx": ["libs/mailroom/ngx/src/index.ts"],
       "@tamu-gisc/maps/esri": ["libs/maps/esri/src/index.ts"],
       "@tamu-gisc/maps/feature/accessibility": ["libs/maps/feature/accessibility/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -77,6 +77,7 @@
     "mailroom-angular-e2e": "apps/mailroom-angular-e2e",
     "mailroom-common": "libs/mailroom/common",
     "mailroom-data-access": "libs/mailroom/data-access",
+    "mailroom-data-api": "libs/mailroom/data-api",
     "mailroom-nest": "apps/mailroom-nest",
     "mailroom-ngx": "libs/mailroom/ngx",
     "maps-esri": "libs/maps/esri",


### PR DESCRIPTION
Initial boilerplate for the creation of the mailroom/data-api lib; addresses https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pull/260#discussion_r927715410. As this is just a boiler plate PR no implementation is included.