### PR TITLE
ci: Bump actions to move away from node16 base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.17.0'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: '**/node_modules'
@@ -37,7 +37,8 @@ jobs:
           cp -r package.json package-lock.json scripts/ci/tokenSubstitute.sh dist/
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: dist/
+          include-hidden-files: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,16 +10,16 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.17.0'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: npm-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: 'Download artifacts'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: main.yml
           name: ${{ github.event.pull_request.head.sha }}
@@ -42,14 +42,14 @@ jobs:
         image: ${{ fromJson(needs.list-publishable.outputs.matrix) }}
     steps:
       - name: 'Download artifacts'
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: main.yml
           name: ${{ github.event.pull_request.head.sha }}
           path: artifacts
 
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/TamuGeoInnovation/${{ matrix.image }}
           flavor: |
@@ -73,7 +73,7 @@ jobs:
           cp artifacts/package.json artifacts/package-lock.json artifacts/tokenSubstitute.sh artifacts/apps/${{ matrix.image }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./artifacts/apps/${{ matrix.image }}
           push: true


### PR DESCRIPTION
Node 16-based actions were deprecated and causing issues with all artifacts being uploaded, and I'm sure other effects. Updating all of them in one go