### PR TITLE
fix(ui-kits-forms): Initial value set and changes

### DIFF
--- a/libs/ui-kits/ngx/forms/src/lib/components/checkbox-group/checkbox-group.component.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/components/checkbox-group/checkbox-group.component.ts
@@ -158,6 +158,8 @@ export class CheckboxGroupComponent implements OnInit, OnDestroy, AfterContentIn
   }
 
   public writeValue(value) {
+    if (value === null) return;
+
     this.value = [...value];
 
     this.setChildrenValue();

--- a/libs/ui-kits/ngx/forms/src/lib/components/select/select.component.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/components/select/select.component.ts
@@ -39,6 +39,8 @@ export class SelectComponent<T extends object> implements ControlValueAccessor {
 
   public set value(value: T) {
     this._value = value === null || value === undefined || value === ('undefined' as unknown) ? undefined : value;
+    this._onChange(value === null || value === undefined || value === ('undefined' as unknown) ? undefined : value);
+    this._onTouched();
     this.cd.markForCheck();
   }
 
@@ -82,12 +84,11 @@ export class SelectComponent<T extends object> implements ControlValueAccessor {
 
   constructor(private cd: ChangeDetectorRef) {}
 
-  private _onChange = (value: T) => {
-    return value;
-  };
-  private _onTouched = () => {
-    return;
-  };
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private _onChange = (value: T) => {};
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private _onTouched = () => {};
 
   /**
    * Responsible for emitting the model changed event to the parent component.

--- a/libs/ui-kits/ngx/forms/src/lib/components/textbox/textbox.component.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/components/textbox/textbox.component.ts
@@ -23,7 +23,7 @@ export class TextboxComponent extends AbstractValueAccessorFormComponent<string>
    * Defaults to `default`
    */
   @Input()
-  public formControlName: 'default';
+  public formControlName = 'default';
 
   /**
    * Responsible for rendering the correct input element (input vs textarea), and setting its associated type attribute.
@@ -57,3 +57,4 @@ export class TextboxComponent extends AbstractValueAccessorFormComponent<string>
   @Input()
   public floatLabel = false;
 }
+


### PR DESCRIPTION
Fixes several underlying issues with form inputs, including failure to set value in certain conditions (null) and to update children's state when value is set through the forms API.

It also includes a fix in preparation for strict templates relating to default input values.

