### PR TITLE
feat(oidc-provider-nest): Post-registration redirect implemented

### DIFF
--- a/apps/oidc-provider-nest/src/assets/views/post-registration-redirect.ejs
+++ b/apps/oidc-provider-nest/src/assets/views/post-registration-redirect.ejs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>GeoInnovation Service Center Register</title>
+
+    <script src="/qrcode.min.js"></script>
+
+    <link rel="stylesheet" href="/styles.css" />
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,600" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="container">
+      <div class="logo">
+        <img src="/TAM-Logo.svg" alt="GeoInnovation Service Center Logo" />
+      </div>
+
+      <h1 class="title">GeoInnovation Service Center</h1>
+
+      <p class="text center authorize-instructions">
+        Thank you for registering; you will be receiving a confirmation email shortly.
+      </p>
+      <div class="login-card">
+        <a href="<%= redirectUrl %>">Click here to be redirected back to <%= redirectUrl %></p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/oidc-provider-nest/src/assets/views/register.ejs
+++ b/apps/oidc-provider-nest/src/assets/views/register.ejs
@@ -1,4 +1,6 @@
 <form autocomplete="off" action="/user/register" method="post">
+  <input type="hidden" name="returnUrl" value="<%= returnUrl %>" />
+
   <% if (error) {%>
     <ul>
     <% message.map((errorMessage) => { %>

--- a/apps/oidc-provider-nest/src/assets/views/user-info.ejs
+++ b/apps/oidc-provider-nest/src/assets/views/user-info.ejs
@@ -31,10 +31,6 @@
   </div>
 
   <div class="account-register-prompt">
-    <%if (!devMode) { %>
-    <p>Don't have an account? <a href="../user/register">Get started</a>.</p>
-    <%} else { %>
-    <p>Don't have an account? <a href="../user/register">Get started</a>.</p>
-    <%} %>
+    <p>Don't have an account? <a href="../user/register?returnUrl=<%= returnUrl %>">Get started</a>.</p>
   </div>
 </form>

--- a/libs/oidc/common/src/lib/controllers/user/user.controller.ts
+++ b/libs/oidc/common/src/lib/controllers/user/user.controller.ts
@@ -1,4 +1,17 @@
-import { Controller, Get, Param, Req, Res, Post, HttpException, HttpStatus, Body, UseGuards, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Req,
+  Res,
+  Post,
+  HttpException,
+  HttpStatus,
+  Body,
+  UseGuards,
+  Delete,
+  Render
+} from '@nestjs/common';
 
 import { Request, Response } from 'express';
 import { authenticator } from 'otplib';
@@ -94,7 +107,8 @@ export class UserController {
       error: false,
       questions: questions,
       devMode: urlHas(req.path, 'dev', true),
-      requestingHost: urlFragment('', 'hostname')
+      requestingHost: urlFragment('', 'hostname'),
+      returnUrl: req.query.returnUrl
     };
 
     return res.render('register', locals, (err, html) => {
@@ -113,7 +127,8 @@ export class UserController {
    *
    */
   @Post('register')
-  public async registerPost(@Body() body, @Req() req: Request, @Res() res: Response) {
+  @Render('post-registration-redirect')
+  public async registerPost(@Body() body, @Req() req: Request) {
     try {
       const _user: Partial<User> = {
         email: body.email,
@@ -129,7 +144,9 @@ export class UserController {
 
       await this.userService.insertSecretAnswers(secretQuestion1, secretQuestion2, secretanswer1, secretanswer2, userEnt);
 
-      return res.send(`Welcome aboard, ${userEnt.account.name}!`);
+      return {
+        redirectUrl: body.returnUrl
+      };
     } catch (err) {
       throw new HttpException(err, HttpStatus.PARTIAL_CONTENT);
     }

--- a/libs/oidc/provider/src/lib/controllers/interaction/interaction.controller.ts
+++ b/libs/oidc/provider/src/lib/controllers/interaction/interaction.controller.ts
@@ -25,6 +25,10 @@ export class InteractionController {
 
       const name = prompt.name;
 
+      const hostname = urlFragment(client.redirectUris[0], 'hostname');
+      const host = urlFragment(client.redirectUris[0], 'host');
+      const protocol = urlFragment(client.redirectUris[0], 'protocol');
+
       switch (name) {
         case 'login': {
           const locals = {
@@ -33,7 +37,8 @@ export class InteractionController {
             error: false,
             interaction: true,
             devMode: urlHas(req.path, 'dev', true),
-            requestingHost: urlFragment(client.redirectUris[0], 'hostname')
+            requestingHost: hostname,
+            returnUrl: `${protocol}//${host}`
           };
 
           return res.render('user-info', locals, (err, html) => {


### PR DESCRIPTION
Previously whenever you registered you would be sent to the home page of the IdP with a message saying something like "Welcome aboard, [person]!". This message doesn't help anyone. Now upon successful registration, they will be shown a stylized dialog that asks them to click a link to be taken back to the site from which they just registered from. 

Unfortunately the registration process does not log the person in, so they will still need to login once they've created an account on the IdP.

Addresses issue #231 

![image](https://user-images.githubusercontent.com/5430492/184247512-b41f898f-5a3c-4e92-9da6-51ed545955f9.png)
