### PR TITLE
fix(ui-kits-ngx-modal): Responsive layout improvements

### DIFF
--- a/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
+++ b/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
@@ -1,3 +1,5 @@
+@import 'libs/sass/mixins';
+
 ::ng-deep {
   body.modal-open {
     overflow: hidden;
@@ -6,10 +8,10 @@
 
 :host {
   position: fixed;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  @include flexbox();
+  @include flex-direction(column);
+  @include justify-content(center);
+  @include align-items(center);
   top: 0;
   left: 0;
   height: 100%;
@@ -28,8 +30,8 @@
 
 .modal--container {
   background-color: #fafafa;
-  display: flex;
-  flex-direction: column;
+  @include flexbox();
+  @include flex-direction(column);
   position: absolute;
   border-radius: 3pt;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
@@ -45,14 +47,14 @@
   }
 
   header {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
+    @include flexbox();
+    @include flex-direction(row);
+    @include justify-content(flex-end);
     margin-bottom: 0.75rem;
 
     .modal--header-action {
-      display: flex;
-      justify-content: center;
+      @include flexbox();
+      @include justify-content(center);
       cursor: pointer;
       color: #9e9e9e;
       transition: color 0.3s;
@@ -83,4 +85,3 @@
     max-width: 60%;
   }
 }
-

--- a/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
+++ b/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
@@ -6,6 +6,10 @@
 
 :host {
   position: fixed;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   top: 0;
   left: 0;
   height: 100%;
@@ -27,23 +31,28 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translateX(-50%) translateY(-50%);
   border-radius: 3pt;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
-  padding: 1.25rem 2rem 2.5rem 2rem;
-  max-width: 75%;
+  padding: 1.25rem 0 2.5rem 0;
+  max-width: 95%;
   max-height: 95%;
   box-sizing: border-box;
-  overflow-y: auto;
+
+  header,
+  .modal--body {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
 
   header {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
+    margin-bottom: 0.75rem;
 
     .modal--header-action {
+      display: flex;
+      justify-content: center;
       cursor: pointer;
       color: #9e9e9e;
       transition: color 0.3s;
@@ -56,6 +65,10 @@
         color: #323232;
       }
     }
+  }
+
+  .modal--body {
+    overflow-y: auto;
   }
 }
 

--- a/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
+++ b/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
@@ -32,6 +32,10 @@
   border-radius: 3pt;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
   padding: 1.25rem 2rem 2.5rem 2rem;
+  max-width: 75%;
+  max-height: 95%;
+  box-sizing: border-box;
+  overflow-y: scroll;
 
   header {
     display: flex;

--- a/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
+++ b/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
@@ -34,8 +34,8 @@
   border-radius: 3pt;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
   padding: 1.25rem 0 2.5rem 0;
-  max-width: 95%;
   max-height: 95%;
+  max-width: 95%;
   box-sizing: border-box;
 
   header,
@@ -69,6 +69,18 @@
 
   .modal--body {
     overflow-y: auto;
+  }
+}
+
+@media screen and (min-width: 550px) {
+  .modal--container {
+    max-width: 75%;
+  }
+}
+
+@media screen and (min-width: 767px) {
+  .modal--container {
+    max-width: 60%;
   }
 }
 

--- a/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
+++ b/libs/ui-kits/ngx/layout/modal/src/lib/components/modal-host/modal-host.component.scss
@@ -24,7 +24,8 @@
 
 .modal--container {
   background-color: #fafafa;
-  display: block;
+  display: flex;
+  flex-direction: column;
   position: absolute;
   left: 50%;
   top: 50%;
@@ -35,7 +36,7 @@
   max-width: 75%;
   max-height: 95%;
   box-sizing: border-box;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   header {
     display: flex;
@@ -57,3 +58,4 @@
     }
   }
 }
+


### PR DESCRIPTION
### **Added basic breakpoints that cover most screen resolutions.**

Mobile:
<img width="404" alt="image" src="https://user-images.githubusercontent.com/3969818/182985536-4b9bb5cb-504c-4b7a-9a29-11cf9e1f2f70.png">

Mid-size:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/3969818/182985566-91c5d483-12c6-4267-bd72-59c9118b1535.png">

Desktop:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/3969818/182985682-efebcf28-29d6-4a1b-ab5c-ea1efd4543a6.png">

### **Improved the vertical overflow behavior of the modal body.**

Resolves #272 

