### PR TITLE
chore(aggiemap-angular): Remove building departments list from popup

### DIFF
--- a/libs/aggiemap/ngx/popups/src/lib/components/building/building-popup.component.html
+++ b/libs/aggiemap/ngx/popups/src/lib/components/building/building-popup.component.html
@@ -18,12 +18,6 @@
 </div>
 
 <div class="popup-section">
-  <div class="feature-style-1" tabindex="0">Departments & Offices</div>
-
-  <tamu-gisc-building-department-list [buildingNumber]="data.attributes.Number"></tamu-gisc-building-department-list>
-</div>
-
-<div class="popup-section">
   <div class="image" tabindex="0" aria-label="Image of feature">
     <img alt="" src="https://aggiemap.tamu.edu/images/compressed_test/{{ data.attributes.Number }}.jpg" />
   </div>


### PR DESCRIPTION
The building department list that appeared on the building popup component has been removed until further notice. 

Addresses #273