### PR TITLE
feat(aggiemap-angular): Add bus routes mobile flow

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -7,7 +7,7 @@
       <p><a title="" routerLink="/instructions" tabindex="0">Map Instructions</a></p>
       <p><a title="" routerLink="/directory" tabindex="0">Building Directory</a></p>
       <p><a title="" href="https://aggiemap.tamu.edu/feedback.asp" tabindex="0">Feedback</a></p>
-      <p><a tabindex="0" (click)="openBetaModal()" *ngIf="isDev | async">Beta Branch</a></p>
+      <p><a tabindex="0" (click)="openBetaModal(true)" *ngIf="isDev | async">Beta Branch</a></p>
       <p><a title="" routerLink="/about" tabindex="0">About</a></p>
       <p><a title="" href="https://aggiemap.tamu.edu/movein/" tabindex="0">Move-in Parking App</a></p>
       <p><a title="" href="https://aggiemap.tamu.edu/graduation/arrival" tabindex="0">Graduation Parking App</a></p>
@@ -28,6 +28,10 @@
     <div class="map-overlay-ui">
       <div class="overlay-zone top left">
         <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers" *ngIf="(isDev | async) === true"></tamu-gisc-perspective-toggle>
+      </div>
+
+      <div class="overlay-zone bottom right">
+        <div routerLink="/map/m/bus" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons">directions_bus</span></div>
       </div>
     </div>
   </tamu-gisc-esri-map>

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -30,7 +30,6 @@ import { MapsFeaturePerspectiveModule } from '@tamu-gisc/maps/feature/perspectiv
 import {
   AggiemapNgxSharedUiStructuralModule,
   TransportationModule,
-  BusListComponent,
   ModalComponent,
   ReportBadRouteComponent,
   AggiemapFormsModule,
@@ -41,7 +40,8 @@ import {
   AggiemapSidebarModule,
   AggiemapSidebarComponent,
   SidebarReferenceComponent,
-  SidebarTripPlannerComponent
+  SidebarTripPlannerComponent,
+  SidebarBusListComponent
 } from '@tamu-gisc/aggiemap/ngx/ui/desktop';
 import {
   AggiemapNgxUiMobileModule,
@@ -51,7 +51,8 @@ import {
   MobileSidebarComponent,
   MainMobileSidebarComponent,
   AggiemapNgxUiMobileComponent,
-  BusListBottomComponent
+  BusListBottomComponent,
+  BusTimetableBottomComponent
 } from '@tamu-gisc/aggiemap/ngx/ui/mobile';
 
 import { AggiemapNgxPopupsModule } from '@tamu-gisc/aggiemap/ngx/popups';
@@ -74,7 +75,7 @@ const routes: Routes = [
         canActivateChild: [DesktopGuard],
         children: [
           { path: '', component: SidebarReferenceComponent },
-          { path: 'bus', component: BusListComponent },
+          { path: 'bus', component: SidebarBusListComponent },
           { path: 'trip', component: SidebarTripPlannerComponent },
           { path: 'trip/options', component: TripPlannerOptionsComponent },
           { path: 'experiments', component: ExperimentsListComponent }
@@ -110,6 +111,17 @@ const routes: Routes = [
               { path: '', component: MainMobileSidebarComponent },
               { path: 'legend', component: LegendComponent },
               { path: 'layers', component: LayerListComponent }
+            ]
+          },
+          {
+            path: 'bus/:route',
+            children: [
+              { path: '', component: OmnisearchComponent },
+              {
+                path: '',
+                component: BusTimetableBottomComponent,
+                outlet: 'outlet-2'
+              }
             ]
           },
           {

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -116,7 +116,6 @@ const routes: Routes = [
           {
             path: 'bus/:route',
             children: [
-              { path: '', component: OmnisearchComponent },
               {
                 path: '',
                 component: BusTimetableBottomComponent,
@@ -127,7 +126,6 @@ const routes: Routes = [
           {
             path: 'bus',
             children: [
-              { path: '', component: OmnisearchComponent },
               {
                 path: '',
                 component: BusListBottomComponent,

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -50,7 +50,8 @@ import {
   TripPlannerTopComponent,
   MobileSidebarComponent,
   MainMobileSidebarComponent,
-  AggiemapNgxUiMobileComponent
+  AggiemapNgxUiMobileComponent,
+  BusListBottomComponent
 } from '@tamu-gisc/aggiemap/ngx/ui/mobile';
 
 import { AggiemapNgxPopupsModule } from '@tamu-gisc/aggiemap/ngx/popups';
@@ -109,6 +110,17 @@ const routes: Routes = [
               { path: '', component: MainMobileSidebarComponent },
               { path: 'legend', component: LegendComponent },
               { path: 'layers', component: LayerListComponent }
+            ]
+          },
+          {
+            path: 'bus',
+            children: [
+              { path: '', component: OmnisearchComponent },
+              {
+                path: '',
+                component: BusListBottomComponent,
+                outlet: 'outlet-2'
+              }
             ]
           }
         ]

--- a/libs/aggiemap/ngx/ui/desktop/src/index.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/modules/sidebar/sidebar.module';
 export * from './lib/modules/sidebar/sidebar.component';
 export * from './lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component';
 export * from './lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component';
+export * from './lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component';

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
@@ -1,0 +1,7 @@
+<div class="sidebar-component-name">
+  <p>AggieSpirit Bus Routes</p>
+</div>
+
+<div class="sidebar-component-content-container">
+  <tamu-gisc-bus-list [selectionAction]="'in-place'"></tamu-gisc-bus-list>
+</div>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
@@ -1,0 +1,1 @@
+@import 'libs/sass/components/sidebar';

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SidebarBusListComponent } from './sidebar-bus-list.component';
+
+describe('SidebarBusListComponent', () => {
+  let component: SidebarBusListComponent;
+  let fixture: ComponentFixture<SidebarBusListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SidebarBusListComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SidebarBusListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-sidebar-bus-list',
+  templateUrl: './sidebar-bus-list.component.html',
+  styleUrls: ['./sidebar-bus-list.component.scss']
+})
+export class SidebarBusListComponent {}

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
@@ -4,13 +4,13 @@ We are injecting application-specific sidebar tabs and content -->
 
 <tamu-gisc-sidebar [position]="'right'">
   <div class="tabs left">
-    <tamu-gisc-sidebar-tab [title]="'Features'" [description]="'Toggle Features (Search, Layers, Legend)'" [material_icon]="'menu'" [route]="''"></tamu-gisc-sidebar-tab>
+    <tamu-gisc-sidebar-tab [title]="'Features'" [description]="'Toggle Features (Search, Layers, Legend)'" [material_icon]="'menu'" [route]="''" (click)="reportSidebarContent('Features')"></tamu-gisc-sidebar-tab>
 
-    <tamu-gisc-sidebar-tab [title]="'Directions'" [description]="'Toggle directions controls (routing and way-finding)'" [material_icon]="'directions'" [route]="'trip'"></tamu-gisc-sidebar-tab>
+    <tamu-gisc-sidebar-tab [title]="'Directions'" [description]="'Toggle directions controls (routing and way-finding)'" [material_icon]="'directions'" [route]="'trip'" (click)="reportSidebarContent('Directions')"></tamu-gisc-sidebar-tab>
 
-    <tamu-gisc-sidebar-tab [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'"></tamu-gisc-sidebar-tab>
+    <tamu-gisc-sidebar-tab [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'" (click)="reportSidebarContent('Bus Routes')"></tamu-gisc-sidebar-tab>
 
-    <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Experiments'" [description]="'Aggiemap Experiments'" [material_icon]="'science'" [route]="'experiments'"></tamu-gisc-sidebar-tab>
+    <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Experiments'" [description]="'Aggiemap Experiments'" [material_icon]="'science'" [route]="'experiments'" (click)="reportSidebarContent('Experiments')"></tamu-gisc-sidebar-tab>
   </div>
 
   <div class="content">

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { Angulartics2 } from 'angulartics2';
+import { v4 as guid } from 'uuid';
+
 import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
 @Component({
@@ -11,9 +14,25 @@ import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 export class AggiemapSidebarComponent implements OnInit {
   public isDev: Observable<boolean>;
 
-  constructor(private devTools: TestingService) {}
+  constructor(private devTools: TestingService, private readonly analytics: Angulartics2) {}
 
   public ngOnInit() {
     this.isDev = this.devTools.get('isTesting');
+  }
+
+  public reportSidebarContent(tabTitle: string) {
+    const label = {
+      guid: guid(),
+      date: Date.now(),
+      value: tabTitle
+    };
+
+    this.analytics.eventTrack.next({
+      action: 'Desktop Sidebar Tab Select',
+      properties: {
+        category: 'UI Interaction',
+        label: JSON.stringify(label)
+      }
+    });
   }
 }

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.module.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.module.ts
@@ -9,10 +9,12 @@ import { SearchModule } from '@tamu-gisc/ui-kits/ngx/search';
 import { MapsFeatureTripPlannerModule } from '@tamu-gisc/maps/feature/trip-planner';
 import { LayerListModule } from '@tamu-gisc/maps/feature/layer-list';
 import { LegendModule } from '@tamu-gisc/maps/feature/legend';
+import { TransportationModule } from '@tamu-gisc/aggiemap/ngx/ui/shared';
 
 import { AggiemapSidebarComponent } from './sidebar.component';
 import { SidebarReferenceComponent } from './components/sidebar-reference/sidebar-reference.component';
 import { SidebarTripPlannerComponent } from './components/sidebar-trip-planner/sidebar-trip-planner.component';
+import { SidebarBusListComponent } from './components/sidebar-bus-list/sidebar-bus-list.component';
 
 @NgModule({
   imports: [
@@ -24,9 +26,10 @@ import { SidebarTripPlannerComponent } from './components/sidebar-trip-planner/s
     SearchModule,
     MapsFeatureTripPlannerModule,
     LayerListModule,
-    LegendModule
+    LegendModule,
+    TransportationModule
   ],
-  declarations: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent],
+  declarations: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent, SidebarBusListComponent],
   exports: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent]
 })
 export class AggiemapSidebarModule {}

--- a/libs/aggiemap/ngx/ui/mobile/src/index.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/components/trip-planner-top/trip-planner-top.component';
 export * from './lib/components/trip-planner-bottom/trip-planner-bottom.component';
 export * from './lib/components/mobile-sidebar/mobile-sidebar.component';
 export * from './lib/components/main-mobile-sidebar/main-mobile-sidebar.component';
+export * from './lib/components/bus-list-bottom/bus-list-bottom.component';

--- a/libs/aggiemap/ngx/ui/mobile/src/index.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/components/trip-planner-bottom/trip-planner-bottom.componen
 export * from './lib/components/mobile-sidebar/mobile-sidebar.component';
 export * from './lib/components/main-mobile-sidebar/main-mobile-sidebar.component';
 export * from './lib/components/bus-list-bottom/bus-list-bottom.component';
+export * from './lib/components/bus-timetable-bottom/bus-timetable-bottom.component';

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/aggiemap-ngx-ui-mobile.module.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/aggiemap-ngx-ui-mobile.module.ts
@@ -15,6 +15,7 @@ import { OmnisearchComponent } from './components/omnisearch/omnisearch.componen
 import { MobileSidebarComponent } from './components/mobile-sidebar/mobile-sidebar.component';
 import { MainMobileSidebarComponent } from './components/main-mobile-sidebar/main-mobile-sidebar.component';
 import { BusListBottomComponent } from './components/bus-list-bottom/bus-list-bottom.component';
+import { BusTimetableBottomComponent } from './components/bus-timetable-bottom/bus-timetable-bottom.component';
 
 @NgModule({
   imports: [
@@ -34,7 +35,8 @@ import { BusListBottomComponent } from './components/bus-list-bottom/bus-list-bo
     OmnisearchComponent,
     MobileSidebarComponent,
     MainMobileSidebarComponent,
-    BusListBottomComponent
+    BusListBottomComponent,
+    BusTimetableBottomComponent
   ],
   exports: [
     AggiemapNgxUiMobileComponent,
@@ -43,7 +45,8 @@ import { BusListBottomComponent } from './components/bus-list-bottom/bus-list-bo
     OmnisearchComponent,
     MobileSidebarComponent,
     MainMobileSidebarComponent,
-    BusListBottomComponent
+    BusListBottomComponent,
+    BusTimetableBottomComponent
   ]
 })
 export class AggiemapNgxUiMobileModule {}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/aggiemap-ngx-ui-mobile.module.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/aggiemap-ngx-ui-mobile.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { AggiemapNgxSharedUiStructuralModule } from '@tamu-gisc/aggiemap/ngx/ui/shared';
+import { AggiemapNgxSharedUiStructuralModule, TransportationModule } from '@tamu-gisc/aggiemap/ngx/ui/shared';
 import { MapsFeatureTripPlannerModule } from '@tamu-gisc/maps/feature/trip-planner';
 import { UIDragModule } from '@tamu-gisc/ui-kits/ngx/interactions/draggable';
 import { SearchModule } from '@tamu-gisc/ui-kits/ngx/search';
@@ -14,6 +14,7 @@ import { TripPlannerBottomComponent } from './components/trip-planner-bottom/tri
 import { OmnisearchComponent } from './components/omnisearch/omnisearch.component';
 import { MobileSidebarComponent } from './components/mobile-sidebar/mobile-sidebar.component';
 import { MainMobileSidebarComponent } from './components/main-mobile-sidebar/main-mobile-sidebar.component';
+import { BusListBottomComponent } from './components/bus-list-bottom/bus-list-bottom.component';
 
 @NgModule({
   imports: [
@@ -23,7 +24,8 @@ import { MainMobileSidebarComponent } from './components/main-mobile-sidebar/mai
     MapsFeatureTripPlannerModule,
     UIDragModule,
     SearchModule,
-    UITamuBrandingModule
+    UITamuBrandingModule,
+    TransportationModule
   ],
   declarations: [
     AggiemapNgxUiMobileComponent,
@@ -31,7 +33,8 @@ import { MainMobileSidebarComponent } from './components/main-mobile-sidebar/mai
     TripPlannerBottomComponent,
     OmnisearchComponent,
     MobileSidebarComponent,
-    MainMobileSidebarComponent
+    MainMobileSidebarComponent,
+    BusListBottomComponent
   ],
   exports: [
     AggiemapNgxUiMobileComponent,
@@ -39,7 +42,8 @@ import { MainMobileSidebarComponent } from './components/main-mobile-sidebar/mai
     TripPlannerBottomComponent,
     OmnisearchComponent,
     MobileSidebarComponent,
-    MainMobileSidebarComponent
+    MainMobileSidebarComponent,
+    BusListBottomComponent
   ]
 })
 export class AggiemapNgxUiMobileModule {}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
@@ -2,7 +2,7 @@
   <div class="handle"></div>
 
   <div id="list-results">
-    <p class="list-title">AggieSpirit Routes</p>
+    <p class="list-title"><span class="material-icons" (click)="routeReturn()">arrow_back</span> AggieSpirit Bus Routes</p>
     <tamu-gisc-bus-list [selectionAction]="'route'"></tamu-gisc-bus-list>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
@@ -2,6 +2,7 @@
   <div class="handle"></div>
 
   <div id="list-results">
-    <tamu-gisc-bus-list></tamu-gisc-bus-list>
+    <p class="list-title">AggieSpirit Routes</p>
+    <tamu-gisc-bus-list [selectionAction]="'route'"></tamu-gisc-bus-list>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.html
@@ -1,0 +1,7 @@
+<div class="draggable" draggable [draggableIdentifier]="identifier">
+  <div class="handle"></div>
+
+  <div id="list-results">
+    <tamu-gisc-bus-list></tamu-gisc-bus-list>
+  </div>
+</div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
@@ -26,4 +26,12 @@
 .list-title {
   font-weight: bold;
   font-size: 1.1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .material-icons {
+    padding-right: 0.5rem;
+    font-size: 1.3rem;
+  }
 }

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
@@ -1,0 +1,23 @@
+.draggable {
+  position: absolute;
+  background: #ffffff;
+  top: calc(100% - 5.25rem);
+  border-top-right-radius: 0.5rem;
+  border-top-left-radius: 0.5rem;
+  overflow: hidden;
+  font-size: 0.9rem;
+  touch-action: none;
+  pointer-events: initial;
+  width: 100%;
+  z-index: 10;
+  padding-top: 0.5rem;
+}
+
+#list-results {
+  padding: 0 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 2rem;
+  border-top: none;
+  margin-top: 0;
+  box-sizing: border-box;
+}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.scss
@@ -1,7 +1,8 @@
 .draggable {
   position: absolute;
   background: #ffffff;
-  top: calc(100% - 5.25rem);
+  top: calc(100% - 10rem);
+  min-height: 10rem;
   border-top-right-radius: 0.5rem;
   border-top-left-radius: 0.5rem;
   overflow: hidden;
@@ -15,8 +16,8 @@
 
 #list-results {
   padding: 0 0.5rem;
-  padding-top: 0.5rem;
-  padding-bottom: 2rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
   border-top: none;
   margin-top: 0;
   box-sizing: border-box;

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BusListBottomComponent } from './bus-list-bottom.component';
+
+describe('BusListBottomComponent', () => {
+  let component: BusListBottomComponent;
+  let fixture: ComponentFixture<BusListBottomComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BusListBottomComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BusListBottomComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+import { DragService } from '@tamu-gisc/ui-kits/ngx/interactions/draggable';
+
+@Component({
+  selector: 'tamu-gisc-bus-list-bottom',
+  templateUrl: './bus-list-bottom.component.html',
+  styleUrls: ['./bus-list-bottom.component.scss']
+})
+export class BusListBottomComponent implements OnInit {
+  public identifier: string;
+
+  constructor(private readonly ds: DragService) {}
+
+  public ngOnInit(): void {
+    this.identifier = this.ds.register(this);
+  }
+}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-list-bottom/bus-list-bottom.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { DragService } from '@tamu-gisc/ui-kits/ngx/interactions/draggable';
 
@@ -10,9 +11,13 @@ import { DragService } from '@tamu-gisc/ui-kits/ngx/interactions/draggable';
 export class BusListBottomComponent implements OnInit {
   public identifier: string;
 
-  constructor(private readonly ds: DragService) {}
+  constructor(private readonly ds: DragService, private readonly router: Router) {}
 
   public ngOnInit(): void {
     this.identifier = this.ds.register(this);
+  }
+
+  public routeReturn() {
+    this.router.navigate(['/map']);
   }
 }

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.html
@@ -1,0 +1,11 @@
+<div class="draggable" draggable [draggableIdentifier]="identifier">
+  <div class="handle"></div>
+
+  <div id="list-results">
+    <p class="list-title"><span class="material-icons" (click)="routeReturn()">arrow_back</span> AggieSpirit Timetable</p>
+
+    <ng-container *ngIf="(busRoute | async) as rt">
+      <tamu-gisc-bus-route [route]="rt" [eagerLoad]="true"></tamu-gisc-bus-route>
+    </ng-container>
+  </div>
+</div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.scss
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.scss
@@ -26,4 +26,12 @@
 .list-title {
   font-weight: bold;
   font-size: 1.1rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .material-icons {
+    padding-right: 0.5rem;
+    font-size: 1.3rem;
+  }
 }

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BusTimetableBottomComponent } from './bus-timetable-bottom.component';
+
+describe('BusTimetableBottomComponent', () => {
+  let component: BusTimetableBottomComponent;
+  let fixture: ComponentFixture<BusTimetableBottomComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BusTimetableBottomComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BusTimetableBottomComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/bus-timetable-bottom/bus-timetable-bottom.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { filter, map, mergeMap, Observable, take, withLatestFrom } from 'rxjs';
+
+import { BusService, TSRoute } from '@tamu-gisc/maps/feature/trip-planner';
+import { DragService } from '@tamu-gisc/ui-kits/ngx/interactions/draggable';
+
+@Component({
+  selector: 'tamu-gisc-bus-timetable-bottom',
+  templateUrl: './bus-timetable-bottom.component.html',
+  styleUrls: ['./bus-timetable-bottom.component.scss']
+})
+export class BusTimetableBottomComponent implements OnInit {
+  public identifier: string;
+
+  public selectedRoute: Observable<string>;
+
+  public busRoute: Observable<TSRoute>;
+
+  constructor(
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
+    private readonly ds: DragService,
+    private readonly bs: BusService
+  ) {}
+
+  public ngOnInit(): void {
+    this.identifier = this.ds.register(this);
+
+    this.selectedRoute = this.route.params.pipe(
+      map((params) => {
+        return params.route;
+      })
+    );
+
+    this.busRoute = this.bs.getRoutes().pipe(
+      mergeMap((routes) => routes),
+      withLatestFrom(this.selectedRoute),
+      filter(([route, selectedRoute]) => route.ShortName === selectedRoute),
+      map(([result]) => {
+        return result;
+      }),
+      take(1)
+    );
+  }
+
+  public routeReturn() {
+    this.router.navigate(['map/m/bus']);
+  }
+}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.html
@@ -2,7 +2,7 @@
 
 <div class="list-container">
   <div class="list-item" *ngFor="let item of menu">
-    <p *ngIf="item.path !== ''" [routerLink]="item.path">{{ item.name }} <span *ngIf="item.type === 'outlet'" class="material-icons">keyboard_arrow_right</span></p>
-    <a *ngIf="item.url" [href]="item.url" [target]="item.type === 'link-internal' ? '_self' : '_blank'">{{ item.name }} <span *ngIf="item.type === 'outlet'" class="material-icons">keyboard_arrow_right</span></a>
+    <p *ngIf="item.path !== ''" [routerLink]="item.path" (click)="reportNavigation(item.name)">{{ item.name }} <span *ngIf="item.type === 'outlet'" class="material-icons">keyboard_arrow_right</span></p>
+    <a *ngIf="item.url" [href]="item.url" [target]="item.type === 'link-internal' ? '_self' : '_blank'" (click)="reportNavigation(item.name)">{{ item.name }} <span *ngIf="item.type === 'outlet'" class="material-icons">keyboard_arrow_right</span></a>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
@@ -1,5 +1,8 @@
 import { Component } from '@angular/core';
 
+import { Angulartics2 } from 'angulartics2';
+import { v4 as guid } from 'uuid';
+
 interface MenuItem {
   name: string;
   type: 'link-internal' | 'link-external' | 'router-path' | 'outlet';
@@ -68,4 +71,22 @@ export class MainMobileSidebarComponent {
       path: '../../../../../changelog'
     }
   ];
+
+  constructor(private analytics: Angulartics2) {}
+
+  public reportNavigation(name: string) {
+    const label = {
+      guid: guid(),
+      date: Date.now(),
+      value: name
+    };
+
+    this.analytics.eventTrack.next({
+      action: 'Mobile Sidebar Selection',
+      properties: {
+        category: 'UI Interaction',
+        label: JSON.stringify(label)
+      }
+    });
+  }
 }

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
@@ -25,6 +25,11 @@ export class MainMobileSidebarComponent {
       path: 'layers'
     },
     {
+      name: 'Bus Routes',
+      type: 'router-path',
+      path: '/map/m/bus'
+    },
+    {
       name: 'Building Directory',
       type: 'router-path',
       path: '../../../../../directory'

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/omnisearch/omnisearch.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/omnisearch/omnisearch.component.ts
@@ -186,7 +186,7 @@ export class OmnisearchComponent implements OnInit, OnDestroy {
     if ('id' in this.route.snapshot.params) {
       this.router.navigate(['map/d/trip']);
     } else if (this.searchComponentLeftAction === 'menu') {
-      this.router.navigate(['../sidebar'], { relativeTo: this.route });
+      this.router.navigate(['map/m/sidebar']);
     } else {
       this.clearFocus();
     }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -4,7 +4,7 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <div *ngIf="loaded !== true" class="flex flex-column justify-center align-center leader-2 trailer-2">
+  <div *ngIf="(routes | async) === null" class="flex flex-column justify-center align-center leader-2 trailer-2">
     <div class="spinning-loader"></div>
   </div>
 

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -1,17 +1,11 @@
-<div class="sidebar-component-name">
-  <p>AggieSpirit Bus Routes</p>
+<div *ngIf="(routes | async) === null" class="flex flex-column justify-center align-center leader-2 trailer-2">
+  <div class="spinning-loader"></div>
 </div>
 
-<div class="sidebar-component-content-container">
-  <div *ngIf="(routes | async) === null" class="flex flex-column justify-center align-center leader-2 trailer-2">
-    <div class="spinning-loader"></div>
-  </div>
+<div class="group" *ngFor="let group of routes | async">
+  <p class="group-name">{{ group.identity['Name'] }}</p>
 
-  <div class="group" *ngFor="let group of routes | async">
-    <p class="group-name">{{ group.identity['Name'] }}</p>
-
-    <div class="routes">
-      <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route"></tamu-gisc-bus-route>
-    </div>
+  <div class="routes">
+    <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route" [selection]="selectionAction"></tamu-gisc-bus-route>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -1,5 +1,4 @@
 <div class="sidebar-component-name">
-  <span class="material-icons" *ngIf="responsive?.isMobile" (click)="backAction()">arrow_back</span>
   <p>AggieSpirit Bus Routes</p>
 </div>
 

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -6,6 +6,6 @@
   <p class="group-name">{{ group.identity['Name'] }}</p>
 
   <div class="routes">
-    <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route" [selection]="selectionAction" (click)="reportSelection(route.ShortName)"></tamu-gisc-bus-route>
+    <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route" [selection]="selectionAction"></tamu-gisc-bus-route>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -6,6 +6,6 @@
   <p class="group-name">{{ group.identity['Name'] }}</p>
 
   <div class="routes">
-    <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route" [selection]="selectionAction"></tamu-gisc-bus-route>
+    <tamu-gisc-bus-route *ngFor="let route of group.items" [route]="route" [selection]="selectionAction" (click)="reportSelection(route.ShortName)"></tamu-gisc-bus-route>
   </div>
 </div>

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.scss
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.scss
@@ -1,5 +1,4 @@
 @import 'libs/sass/mixins';
-@import 'libs/sass/components/sidebar';
 
 .group {
   margin-bottom: 1rem;

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { switchMap, tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 
 import { BusService, TSRoute } from '@tamu-gisc/maps/feature/trip-planner';
 import { ResponsiveService, ResponsiveSnapshot } from '@tamu-gisc/dev-tools/responsive';
@@ -48,6 +48,9 @@ export class BusListComponent implements OnInit, OnDestroy {
         const grouped = groupBy(sorted, 'Group.Name', 'Group');
 
         return of(grouped);
+      }),
+      map((grouped) => {
+        return grouped.reverse();
       }),
       tap(() => {
         setTimeout(() => {

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 import { BusService, TSRoute } from '@tamu-gisc/maps/feature/trip-planner';
 import { ResponsiveService, ResponsiveSnapshot } from '@tamu-gisc/dev-tools/responsive';
@@ -16,8 +16,6 @@ export class BusListComponent implements OnInit, OnDestroy {
   public routes: Observable<Group<TSRoute>[]>;
 
   public responsive: ResponsiveSnapshot;
-
-  public loaded: boolean;
 
   constructor(
     private busService: BusService,
@@ -51,11 +49,6 @@ export class BusListComponent implements OnInit, OnDestroy {
       }),
       map((grouped) => {
         return grouped.reverse();
-      }),
-      tap(() => {
-        setTimeout(() => {
-          this.loaded = true;
-        }, 0);
       })
     );
   }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
@@ -12,6 +12,9 @@ import { groupBy, Group } from '@tamu-gisc/common/utils/collection';
   styleUrls: ['./bus-list.component.scss']
 })
 export class BusListComponent implements OnInit, OnDestroy {
+  @Input()
+  public selectionAction: 'in-place' | 'navigate' = 'in-place';
+
   public routes: Observable<Group<TSRoute>[]>;
 
   public responsive: ResponsiveSnapshot;

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
@@ -22,6 +22,8 @@ export class BusListComponent implements OnInit, OnDestroy {
   constructor(private busService: BusService, private responsiveService: ResponsiveService) {}
 
   public ngOnInit(): void {
+    const catOrder = ['On Campus', 'Off Campus', 'Game Day'];
+
     this.responsive = this.responsiveService.snapshot;
 
     this.routes = this.busService.getRoutes().pipe(
@@ -45,7 +47,9 @@ export class BusListComponent implements OnInit, OnDestroy {
         return of(grouped);
       }),
       map((grouped) => {
-        return grouped.reverse();
+        return catOrder.map((cat) => {
+          return grouped.find((g) => (g.identity as TSRoute).Name === cat);
+        });
       })
     );
   }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
@@ -17,12 +16,7 @@ export class BusListComponent implements OnInit, OnDestroy {
 
   public responsive: ResponsiveSnapshot;
 
-  constructor(
-    private busService: BusService,
-    private responsiveService: ResponsiveService,
-    private router: Router,
-    private route: ActivatedRoute
-  ) {}
+  constructor(private busService: BusService, private responsiveService: ResponsiveService) {}
 
   public ngOnInit(): void {
     this.responsive = this.responsiveService.snapshot;
@@ -57,9 +51,5 @@ export class BusListComponent implements OnInit, OnDestroy {
     // When the user navigates away from the component, any and all bus
     // features drawn on the map.
     this.busService.removeAllFromMap();
-  }
-
-  public backAction(): void {
-    this.router.navigate(['../'], { relativeTo: this.route });
   }
 }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-route/bus-route.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-route/bus-route.component.ts
@@ -1,7 +1,10 @@
-import { Component, OnInit, Input, OnDestroy, ViewChild, ChangeDetectorRef, AfterViewInit } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy, ViewChild, AfterViewInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, timer, Observable, NEVER } from 'rxjs';
 import { switchMap, takeUntil, shareReplay, distinctUntilChanged, take, filter } from 'rxjs/operators';
+
+import { v4 as guid } from 'uuid';
+import { Angulartics2 } from 'angulartics2';
 
 import { TSRoute, BusService } from '@tamu-gisc/maps/feature/trip-planner';
 import { AccordionComponent } from '@tamu-gisc/ui-kits/ngx/layout';
@@ -48,7 +51,7 @@ export class BusRouteComponent implements OnInit, AfterViewInit, OnDestroy {
     private busService: BusService,
     private readonly router: Router,
     private readonly rt: ActivatedRoute,
-    private readonly cd: ChangeDetectorRef
+    private readonly analytics: Angulartics2
   ) {}
 
   public ngOnInit() {
@@ -132,6 +135,8 @@ export class BusRouteComponent implements OnInit, AfterViewInit, OnDestroy {
    * Either removes or adds the bound route features to/from the map.
    */
   public toggleRoute(): void {
+    this.reportToggleRoute(this.route.ShortName);
+
     if (this.selection === 'route') {
       this.router.navigate([this.route.ShortName], { relativeTo: this.rt });
     }
@@ -143,5 +148,21 @@ export class BusRouteComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.selection === 'in-place') {
       this.busService.toggleMapRoute(this.route.ShortName);
     }
+  }
+
+  private reportToggleRoute(shortName: string) {
+    const label = {
+      guid: guid(),
+      date: Date.now(),
+      value: shortName
+    };
+
+    this.analytics.eventTrack.next({
+      action: 'Bus Route Load',
+      properties: {
+        category: 'UI Interaction',
+        label: JSON.stringify(label)
+      }
+    });
   }
 }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-route/bus-route.component.ts
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-route/bus-route.component.ts
@@ -1,20 +1,31 @@
-import { Component, OnInit, Input, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy, ViewChild, ChangeDetectorRef, AfterViewInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of, Subject, timer, Observable, NEVER } from 'rxjs';
-import { switchMap, takeUntil, shareReplay, distinctUntilChanged } from 'rxjs/operators';
+import { switchMap, takeUntil, shareReplay, distinctUntilChanged, take, filter } from 'rxjs/operators';
 
 import { TSRoute, BusService } from '@tamu-gisc/maps/feature/trip-planner';
+import { AccordionComponent } from '@tamu-gisc/ui-kits/ngx/layout';
 
 @Component({
   selector: 'tamu-gisc-bus-route',
   templateUrl: './bus-route.component.html',
   styleUrls: ['./bus-route.component.scss']
 })
-export class BusRouteComponent implements OnInit, OnDestroy {
+export class BusRouteComponent implements OnInit, AfterViewInit, OnDestroy {
   /**
    * Provided TSRoute object from the parent component.
    */
   @Input()
   public route: TSRoute;
+
+  @Input()
+  public selection: 'route' | 'in-place' = 'in-place';
+
+  @Input()
+  public eagerLoad = false;
+
+  @ViewChild(AccordionComponent, { static: false })
+  public accordion;
 
   /**
    * Describes whether or not any given bus route is drawn on the map.
@@ -33,7 +44,12 @@ export class BusRouteComponent implements OnInit, OnDestroy {
    */
   private _destroy$: Subject<boolean> = new Subject();
 
-  constructor(private busService: BusService) {}
+  constructor(
+    private busService: BusService,
+    private readonly router: Router,
+    private readonly rt: ActivatedRoute,
+    private readonly cd: ChangeDetectorRef
+  ) {}
 
   public ngOnInit() {
     // Each route makes a subscription to this function that returns a boolean
@@ -87,6 +103,21 @@ export class BusRouteComponent implements OnInit, OnDestroy {
     });
   }
 
+  public ngAfterViewInit(): void {
+    this.busService.busLayer
+      .pipe(
+        filter((l) => l !== null),
+        take(1)
+      )
+      .subscribe(() => {
+        if (this.eagerLoad) {
+          this.toggleRoute();
+
+          this.accordion.toggle();
+        }
+      });
+  }
+
   public ngOnDestroy() {
     this._destroy$.next(true);
     this._destroy$.complete();
@@ -101,10 +132,16 @@ export class BusRouteComponent implements OnInit, OnDestroy {
    * Either removes or adds the bound route features to/from the map.
    */
   public toggleRoute(): void {
+    if (this.selection === 'route') {
+      this.router.navigate([this.route.ShortName], { relativeTo: this.rt });
+    }
+
     if (!this.isLoading) {
       this.isLoading = true;
     }
 
-    this.busService.toggleMapRoute(this.route.ShortName);
+    if (this.selection === 'in-place') {
+      this.busService.toggleMapRoute(this.route.ShortName);
+    }
   }
 }

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-timetable/bus-timetable.component.scss
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-timetable/bus-timetable.component.scss
@@ -26,3 +26,7 @@ td {
     text-decoration: line-through;
   }
 }
+
+tbody tr:nth-child(2n) {
+  background: #eeeeee;
+}

--- a/libs/maps/esri/src/lib/components/esri-map/esri-map.component.scss
+++ b/libs/maps/esri/src/lib/components/esri-map/esri-map.component.scss
@@ -15,7 +15,7 @@
 
 ::ng-deep {
   .map-overlay-ui {
-    position: fixed;
+    position: absolute;
 
     .overlay-zone {
       position: fixed;
@@ -25,7 +25,7 @@
       }
 
       &.bottom {
-        top: 15px; // This value is the same as the esri ui "inset" bottom value
+        bottom: 2rem;
       }
 
       &.left {
@@ -33,7 +33,7 @@
       }
 
       &.right {
-        left: 3.75rem;
+        right: 3.5rem;
       }
     }
   }

--- a/libs/ui-kits/ngx/layout/src/lib/components/accordion/accordion.component.ts
+++ b/libs/ui-kits/ngx/layout/src/lib/components/accordion/accordion.component.ts
@@ -31,4 +31,12 @@ export class AccordionComponent implements AfterContentInit {
       resize: this.resize
     });
   }
+
+  public toggle() {
+    this.comm.update({
+      animate: this.animate,
+      expanded: !this.expanded,
+      resize: this.resize
+    });
+  }
 }


### PR DESCRIPTION
Added views that support viewing aggie bus routes in a more mobile-friendly format. Routes feature is accessible through the `/bus` sub-route:

![image](https://user-images.githubusercontent.com/3969818/186382036-ae68c0dc-32cc-40eb-ad2a-8ba2fb28e2b3.png)

Clicking on the floating icon brings up the bus route list:

![image](https://user-images.githubusercontent.com/3969818/186382158-94b38a42-ad25-49b1-9fd8-b9005b662a2c.png)

Clicking on the route directs to a separate view, and only the timetable for the selected route is visible. This ensures that the selected route is always at the top of the draggable container card and makes the map visible at all times until the user scrolls up to reveal more of the timetable.

![image](https://user-images.githubusercontent.com/3969818/186382524-4d9d9c74-0da4-48a4-83bb-97f3404f5780.png)
