### PR TITLE
feat(aggiemap-angular): Support ability to override rendered basemap

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.ts
@@ -28,6 +28,7 @@ export class MapComponent implements OnInit, OnDestroy {
   public threeDLayers: Array<LayerSource>;
 
   public isDev: Observable<boolean>;
+  public urlBasemap: string;
 
   private _destroy$: Subject<boolean> = new Subject();
   private _connections: { [key: string]: string };
@@ -44,6 +45,12 @@ export class MapComponent implements OnInit, OnDestroy {
     this._connections = this.env.value('Connections');
     this.isDev = this.ts.get('isTesting');
 
+    // TODO: This needs to be updated when settings service is updated to support settings branch get without feature component/module being loaded.
+    // https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/issues/274
+    const preferencesString = localStorage.getItem('user-preferences');
+    const { experiments } = preferencesString !== null ? JSON.parse(preferencesString) : { experiments: null };
+    const { basemap_url } = experiments;
+
     this.responsiveService.isMobile.pipe(takeUntil(this._destroy$)).subscribe((value) => {
       this.isMobile = value;
 
@@ -53,7 +60,7 @@ export class MapComponent implements OnInit, OnDestroy {
             baseLayers: [
               {
                 type: 'TileLayer',
-                url: this._connections['basemapUrl'],
+                url: basemap_url ? basemap_url : this._connections['basemapUrl'],
                 spatialReference: {
                   wkid: 102100
                 },

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -33,7 +33,9 @@ import {
   BusListComponent,
   ModalComponent,
   ReportBadRouteComponent,
-  AggiemapFormsModule
+  AggiemapFormsModule,
+  ExperimentsModule,
+  ExperimentsListComponent
 } from '@tamu-gisc/aggiemap/ngx/ui/shared';
 import {
   AggiemapSidebarModule,
@@ -73,7 +75,8 @@ const routes: Routes = [
           { path: '', component: SidebarReferenceComponent },
           { path: 'bus', component: BusListComponent },
           { path: 'trip', component: SidebarTripPlannerComponent },
-          { path: 'trip/options', component: TripPlannerOptionsComponent }
+          { path: 'trip/options', component: TripPlannerOptionsComponent },
+          { path: 'experiments', component: ExperimentsListComponent }
         ]
       },
       {
@@ -150,7 +153,8 @@ const routes: Routes = [
     AggiemapNgxUiMobileModule,
     MapsFeatureCoordinatesModule,
     AggiemapFormsModule,
-    MapsFeaturePerspectiveModule
+    MapsFeaturePerspectiveModule,
+    ExperimentsModule
   ],
   declarations: [MapComponent]
 })

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
@@ -9,6 +9,8 @@ We are injecting application-specific sidebar tabs and content -->
     <tamu-gisc-sidebar-tab [title]="'Directions'" [description]="'Toggle directions controls (routing and way-finding)'" [material_icon]="'directions'" [route]="'trip'"></tamu-gisc-sidebar-tab>
 
     <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'"></tamu-gisc-sidebar-tab>
+
+    <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Experiments'" [description]="'Aggiemap Experiments'" [material_icon]="'science'" [route]="'experiments'"></tamu-gisc-sidebar-tab>
   </div>
 
   <div class="content">

--- a/libs/aggiemap/ngx/ui/shared/src/index.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/index.ts
@@ -3,9 +3,11 @@ export * from './lib/modules/structural/structural.module';
 export * from './lib/modules/forms/forms.module';
 export * from './lib/modules/transportation/transportation.module';
 export * from './lib/modules/modals/modals.module';
+export * from './lib/modules/experiments/experiments.module';
 
 // Component symbols
 export * from './lib/modules/transportation/components/bus-list/bus-list.component';
 export * from './lib/modules/structural/components/modal/modal.component';
 export * from './lib/modules/forms/components/report-bad-route/report-bad-route.component';
 export * from './lib/modules/modals/components/beta-prompt/beta-prompt.component';
+export * from './lib/modules/experiments/components/experiments-list/experiments-list.component';

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.html
@@ -1,0 +1,11 @@
+<div class="form-section">
+  <form [formGroup]="form">
+    <div class="form-collection column">
+      <div class="form-section">
+        <p>Overrides default basemap. <strong>Application reloads automatically to apply basemap change</strong>. This will only affect the basemap rendered and not the underlying data sources for popups, search, and routing.</p>
+
+        <tamu-gisc-textbox placeholder="URL" formControlName="url" [floatLabel]="false"></tamu-gisc-textbox>
+      </div>
+    </div>
+  </form>
+</div>

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.scss
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.scss
@@ -1,0 +1,1 @@
+@import 'libs/sass/modules/forms';

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BasemapOverrideComponent } from './basemap-override.component';
+
+describe('BasemapOverrideComponent', () => {
+  let component: BasemapOverrideComponent;
+  let fixture: ComponentFixture<BasemapOverrideComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BasemapOverrideComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BasemapOverrideComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/basemap-override/basemap-override.component.ts
@@ -1,0 +1,77 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, map, Subject, takeUntil } from 'rxjs';
+
+import { SettingsInitializationConfig, SettingsService } from '@tamu-gisc/common/ngx/settings';
+
+@Component({
+  selector: 'tamu-gisc-basemap-override',
+  templateUrl: './basemap-override.component.html',
+  styleUrls: ['./basemap-override.component.scss']
+})
+export class BasemapOverrideComponent implements OnInit, OnDestroy {
+  public form: FormGroup;
+
+  private settingsConfig: SettingsInitializationConfig = {
+    storage: {
+      subKey: 'experiments'
+    },
+    settings: {
+      basemap_url: {
+        value: null,
+        persistent: true
+      }
+    }
+  };
+
+  private $destroy: Subject<boolean> = new Subject();
+
+  constructor(private readonly ss: SettingsService, private readonly fb: FormBuilder) {}
+
+  public ngOnInit(): void {
+    this.form = this.fb.group({
+      url: ['', Validators.required]
+    });
+
+    this.ss.init(this.settingsConfig).pipe(takeUntil(this.$destroy)).subscribe(this.next.bind(this));
+  }
+
+  public ngOnDestroy(): void {
+    this.$destroy.next(true);
+    this.$destroy.complete();
+  }
+
+  public next(settings: BasemapOverrideSettingsBranch) {
+    const { basemap_url } = settings;
+
+    if (basemap_url) {
+      this.form.patchValue({ url: basemap_url });
+    }
+
+    this.form
+      .get('url')
+      .valueChanges.pipe(
+        takeUntil(this.$destroy),
+        debounceTime(1000),
+        distinctUntilChanged(),
+        map((v) => {
+          if (v === '') {
+            return null;
+          }
+
+          return v;
+        })
+      )
+      .subscribe((res) => {
+        this.ss.updateSettings({
+          basemap_url: res
+        });
+
+        location.reload();
+      });
+  }
+}
+
+interface BasemapOverrideSettingsBranch {
+  basemap_url: string | null;
+}

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.html
@@ -1,0 +1,8 @@
+<div class="sidebar-component-name">
+  <span class="material-icons" *ngIf="(responsive | async)" (click)="backAction()">arrow_back</span>
+  <p>Aggiemap Experiments</p>
+</div>
+
+<div class="sidebar-component-content-container">
+  <tamu-gisc-basemap-override></tamu-gisc-basemap-override>
+</div>

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.scss
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.scss
@@ -1,0 +1,2 @@
+@import 'libs/sass/mixins';
+@import 'libs/sass/components/sidebar';

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExperimentsListComponent } from './experiments-list.component';
+
+describe('ExperimentsListComponent', () => {
+  let component: ExperimentsListComponent;
+  let fixture: ComponentFixture<ExperimentsListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ExperimentsListComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExperimentsListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/components/experiments-list/experiments-list.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ResponsiveService } from '@tamu-gisc/dev-tools/responsive';
+
+@Component({
+  selector: 'tamu-gisc-experiments-list',
+  templateUrl: './experiments-list.component.html',
+  styleUrls: ['./experiments-list.component.scss']
+})
+export class ExperimentsListComponent implements OnInit {
+  public responsive: Observable<boolean>;
+
+  constructor(private readonly rs: ResponsiveService) {}
+
+  ngOnInit(): void {
+    this.responsive = this.rs.isMobile;
+  }
+}

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/experiments.module.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/experiments/experiments.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { UIFormsModule } from '@tamu-gisc/ui-kits/ngx/forms';
+
+import { ExperimentsListComponent } from './components/experiments-list/experiments-list.component';
+import { BasemapOverrideComponent } from './components/basemap-override/basemap-override.component';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, UIFormsModule],
+  declarations: [ExperimentsListComponent, BasemapOverrideComponent],
+  exports: [ExperimentsListComponent]
+})
+export class ExperimentsModule {}


### PR DESCRIPTION
Adds "experiments" sidebar tab that hosts a single component: basemap override which supports the function to replace the rendered basemap. 

Is only visible in development environments.

Addresses #271 