### PR TITLE
fix(veoride-data-compiler-node): Import paths for old node versions

### DIFF
--- a/apps/veoride-data-compiler-node/src/main.ts
+++ b/apps/veoride-data-compiler-node/src/main.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { createConnection } from 'typeorm';
-import { readdir, stat, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readdir, stat, rm } from 'fs/promises';
+import { join } from 'path';
 
 import { Trip, StatusChange, DataTask, Log } from '@tamu-gisc/veoride/common/entities';
 import { VeorideDataCompilerManager } from '@tamu-gisc/veoride/data-compiler';


### PR DESCRIPTION
New import paths don't work in older NodeJS versions.