### PR TITLE
feat(gisday-bridge-nest): Initial commit of boilerplate

### DIFF
--- a/apps/gisday-bridge-nest/.eslintrc.json
+++ b/apps/gisday-bridge-nest/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/gisday-bridge-nest/jest.config.js
+++ b/apps/gisday-bridge-nest/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'gisday-bridge-nest',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/apps/gisday-bridge-nest'
+};

--- a/apps/gisday-bridge-nest/project.json
+++ b/apps/gisday-bridge-nest/project.json
@@ -1,0 +1,52 @@
+{
+  "root": "apps/gisday-bridge-nest",
+  "sourceRoot": "apps/gisday-bridge-nest/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/node:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/gisday-bridge-nest",
+        "main": "apps/gisday-bridge-nest/src/main.ts",
+        "tsConfig": "apps/gisday-bridge-nest/tsconfig.app.json",
+        "assets": ["apps/gisday-bridge-nest/src/assets"]
+      },
+      "configurations": {
+        "production": {
+          "optimization": true,
+          "extractLicenses": true,
+          "inspect": false,
+          "fileReplacements": [
+            {
+              "replace": "apps/gisday-bridge-nest/src/environments/environment.ts",
+              "with": "apps/gisday-bridge-nest/src/environments/environment.prod.ts"
+            }
+          ]
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nrwl/node:execute",
+      "options": {
+        "buildTarget": "gisday-bridge-nest:build"
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["apps/gisday-bridge-nest/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/apps/gisday-bridge-nest"],
+      "options": {
+        "jestConfig": "apps/gisday-bridge-nest/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/gisday-bridge-nest/src/app/app.controller.spec.ts
+++ b/apps/gisday-bridge-nest/src/app/app.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let app: TestingModule;
+
+  beforeAll(async () => {
+    app = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService]
+    }).compile();
+  });
+
+  describe('getData', () => {
+    it('should return "Welcome to gisday-bridge-nest!"', () => {
+      const appController = app.get<AppController>(AppController);
+      expect(appController.getData()).toEqual({ message: 'Welcome to gisday-bridge-nest!' });
+    });
+  });
+});

--- a/apps/gisday-bridge-nest/src/app/app.controller.ts
+++ b/apps/gisday-bridge-nest/src/app/app.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getData() {
+    return this.appService.getData();
+  }
+}

--- a/apps/gisday-bridge-nest/src/app/app.module.ts
+++ b/apps/gisday-bridge-nest/src/app/app.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService]
+})
+export class AppModule {}

--- a/apps/gisday-bridge-nest/src/app/app.service.spec.ts
+++ b/apps/gisday-bridge-nest/src/app/app.service.spec.ts
@@ -1,0 +1,21 @@
+import { Test } from '@nestjs/testing';
+
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeAll(async () => {
+    const app = await Test.createTestingModule({
+      providers: [AppService]
+    }).compile();
+
+    service = app.get<AppService>(AppService);
+  });
+
+  describe('getData', () => {
+    it('should return "Welcome to gisday-bridge-nest!"', () => {
+      expect(service.getData()).toEqual({ message: 'Welcome to gisday-bridge-nest!' });
+    });
+  });
+});

--- a/apps/gisday-bridge-nest/src/app/app.service.ts
+++ b/apps/gisday-bridge-nest/src/app/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getData(): { message: string } {
+    return { message: 'Welcome to gisday-bridge-nest!' };
+  }
+}

--- a/apps/gisday-bridge-nest/src/environments/environment.prod.ts
+++ b/apps/gisday-bridge-nest/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/apps/gisday-bridge-nest/src/environments/environment.ts
+++ b/apps/gisday-bridge-nest/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false
+};

--- a/apps/gisday-bridge-nest/src/main.ts
+++ b/apps/gisday-bridge-nest/src/main.ts
@@ -1,0 +1,20 @@
+/**
+ * This is not a production server yet!
+ * This is only a minimal backend to get started.
+ */
+
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app/app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const globalPrefix = 'api';
+  app.setGlobalPrefix(globalPrefix);
+  const port = process.env.PORT || 3333;
+  await app.listen(port);
+  Logger.log(`🚀 Application is running on: http://localhost:${port}/${globalPrefix}`);
+}
+
+bootstrap();

--- a/apps/gisday-bridge-nest/tsconfig.app.json
+++ b/apps/gisday-bridge-nest/tsconfig.app.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"],
+    "emitDecoratorMetadata": true,
+    "target": "es2015"
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/apps/gisday-bridge-nest/tsconfig.json
+++ b/apps/gisday-bridge-nest/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/gisday-bridge-nest/tsconfig.spec.json
+++ b/apps/gisday-bridge-nest/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/gisday/bridge/.babelrc
+++ b/libs/gisday/bridge/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/gisday/bridge/.eslintrc.json
+++ b/libs/gisday/bridge/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/gisday/bridge/README.md
+++ b/libs/gisday/bridge/README.md
@@ -1,0 +1,7 @@
+# gisday-bridge
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test gisday-bridge` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/gisday/bridge/jest.config.js
+++ b/libs/gisday/bridge/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'gisday-bridge',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/gisday/bridge'
+};

--- a/libs/gisday/bridge/project.json
+++ b/libs/gisday/bridge/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/gisday/bridge",
+  "sourceRoot": "libs/gisday/bridge/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/gisday/bridge/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/gisday/bridge"],
+      "options": {
+        "jestConfig": "libs/gisday/bridge/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/gisday/bridge/src/index.ts
+++ b/libs/gisday/bridge/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/gisday-bridge.module';

--- a/libs/gisday/bridge/src/lib/gisday-bridge.module.ts
+++ b/libs/gisday/bridge/src/lib/gisday-bridge.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [],
+  providers: [],
+  exports: []
+})
+export class GisdayBridgeModule {}

--- a/libs/gisday/bridge/tsconfig.json
+++ b/libs/gisday/bridge/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/gisday/bridge/tsconfig.lib.json
+++ b/libs/gisday/bridge/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/gisday/bridge/tsconfig.spec.json
+++ b/libs/gisday/bridge/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -62,6 +62,7 @@
       "@tamu-gisc/dev-tools/responsive": ["libs/dev-tools/responsive/src/index.ts"],
       "@tamu-gisc/geoservices/data-access": ["libs/geoservices/data-access/src/index.ts"],
       "@tamu-gisc/geoservices/ngx": ["libs/geoservices/ngx/src/index.ts"],
+      "@tamu-gisc/gisday/bridge": ["libs/gisday/bridge/src/index.ts"],
       "@tamu-gisc/gisday/competitions/data-api": ["libs/gisday/competitions/data-api/src/index.ts"],
       "@tamu-gisc/gisday/competitions/ngx/common": ["libs/gisday/competitions/ngx/common/src/index.ts"],
       "@tamu-gisc/gisday/competitions/ngx/core": ["libs/gisday/competitions/ngx/core/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -57,6 +57,7 @@
     "geoservices-ngx": "libs/geoservices/ngx",
     "gisday-angular": "apps/gisday-angular",
     "gisday-angular-e2e": "apps/gisday-angular-e2e",
+    "gisday-bridge": "libs/gisday/bridge",
     "gisday-bridge-nest": "apps/gisday-bridge-nest",
     "gisday-competitions-angular": "apps/gisday-competitions-angular",
     "gisday-competitions-angular-e2e": "apps/gisday-competitions-angular-e2e",

--- a/workspace.json
+++ b/workspace.json
@@ -57,6 +57,7 @@
     "geoservices-ngx": "libs/geoservices/ngx",
     "gisday-angular": "apps/gisday-angular",
     "gisday-angular-e2e": "apps/gisday-angular-e2e",
+    "gisday-bridge-nest": "apps/gisday-bridge-nest",
     "gisday-competitions-angular": "apps/gisday-competitions-angular",
     "gisday-competitions-angular-e2e": "apps/gisday-competitions-angular-e2e",
     "gisday-competitions-data-api": "libs/gisday/competitions/data-api",


### PR DESCRIPTION
Decided to integrate my bridge conversion application into the monorepo so I don't need to maintain two different sets of GIS Day entities as this was proving to be quite the headache. 

Created:
- app/gisday-bridge-nest
- lib/gisday/bridge