### PR TITLE
fix(ci):  Tag pipeline stage lastSha resolution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,9 @@ stages:
           buildType: production
 
   - stage: Tag
-    dependsOn: Build
+    dependsOn:
+      - Setup
+      - Build
     variables:
       baseSha: $[stageDependencies.Setup.Last_SHA.outputs['last_successful_sha.BASE_SHA']]
     jobs:


### PR DESCRIPTION
Fixes the add tags stage not resolving the correct affected apps because `lastSha` resolved to undefined due to it not being dependent on the Setup stage that exports that variable.

Did not have access to the `lastSha` output from setup, which is necessary to determine tags