### PR TITLE
fix(aggiemap-angular): Remove university depts from active search sources

### DIFF
--- a/apps/aggiemap-angular/src/environments/definitions.ts
+++ b/apps/aggiemap-angular/src/environments/definitions.ts
@@ -376,7 +376,7 @@ export const SearchSources: SearchSource[] = [
     featuresLocation: 'features',
     displayTemplate: '{attributes.DeptName}',
     popupComponent: 'BasePopupComponent',
-    searchActive: true,
+    searchActive: false,
     altLookup: {
       source: 'building-exact',
       reference: {


### PR DESCRIPTION
Fixes #292 

This PR disables the search source, which is not used when performing keyword searches on the main search bar.