### PR TITLE
feat(gisday-competitions): 2022 season changes

### DIFF
--- a/apps/gisday-competitions-angular/ngsw-config.json
+++ b/apps/gisday-competitions-angular/ngsw-config.json
@@ -35,7 +35,7 @@
   "dataGroups": [
     {
       "name": "api",
-      "urls": ["https://gisday.tamu.edu/Rest/**"],
+      "urls": ["https://txgisday.org/Rest/**"],
       "cacheConfig": {
         "maxSize": 10,
         "maxAge": "5m",

--- a/libs/gisday/competitions/data-api/src/lib/entities/all.entities.ts
+++ b/libs/gisday/competitions/data-api/src/lib/entities/all.entities.ts
@@ -80,6 +80,9 @@ export class CompetitionSeason extends GISDayCompetitionBaseEntity implements IC
   @Column()
   public year: string;
 
+  @Column({ default: false })
+  public active: boolean;
+
   @OneToOne(() => CompetitionForm, { cascade: true, nullable: true })
   @JoinColumn()
   public form?: CompetitionForm;

--- a/libs/gisday/competitions/data-api/src/lib/form/form.controller.ts
+++ b/libs/gisday/competitions/data-api/src/lib/form/form.controller.ts
@@ -11,6 +11,17 @@ export class FormController extends BaseController<CompetitionForm> {
     super(service);
   }
 
+  @Get('active')
+  public async getFormForActiveSeason() {
+    const season = await this.service.getActiveSeason();
+
+    if (season) {
+      return season;
+    } else {
+      throw new NotFoundException();
+    }
+  }
+
   @Get(':year')
   public async getForm(@Param() params) {
     const season = await this.service.getSeason(params.year);

--- a/libs/gisday/competitions/data-api/src/lib/form/form.service.ts
+++ b/libs/gisday/competitions/data-api/src/lib/form/form.service.ts
@@ -27,4 +27,13 @@ export class FormService extends BaseService<CompetitionForm> {
       ]
     });
   }
+
+  public async getActiveSeason() {
+    return this.seasonRepo.findOne({
+      relations: ['form'],
+      where: {
+        active: true
+      }
+    });
+  }
 }

--- a/libs/gisday/competitions/data-api/src/lib/leaderboard/leaderboard.controller.ts
+++ b/libs/gisday/competitions/data-api/src/lib/leaderboard/leaderboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get } from '@nestjs/common';
 
 import { CompetitionSubmission } from '../entities/all.entities';
 import { BaseController } from '../_base/base.controller';
@@ -10,8 +10,18 @@ export class LeaderboardController extends BaseController<CompetitionSubmission>
     super(service);
   }
 
+  @Get('/season')
+  public getLeaderBoardForSeason(@Body() { season }) {
+    return this.service.getLeaderBoardItemsForSeason(season);
+  }
+
+  @Get('/all')
+  public get() {
+    return this.service.getAllLeaderboardItems();
+  }
+
   @Get()
   public getLeaderboard() {
-    return this.service.getAllLeaderboardItems();
+    return this.service.getLeaderBoardForActiveSeason();
   }
 }

--- a/libs/gisday/competitions/data-api/src/lib/leaderboard/leaderboard.service.ts
+++ b/libs/gisday/competitions/data-api/src/lib/leaderboard/leaderboard.service.ts
@@ -22,4 +22,36 @@ export class LeaderboardService extends BaseService<CompetitionSubmission> {
       'SELECT RIGHT(userGuid, 4) as [identity], userGuid as guid, COUNT(userGuid) as points FROM submissions GROUP BY userGuid ORDER BY points DESC'
     );
   }
+
+  public async getLeaderBoardForActiveSeason() {
+    const subs = await this.submissionRepo
+      .createQueryBuilder('submissions')
+      .leftJoin('submissions.season', 'season')
+      .select('RIGHT(submissions.userGuid, 4)', 'identity')
+      .addSelect('submissions.userGuid', 'guid')
+      .addSelect('COUNT(submissions.userGuid)', 'points')
+      .groupBy('submissions.userGuid')
+      .orderBy('points', 'DESC')
+      .where('season.active = :seasonActivity')
+      .setParameter('seasonActivity', true)
+      .getRawMany();
+
+    return subs;
+  }
+
+  public async getLeaderBoardItemsForSeason(season?: string) {
+    const subs = await this.submissionRepo
+      .createQueryBuilder('submissions')
+      .leftJoin('submissions.season', 'season')
+      .select('RIGHT(submissions.userGuid, 4)', 'identity')
+      .addSelect('submissions.userGuid', 'guid')
+      .addSelect('COUNT(submissions.userGuid)', 'points')
+      .groupBy('submissions.userGuid')
+      .orderBy('points', 'DESC')
+      .where('season.year = :season')
+      .setParameter('season', season)
+      .getRawMany();
+
+    return subs;
+  }
 }

--- a/libs/gisday/competitions/data-api/src/lib/map/map.controller.ts
+++ b/libs/gisday/competitions/data-api/src/lib/map/map.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get } from '@nestjs/common';
 
 import { BaseController } from '../_base/base.controller';
 import { CompetitionSubmission } from '../entities/all.entities';
@@ -11,12 +11,12 @@ export class MapController extends BaseController<CompetitionSubmission> {
   }
 
   @Get()
-  public getLocations() {
-    return this.service.getLocations();
+  public getLocations(@Body() { season }) {
+    return this.service.getLocations(season);
   }
 
   @Get('geojson')
-  public getFeatureCollection() {
-    return this.service.getLocations(true);
+  public getFeatureCollection(@Body() { season }) {
+    return this.service.getLocations(season, true);
   }
 }

--- a/libs/gisday/competitions/data-api/src/lib/season/season.controller.ts
+++ b/libs/gisday/competitions/data-api/src/lib/season/season.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Body, Controller, Get, Param, Put } from '@nestjs/common';
 
 import { CompetitionSeason } from '../entities/all.entities';
 import { GetSeasonStatisticsDto } from '../dtos/dtos';
@@ -14,5 +14,15 @@ export class SeasonController extends BaseController<CompetitionSeason> {
   @Get(':guid/statistics')
   public getStatisticsForSeason(@Param() params: GetSeasonStatisticsDto) {
     return this.service.getSeasonStatistics(params.guid);
+  }
+
+  @Put('/disable/all')
+  public disableAllSeasons() {
+    return this.service.disableAllSeasons();
+  }
+
+  @Put('/enable')
+  public setActiveSeason(@Body() { guid }) {
+    return this.service.setActiveSeason(guid);
   }
 }

--- a/libs/gisday/competitions/data-api/src/lib/season/season.service.ts
+++ b/libs/gisday/competitions/data-api/src/lib/season/season.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, InternalServerErrorException, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { getRepository, Repository } from 'typeorm';
 
@@ -56,5 +56,70 @@ export class SeasonService extends BaseService<CompetitionSeason> {
       total,
       breakdown: dictionary
     };
+  }
+
+  public async setActiveSeason(seasonGuid: string): Promise<CompetitionSeason> {
+    const currentActiveSeason = await this.seasonRepo.findOne({
+      where: {
+        active: true
+      }
+    });
+
+    // If there is a currently active season, disable it first.
+    if (currentActiveSeason) {
+      // If the current active season shares the same input season guid,
+      // skip the update operation and return early.
+      if (currentActiveSeason.guid === seasonGuid) {
+        return currentActiveSeason;
+      }
+
+      try {
+        currentActiveSeason.active = false;
+
+        await currentActiveSeason.save();
+      } catch (e) {
+        throw new InternalServerErrorException('Cannot disable active season.');
+      }
+    }
+
+    const requestedSeasonToActivate = await this.seasonRepo.findOne({
+      where: {
+        guid: seasonGuid
+      }
+    });
+
+    if (requestedSeasonToActivate) {
+      requestedSeasonToActivate.active = true;
+
+      try {
+        return await requestedSeasonToActivate.save();
+      } catch (e) {
+        throw new InternalServerErrorException('Cannot enable requested season.');
+      }
+    } else {
+      throw new UnprocessableEntityException();
+    }
+  }
+
+  public async disableAllSeasons(): Promise<Array<CompetitionSeason>> {
+    const activeSeasons = await this.seasonRepo.find({
+      where: {
+        active: true
+      }
+    });
+
+    if (activeSeasons) {
+      const queries = activeSeasons.map((season) => {
+        season.active = false;
+
+        return season.save();
+      });
+
+      try {
+        return Promise.all(queries);
+      } catch (e) {
+        throw new InternalServerErrorException('Could not deactivate seasons.');
+      }
+    }
   }
 }

--- a/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
+++ b/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
@@ -5,7 +5,7 @@
     <div class="block-input">
       <div class="block-input-presentation" *ngIf="(file | async) === undefined">
         <div class="material-icons">photo_camera</div>
-        <p class="title">Upload Sign Photo</p>
+        <p class="title">Upload Photo</p>
         <p class="description">Tap to take a picture</p>
       </div>
 
@@ -17,22 +17,17 @@
       <p class="label">{{c.get('title').value}}</p>
       <div class="statused-form-input column">
         <div [ngSwitch]="c.get('type').value">
-          <tamu-gisc-select [formControl]="c.get('value')" [valueTemplate]="'value'" [displayTemplate]="'name'"
-            [data]="c.get('options').value" *ngSwitchCase="'select'"></tamu-gisc-select>
+          <tamu-gisc-select [formControl]="c.get('value')" [valueTemplate]="'value'" [displayTemplate]="'name'" [data]="c.get('options').value" *ngSwitchCase="'select'"></tamu-gisc-select>
           <tamu-gisc-textbox [formControl]="c.get('value')" *ngSwitchCase="'text'"></tamu-gisc-textbox>
           <div *ngSwitchDefault>This question does not have a valid input type.</div>
         </div>
       </div>
     </div>
 
-    <p class="rules-text">By submitting, you agree that you have read and understand the competition <a
-        href="https://txgisday.org/competitions/vgi/" target="_blank" rel="noopener noreferrer">rules and
-        guidelines.</a></p>
+    <p class="rules-text">By submitting, you agree that you have read and understand the competition <a href="https://txgisday.org/competitions/vgi/" target="_blank" rel="noopener noreferrer">rules and guidelines.</a></p>
 
-    <div class="button" role="button" (click)="submitResponse()"
-      [class.disabled]="(formValid | async) !== true || (submissionStatus | async) === 1">
-      <div class="progress" *ngIf="(submissionStatus | async) !== -1"
-        [style.width.%]="(submissionProgress | async) * 100"></div>
+    <div class="button" role="button" (click)="submitResponse()" [class.disabled]="(formValid | async) !== true || (submissionStatus | async) === 1">
+      <div class="progress" *ngIf="(submissionStatus | async) !== -1" [style.width.%]="(submissionProgress | async) * 100"></div>
       <div class="status-text" [ngSwitch]="(submissionStatus | async)">
         <div *ngSwitchCase="1">Submitting...</div>
         <div *ngSwitchCase="-1">Error!</div>

--- a/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
+++ b/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
@@ -17,17 +17,22 @@
       <p class="label">{{c.get('title').value}}</p>
       <div class="statused-form-input column">
         <div [ngSwitch]="c.get('type').value">
-          <tamu-gisc-select [formControl]="c.get('value')" [valueTemplate]="'value'" [displayTemplate]="'name'" [data]="c.get('options').value" *ngSwitchCase="'select'"></tamu-gisc-select>
+          <tamu-gisc-select [formControl]="c.get('value')" [valueTemplate]="'value'" [displayTemplate]="'name'"
+            [data]="c.get('options').value" *ngSwitchCase="'select'"></tamu-gisc-select>
           <tamu-gisc-textbox [formControl]="c.get('value')" *ngSwitchCase="'text'"></tamu-gisc-textbox>
           <div *ngSwitchDefault>This question does not have a valid input type.</div>
         </div>
       </div>
     </div>
 
-    <p class="rules-text">By submitting, you agree that you have read and understand the competition <a href="https://txgisday.org/competitions/vgi/" target="_blank" rel="noopener noreferrer">rules and guidelines.</a></p>
+    <p class="rules-text">By submitting, you agree that you have read and understand the competition <a
+        href="https://txgisday.org/competitions/vgi/" target="_blank" rel="noopener noreferrer">rules and
+        guidelines.</a></p>
 
-    <div class="button" role="button" (click)="submitResponse()" [class.disabled]="(formValid | async) !== true || (submissionStatus | async) === 1">
-      <div class="progress" *ngIf="(submissionStatus | async) !== -1" [style.width.%]="(submissionProgress | async) * 100"></div>
+    <div class="button" role="button" (click)="submitResponse()"
+      [class.disabled]="(formValid | async) !== true || (submissionStatus | async) === 1">
+      <div class="progress" *ngIf="(submissionStatus | async) !== -1"
+        [style.width.%]="(submissionProgress | async) * 100"></div>
       <div class="status-text" [ngSwitch]="(submissionStatus | async)">
         <div *ngSwitchCase="1">Submitting...</div>
         <div *ngSwitchCase="-1">Error!</div>

--- a/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.ts
+++ b/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.ts
@@ -90,7 +90,13 @@ export class SubmissionComponent implements OnInit, OnChanges, OnDestroy {
           })
       );
 
-      this.formValid = combineLatest([this.form.statusChanges, this.file.pipe(filter((e) => e !== undefined))]).pipe(
+      // Some seasons will not request anything more than an image for the survey. In this case, the form control size will be zero and there
+      // will be no form controls to ever emit form statusChanges. If that's the case, emit a VALID state for the form statusChanges so the
+      // only other thing to check is the image input change.
+      this.formValid = combineLatest([
+        this.form.controls.length > 0 ? this.form.statusChanges : of('VALID'),
+        this.file.pipe(filter((e) => e !== undefined))
+      ]).pipe(
         map(([formValid, fileValid]) => {
           return formValid === 'VALID' && fileValid !== undefined;
         })

--- a/libs/gisday/competitions/ngx/core/src/lib/pages/public/map/components/map.component.ts
+++ b/libs/gisday/competitions/ngx/core/src/lib/pages/public/map/components/map.component.ts
@@ -29,6 +29,9 @@ export class MapComponent implements OnInit {
           wkid: 102100
         },
         zoom: 15,
+        constraints: {
+          maxZoom: 18
+        },
         popup: {
           dockOptions: {
             buttonEnabled: false,
@@ -66,6 +69,50 @@ export class MapComponent implements OnInit {
                 size: 10,
                 color: '#ffc5c5'
               }
+            }
+          }
+        },
+        {
+          type: 'feature',
+          id: 'water-meter-layer',
+          title: 'Water Meter Rough Locations',
+          url: `https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/WaterMetersTAMU/FeatureServer/0`,
+          listMode: 'show',
+          loadOnInit: true,
+          visible: true,
+          native: {
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'simple-marker',
+                style: 'circle',
+                size: 10,
+                color: '#42A5F5',
+                outline: {
+                  width: '4',
+                  color: '#90CAF9'
+                }, 
+              },
+            }, 
+            featureReduction: {
+              type: 'cluster', 
+              labelingInfo: [
+                {
+                  deconflictionStrategy: "none",
+                  labelExpressionInfo: {
+                    expression: "Text($feature.cluster_count, '#,###')"
+                  },
+                  symbol: {
+                    type: "text",
+                    color: "#E3F2FD",
+                    font: {
+                      family: "Noto Sans",
+                      size: "14px"
+                    }
+                  },
+                  labelPlacement: "center-center"
+                }
+              ],
             }
           }
         }

--- a/libs/gisday/competitions/ngx/core/src/lib/pages/public/public.component.html
+++ b/libs/gisday/competitions/ngx/core/src/lib/pages/public/public.component.html
@@ -1,5 +1,7 @@
 <div id="mobile-app-viewport">
-  <router-outlet></router-outlet>
+  <div id="content-viewport">
+    <router-outlet></router-outlet>
+  </div>
 
   <tamu-gisc-mobile-navigation-tab>
     <tamu-gisc-mobile-nav-tab [route]="'map'" [icon]="'map'" [label]="'Map'"></tamu-gisc-mobile-nav-tab>

--- a/libs/gisday/competitions/ngx/core/src/lib/pages/public/public.component.scss
+++ b/libs/gisday/competitions/ngx/core/src/lib/pages/public/public.component.scss
@@ -14,3 +14,10 @@
   display: flex;
   background: rgba(250, 250, 250, 0.31);
 }
+
+#content-viewport {
+  @include flexbox();
+  @include flex-grow(1);
+  @include flex-direction(column);
+  overflow: scroll;
+}

--- a/libs/gisday/competitions/ngx/core/src/lib/pages/public/submission/components/submission.component.ts
+++ b/libs/gisday/competitions/ngx/core/src/lib/pages/public/submission/components/submission.component.ts
@@ -16,7 +16,6 @@ export class SubmissionComponent implements OnInit {
   constructor(private readonly fs: FormService) {}
 
   public ngOnInit() {
-    const year = new Date().getFullYear().toString();
-    this.model = this.fs.getFormForSeason(year).pipe(pluck('model'));
+    this.model = this.fs.getFormForActiveSeason().pipe(pluck('model'));
   }
 }

--- a/libs/gisday/competitions/ngx/data-access/src/lib/form/form.service.ts
+++ b/libs/gisday/competitions/ngx/data-access/src/lib/form/form.service.ts
@@ -21,6 +21,21 @@ export class FormService {
     this.resource = `${this.env.value('api_url')}/form`;
   }
 
+  public getFormForActiveSeason(): Observable<CompetitionForm> {
+    return this.http.get<CompetitionSeason>(`${this.resource}/active`).pipe(
+      pluck('form'),
+      catchError((err) => {
+        this.ns.toast({
+          id: 'submission-form-load-failure',
+          title: 'Failed to Load Season Form',
+          message: `There was an error loading the competitions submission form for this season. Please try again later. (${err.status})`
+        });
+
+        throw new Error(`Failed loading season form.`);
+      })
+    );
+  }
+
   public getFormForSeason(seasonName: string): Observable<CompetitionForm> {
     return this.http.get<CompetitionSeason>(`${this.resource}/${seasonName}`).pipe(
       pluck('form'),

--- a/libs/sass/modules/_mobile_app.scss
+++ b/libs/sass/modules/_mobile_app.scss
@@ -17,7 +17,6 @@
 
   // Target the kprojected route component
   & > :nth-child(2) {
-    @include flex-grow(1);
     // Find a way to put this in a base class. Not all views need padding (e.g. maps)
     // padding: 1rem;
     overflow-y: auto;


### PR DESCRIPTION
- Add the ability to set an active season. Data endpoints default to the currently active season for leaderboard and submission locations. This makes it, so downstream consumers don't have to update with a season id if they are just interested in the latest.
- Add clustering for the reference layer