### PR TITLE
fix(aggiemap-angular): Disable bus route list

### DIFF
--- a/apps/aggiemap-angular/src/app/app.module.ts
+++ b/apps/aggiemap-angular/src/app/app.module.ts
@@ -16,7 +16,7 @@ import * as WebFont from 'webfontloader';
 
 WebFont.load({
   google: {
-    families: ['Material Icons', 'Material Icons', 'Open Sans:300,400,600', 'Oswald:200,300,400,500']
+    families: ['Material Icons', 'Material Icons Outlined', 'Open Sans:300,400,600', 'Oswald:200,300,400,500']
   }
 });
 
@@ -38,3 +38,4 @@ WebFont.load({
   ]
 })
 export class AppModule {}
+

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -31,7 +31,7 @@
       </div>
 
       <div class="overlay-zone bottom right">
-        <div routerLink="/map/m/bus" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons">directions_bus</span></div>
+        <!-- <div routerLink="/map/m/bus" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons">directions_bus</span></div> -->
       </div>
     </div>
   </tamu-gisc-esri-map>
@@ -51,3 +51,4 @@
     <p class="phrase"></p>
   </div>
 </div>
+

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
@@ -3,12 +3,6 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <!-- <tamu-gisc-bus-list [selectionAction]="'in-place'"></tamu-gisc-bus-list> -->
-
-  <div class="bus-routes-notice leader-2">
-    <span class="material-icons-outlined trailer-1">info</span>
-    <p>Bus routes are currently unavailable on Aggiemap. We apologize for the inconvenience.</p>
-    <p>Visit <a href="https://transport.tamu.edu/busroutes/?utm_source=aggiemap" target="_blank">Transportation Services</a> for bus routes.</p>
-  </div>
+  <tamu-gisc-bus-list [selectionAction]="'in-place'"></tamu-gisc-bus-list>
 </div>
 

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.html
@@ -3,5 +3,12 @@
 </div>
 
 <div class="sidebar-component-content-container">
-  <tamu-gisc-bus-list [selectionAction]="'in-place'"></tamu-gisc-bus-list>
+  <!-- <tamu-gisc-bus-list [selectionAction]="'in-place'"></tamu-gisc-bus-list> -->
+
+  <div class="bus-routes-notice leader-2">
+    <span class="material-icons-outlined trailer-1">info</span>
+    <p>Bus routes are currently unavailable on Aggiemap. We apologize for the inconvenience.</p>
+    <p>Visit <a href="https://transport.tamu.edu/busroutes/?utm_source=aggiemap" target="_blank">Transportation Services</a> for bus routes.</p>
+  </div>
 </div>
+

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
@@ -1,15 +1,2 @@
 @import 'libs/sass/components/sidebar';
 
-.bus-routes-notice {
-  @include flexbox();
-  @include align-items(center);
-  @include flex-direction(column);
-
-  text-align: center;
-
-  span {
-    font-size: 2rem;
-    color: #ef5350;
-  }
-}
-

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component.scss
@@ -1,1 +1,15 @@
 @import 'libs/sass/components/sidebar';
+
+.bus-routes-notice {
+  @include flexbox();
+  @include align-items(center);
+  @include flex-direction(column);
+
+  text-align: center;
+
+  span {
+    font-size: 2rem;
+    color: #ef5350;
+  }
+}
+

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="(routes | async) === null" class="flex flex-column justify-center align-center leader-2 trailer-2">
+<!-- <div *ngIf="(routes | async) === null" class="flex flex-column justify-center align-center leader-2 trailer-2">
   <div class="spinning-loader"></div>
 </div>
 
@@ -8,4 +8,11 @@
   <div class="routes">
     <tamu-gisc-bus-route *ngFor="let route of group?.items" [route]="route" [selection]="selectionAction"></tamu-gisc-bus-route>
   </div>
+</div> -->
+
+<div class="bus-routes-notice leader-1 trailer-2">
+  <span class="material-icons-outlined trailer-1">info</span>
+  <p>Bus routes are currently unavailable on Aggiemap. We apologize for the inconvenience.</p>
+  <p>Visit <a href="https://transport.tamu.edu/busroutes/?utm_source=aggiemap" target="_blank">Transportation Services</a> for bus routes.</p>
 </div>
+

--- a/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.scss
+++ b/libs/aggiemap/ngx/ui/shared/src/lib/modules/transportation/components/bus-list/bus-list.component.scss
@@ -15,3 +15,16 @@
   @include flex-wrap(wrap);
   @include justify-content(space-around);
 }
+
+.bus-routes-notice {
+  @include flexbox();
+  @include align-items(center);
+  @include flex-direction(column);
+
+  text-align: center;
+
+  span {
+    font-size: 2rem;
+    color: #ef5350;
+  }
+}


### PR DESCRIPTION
Changes in transportation services API have caused the list not to load. 

It's been replaced with notice until resolved.

<img width="410" alt="image" src="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/assets/3969818/78602959-a806-4b66-8ff0-1b84d259a309">
