### PR TITLE
fix(aggiemap-angular): Perspective toggle only shows up in testing environments

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -27,7 +27,7 @@
   <tamu-gisc-esri-map [config]="c" (loaded)="continue($event)" [ngClass]="{ mobile: isMobile }">
     <div class="map-overlay-ui">
       <div class="overlay-zone top left">
-        <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers"></tamu-gisc-perspective-toggle>
+        <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers" *ngIf="(isDev | async) === true"></tamu-gisc-perspective-toggle>
       </div>
     </div>
   </tamu-gisc-esri-map>


### PR DESCRIPTION
Use of angular application testing service to remove the perspective toggle component from production environments.

Resolves #283 