### PR TITLE
chore(aggiemap-angular): Add staging build target to project config

### DIFF
--- a/apps/aggiemap-angular/project.json
+++ b/apps/aggiemap-angular/project.json
@@ -30,6 +30,29 @@
           "sourceMap": false,
           "vendorChunk": false
         },
+        "staging": {
+          "outputHashing": "all",
+          "budgets": [
+            {
+              "maximumError": "5mb",
+              "maximumWarning": "2mb",
+              "type": "initial"
+            }
+          ],
+          "fileReplacements": [
+            {
+              "replace": "apps/aggiemap-angular/src/environments/environment.ts",
+              "with": "apps/aggiemap-angular/src/environments/environment.prod.ts"
+            }
+          ],
+          "aot": true,
+          "buildOptimizer": true,
+          "extractLicenses": true,
+          "namedChunks": false,
+          "optimization": true,
+          "sourceMap": false,
+          "vendorChunk": false
+        },
         "development": {
           "outputHashing": "all",
           "budgets": [


### PR DESCRIPTION
In CI, the staging build is currently being built as local development with no build optimization. Staging should follow the same build procedures as production