### PR TITLE
fix(aggiemap-angular): Update surface lots layer index

### DIFF
--- a/apps/aggiemap-angular/src/environments/definitions.ts
+++ b/apps/aggiemap-angular/src/environments/definitions.ts
@@ -55,7 +55,7 @@ export const Definitions = {
     id: 'surface-lots',
     layerId: 'surface-lots-layer',
     name: 'Surface Lots',
-    url: `${Connections.basemapUrl}/8`,
+    url: `${Connections.basemapUrl}/9`,
     popupComponent: Popups.ParkingLotPopupComponent
   },
   VISITOR_PARKING: {
@@ -501,7 +501,7 @@ export const SearchSources: SearchSource[] = [
   {
     source: 'parking-lot',
     name: 'Parking Lot',
-    url: `${Connections.basemapUrl}/8`,
+    url: `${Connections.basemapUrl}/9`,
     queryParams: {
       ...commonQueryParams,
       where: {


### PR DESCRIPTION
The basemap was updated without testing and resulted in an index being off, which impacted the ability to search parking lots and limited the dynamic data in the surface lot popup.

Layer list indexes at the time of this PR:

![image](https://user-images.githubusercontent.com/3969818/186224509-f5b1dfdb-43c3-4b53-ae48-6ba556d32370.png)


Fixes #294  and #295 

