### PR TITLE
fix(gisday-angular): Presenter adding on new events

### DIFF
--- a/libs/gisday/platform/ngx/common/src/lib/modules/forms/components/events/event-add-edit-form/event-add-edit-form.component.ts
+++ b/libs/gisday/platform/ngx/common/src/lib/modules/forms/components/events/event-add-edit-form/event-add-edit-form.component.ts
@@ -202,6 +202,15 @@ export class EventAddEditFormComponent implements OnInit {
       shareReplay()
     );
 
+    const formSpeakerChanges = (this.eventSpeakers$ = this.form.get('speakers').valueChanges.pipe(
+      withLatestFrom(this.speakers$),
+      map(([speakerGuids, speakers]) => {
+        return speakerGuids.map((guid) => {
+          return speakers.find((speaker) => speaker.guid === guid);
+        });
+      })
+    ));
+
     if (this.type === 'edit') {
       this.entity$ = this.at.params.pipe(
         map((params) => {
@@ -217,14 +226,7 @@ export class EventAddEditFormComponent implements OnInit {
       );
 
       this.eventSpeakers$ = merge(
-        this.form.get('speakers').valueChanges.pipe(
-          withLatestFrom(this.speakers$),
-          map(([speakerGuids, speakers]) => {
-            return speakerGuids.map((guid) => {
-              return speakers.find((speaker) => speaker.guid === guid);
-            });
-          })
-        ),
+        formSpeakerChanges,
         this.entity$.pipe(
           map((event) => {
             return event.speakers;
@@ -251,6 +253,8 @@ export class EventAddEditFormComponent implements OnInit {
 
       this.selectedEventDateEnd$ = this.entity$.pipe(take(1), this._timeStringFromEvent$('endTime'), shareReplay());
     } else {
+      this.eventSpeakers$ = formSpeakerChanges;
+
       this.selectedEventDateStart$ = this._defaultTimeFromSelectedEvent$().pipe(
         this._applyTimeToForm('startTime'),
         shareReplay()


### PR DESCRIPTION
Fixes issue where it was not possible to add speakers to a new event. This was due to an un-initialized observable when the form component was in an "create" state.