### PR TITLE
feat(kissingbug-angular): mailroom-nest integration

### DIFF
--- a/apps/kissingbug-angular/src/environments/environment.dev.ts
+++ b/apps/kissingbug-angular/src/environments/environment.dev.ts
@@ -1,12 +1,12 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+export * from './secrets';
 
 export const environment = {
   production: false
 };
 
 export const api_url = 'https://dev.kissingbug.geoservices.tamu.edu/api';
-
-export const email_server_url = 'http://localhost:4005';
+export const email_server_url = 'http://mailroom.dev.gsvcs.lan/api/';
 
 export const SearchSources = [];
 export const LayerSources: LayerSource[] = [];

--- a/apps/kissingbug-angular/src/environments/environment.prod.ts
+++ b/apps/kissingbug-angular/src/environments/environment.prod.ts
@@ -1,12 +1,12 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+export * from './secrets';
 
 export const environment = {
   production: true
 };
 
-export const api_url = 'https://dev.kissingbug.geoservices.tamu.edu/api';
-
-export const email_server_url = 'http://localhost:4005';
+export const api_url = 'https://kissingbug.geoservices.tamu.edu/api';
+export const email_server_url = 'https://mailroom.gsvcs.lan/api/';
 
 export const SearchSources = [];
 export const LayerSources: LayerSource[] = [];

--- a/apps/kissingbug-angular/src/environments/environment.staging.ts
+++ b/apps/kissingbug-angular/src/environments/environment.staging.ts
@@ -1,12 +1,12 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+export * from './secrets';
 
 export const environment = {
   production: false
 };
 
 export const api_url = 'https://kissingbug-stage.geoservices.tamu.edu/api';
-
-export const email_server_url = 'http://localhost:4005';
+export const email_server_url = 'https://mailroom.gsvcs.lan/api/';
 
 export const SearchSources = [];
 export const LayerSources: LayerSource[] = [];

--- a/apps/kissingbug-angular/src/environments/environment.ts
+++ b/apps/kissingbug-angular/src/environments/environment.ts
@@ -3,6 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 import { LayerSource } from '@tamu-gisc/common/types';
+export * from './secrets';
 
 export const environment = {
   production: false
@@ -18,7 +19,7 @@ export const environment = {
 // import 'zone.js/plugins/zone-error';  // Included with Angular CLI.
 
 export const api_url = 'http://localhost:1337';
-export const email_server_url = 'http://localhost:4005';
+export const email_server_url = 'http://mailroom.dev.gsvcs.lan/api/';
 
 export const SearchSources = [];
 export const LayerSources: LayerSource[] = [];

--- a/apps/kissingbug-angular/src/styles.scss
+++ b/apps/kissingbug-angular/src/styles.scss
@@ -102,6 +102,13 @@ li {
   line-height: 31px;
 }
 
+a {
+    text-decoration: none;
+    color: #1976d2;
+    display: inline-block;
+    position: relative;
+}
+
 article.container {
   padding-bottom: 10em;
 }

--- a/apps/kissingbug-angular/src/styles.scss
+++ b/apps/kissingbug-angular/src/styles.scss
@@ -103,10 +103,10 @@ li {
 }
 
 a {
-    text-decoration: none;
-    color: #1976d2;
-    display: inline-block;
-    position: relative;
+  text-decoration: none;
+  color: #1976d2;
+  display: inline-block;
+  position: relative;
 }
 
 article.container {

--- a/libs/kissingbug/ngx/src/lib/modules/core/components/gallery/gallery.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/components/gallery/gallery.component.ts
@@ -38,11 +38,9 @@ export class GalleryComponent implements OnInit {
 
     this.dataSource.items.forEach((item: IStrapiPageFeature, i) => {
       if (i === 0 || i % this.rowLength !== 0) {
-        console.log(i, 'pushing item', item);
         items.push(item);
       }
       if (i !== 0 && i % this.rowLength === 0) {
-        console.log(i, 'reached row limit');
         this.rowItems.push(items);
         items = [];
         items.push(item);

--- a/libs/kissingbug/ngx/src/lib/modules/core/components/portrait-gallery/portrait-gallery.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/components/portrait-gallery/portrait-gallery.component.ts
@@ -26,11 +26,9 @@ export class PortraitGalleryComponent implements OnInit {
 
     this.dataSource.portraits.forEach((item: IStrapiPagePortrait, i) => {
       if (i === 0 || i % this.rowLength !== 0) {
-        console.log(i, 'pushing item', item);
         items.push(item);
       }
       if (i !== 0 && i % this.rowLength === 0) {
-        console.log(i, 'reached row limit');
         this.rowItems.push(items);
         items = [];
         items.push(item);
@@ -38,7 +36,5 @@ export class PortraitGalleryComponent implements OnInit {
     });
 
     this.rowItems.push(items);
-
-    console.log('rowItems', this.rowItems);
   }
 }

--- a/libs/kissingbug/ngx/src/lib/modules/core/components/publication-gallery/publication-gallery.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/components/publication-gallery/publication-gallery.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
@@ -9,15 +9,11 @@ import { IStrapiPublicationGallery } from '../../types/types';
   templateUrl: './publication-gallery.component.html',
   styleUrls: ['./publication-gallery.component.scss']
 })
-export class PublicationGalleryComponent implements OnInit {
+export class PublicationGalleryComponent {
   @Input()
   public dataSource: IStrapiPublicationGallery;
 
   public api_url = this.environment.value('api_url');
 
   constructor(private environment: EnvironmentService) {}
-
-  public ngOnInit() {
-    console.log('publication-gallery', this.dataSource);
-  }
 }

--- a/libs/kissingbug/ngx/src/lib/modules/core/components/table/table.component.html
+++ b/libs/kissingbug/ngx/src/lib/modules/core/components/table/table.component.html
@@ -11,7 +11,7 @@
         <td>{{ rowItem.location }}</td>
         <td>{{ rowItem.numTested }}</td>
         <td>{{ rowItem.numInfected }}</td>
-        <td>{{ rowItem.percent }}</td>
+        <td>{{ rowItem.percent }}%</td>
       </tr>
     </tbody>
   </table>

--- a/libs/kissingbug/ngx/src/lib/modules/core/data-access/strapi.service.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/data-access/strapi.service.ts
@@ -57,6 +57,6 @@ export class StrapiService {
   }
 
   public sendEmailAsMultipartFormdata(mail) {
-    return this.http.post(`${this.environment.value('email_server_url')}/form`, mail);
+    return this.http.post(`${this.resource}/emails`, mail);
   }
 }

--- a/libs/kissingbug/ngx/src/lib/modules/core/data-access/strapi.service.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/data-access/strapi.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+import { IMailroomEmailOutbound } from '@tamu-gisc/mailroom/common';
 
 import {
   IStrapiPageResponse,
@@ -51,7 +52,11 @@ export class StrapiService {
     return this.http.get<IStrapiBugCount[]>(`${this.resource}/bug-submissions/speciesByMonth/${speciesGuid}/${month}`);
   }
 
-  public sendEmail(body: FormData) {
-    return this.http.post(`${this.environment.value('email_server_url')}/`, body);
+  public sendEmail(mail: IMailroomEmailOutbound) {
+    return this.http.post(`${this.environment.value('email_server_url')}/`, mail);
+  }
+
+  public sendEmailAsMultipartFormdata(mail) {
+    return this.http.post(`${this.environment.value('email_server_url')}/form`, mail);
   }
 }

--- a/libs/kissingbug/ngx/src/lib/modules/core/pages/contact/contact.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/pages/contact/contact.component.ts
@@ -92,7 +92,7 @@ export class ContactComponent implements OnInit {
         .join('');
 
       const outboundMail: IMailroomEmailOutbound = {
-        to: this.contactForm.get('email').value,
+        to: this.environment.value('email_to_account'),
         from: this.environment.value('email_from_account'),
         subject: 'Kissing Bugs contact page email',
         text: '',

--- a/libs/kissingbug/ngx/src/lib/modules/core/pages/contact/contact.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/pages/contact/contact.component.ts
@@ -5,6 +5,9 @@ import { Title } from '@angular/platform-browser';
 import { Observable } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 
+import { IMailroomEmailOutbound } from '@tamu-gisc/mailroom/common';
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 import { StrapiService } from '../../data-access/strapi.service';
 import { IStrapiPageResponse, StrapiSingleTypes } from '../../types/types';
 
@@ -21,7 +24,12 @@ export class ContactComponent implements OnInit {
   public contactForm: FormGroup;
   public today: Date = new Date(Date.now());
 
-  constructor(private titleService: Title, private ss: StrapiService, private fb: FormBuilder) {
+  constructor(
+    private titleService: Title,
+    private ss: StrapiService,
+    private fb: FormBuilder,
+    private environment: EnvironmentService
+  ) {
     this.contactForm = this.fb.group(
       {
         application: new FormControl('KissingBug'),
@@ -63,20 +71,48 @@ export class ContactComponent implements OnInit {
       const formData = new FormData();
       const fileControls = [this.contactForm.controls.file1, this.contactForm.controls.file2];
 
-      const controls = Object.keys(this.contactForm.value);
-      controls.forEach((controlName) => {
-        if (!controlName.includes('file')) {
-          formData.append(controlName, this.contactForm.get(controlName).value);
-        }
+      // Construct our IMailroomEmailOutbound
+      const allKeys = Object.keys(this.contactForm.value);
+
+      // Don't include any file controls and values for the HTML portion
+      const keys = allKeys.filter((key) => this.contactForm.controls[key].value !== '' && !key.includes('file'));
+
+      const htmlValue = keys
+        .map((key, index) => {
+          const value = this.contactForm.controls[key].value;
+
+          if (index === 0) {
+            return `<ul><li><b>${key}</b>: ${value}</li>`;
+          } else if (index === keys.length - 1) {
+            return `<li><b>${key}</b>: ${value}</li></ul>`;
+          } else {
+            return `<li><b>${key}</b>: ${value}</li>`;
+          }
+        })
+        .join('');
+
+      const outboundMail: IMailroomEmailOutbound = {
+        to: this.contactForm.get('email').value,
+        from: this.environment.value('email_from_account'),
+        subject: 'Kissing Bugs contact page email',
+        text: '',
+        html: htmlValue
+      };
+
+      // Convert IMailroomEmailOutbound to FormData so we can also handle attachments
+      const mailroomOutboundKeys = Object.keys(outboundMail);
+      mailroomOutboundKeys.forEach((key) => {
+        formData.append(key, outboundMail[key]);
       });
 
+      // Don't forget any files
       fileControls.forEach((fileControl, i) => {
         if (fileControl.value && fileControl.value !== '') {
           formData.append(`file${i}`, fileControl.value, fileControl.value.name);
         }
       });
 
-      this.ss.sendEmail(formData).subscribe(() => {
+      this.ss.sendEmailAsMultipartFormdata(formData).subscribe(() => {
         this.contactForm.reset();
       });
     } else {

--- a/libs/kissingbug/ngx/src/lib/modules/core/pages/faq/faq.component.html
+++ b/libs/kissingbug/ngx/src/lib/modules/core/pages/faq/faq.component.html
@@ -6,8 +6,8 @@
     <div *ngIf="(pageContents | async)?.body">
       <tamu-gisc-kissingbug-dynamic-zone *ngFor="let item of (pageContents | async)?.body" [dataSource]="item"> </tamu-gisc-kissingbug-dynamic-zone>
     </div>
-    <div *ngFor="let question of (pageComponents | async)" class="qacontainer" [ngClass]="question.expanded ? 'qacontainer expanded' : 'qacontainer'" (click)="expandContainer(question)">
-      <div class="question" tabindex="0" aria-role="button">
+    <div *ngFor="let question of (pageComponents | async)" class="qacontainer" [ngClass]="question.expanded ? 'qacontainer expanded' : 'qacontainer'" >
+      <div class="question" tabindex="0" aria-role="button" (click)="expandContainer(question)">
         <p>{{ question.text }}</p>
       </div>
       <div class="answer">

--- a/libs/kissingbug/ngx/src/lib/modules/core/pages/faq/faq.component.html
+++ b/libs/kissingbug/ngx/src/lib/modules/core/pages/faq/faq.component.html
@@ -6,7 +6,7 @@
     <div *ngIf="(pageContents | async)?.body">
       <tamu-gisc-kissingbug-dynamic-zone *ngFor="let item of (pageContents | async)?.body" [dataSource]="item"> </tamu-gisc-kissingbug-dynamic-zone>
     </div>
-    <div *ngFor="let question of (pageComponents | async)" class="qacontainer" [ngClass]="question.expanded ? 'qacontainer expanded' : 'qacontainer'" >
+    <div *ngFor="let question of (pageComponents | async)" class="qacontainer" [ngClass]="question.expanded ? 'qacontainer expanded' : 'qacontainer'">
       <div class="question" tabindex="0" aria-role="button" (click)="expandContainer(question)">
         <p>{{ question.text }}</p>
       </div>

--- a/libs/kissingbug/ngx/src/lib/modules/core/pages/map/map.component.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/pages/map/map.component.ts
@@ -143,9 +143,7 @@ export class MapComponent implements OnInit, AfterViewInit {
             if (featureLayer) {
               this.map.remove(featureLayer);
             }
-
-            const countyLayer = observer[0];
-            const bugCounts = observer[1];
+            const [countyLayer, bugCounts] = observer;
 
             const featureData = countyLayer.features.map((feature) => {
               const found = bugCounts.find((element) => {
@@ -227,13 +225,10 @@ export class MapComponent implements OnInit, AfterViewInit {
 
                     if (graphics.length > 0) {
                       const graphic = graphics[0].graphic as esri.Graphic;
-
                       if (highlight) {
                         highlight.remove();
                       }
-
                       highlight = layerView.highlight(graphic);
-
                       this.currentCounty = {
                         name: graphic.attributes['NAME'],
                         count: graphic.attributes['Count']
@@ -277,12 +272,12 @@ export class MapComponent implements OnInit, AfterViewInit {
       };
     });
 
-    const renderer = ({
+    const renderer = {
       type: 'class-breaks',
       field: 'Count',
       defaultSymbol: { type: 'simple-fill' },
       classBreakInfos: bins
-    } as unknown) as esri.ClassBreaksRenderer;
+    } as unknown as esri.ClassBreaksRenderer;
 
     return renderer;
   }

--- a/libs/kissingbug/ngx/src/lib/modules/core/types/types.ts
+++ b/libs/kissingbug/ngx/src/lib/modules/core/types/types.ts
@@ -6,7 +6,6 @@ export type StrapiSingleTypes =
   | 'map'
   | 'team'
   | 'faq'
-  | 'resources'
   | 'knowledge'
   | 'contact'
   | 'navigation'


### PR DESCRIPTION
Updated `kissingbug-angular` to utilize the custom `emails` route on the Strapi backend; this works by POSTing the form from the Contact page to the `emails` route. This `email` controller will then forward the request to the appropriate `mailroom-nest` instance (dev, staging, prod).

Also cleaned up some code such as removed console.logs and whatnot. 