### PR TITLE
feat(maps-feature-basemap): Add esri basemap gallery

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.ts
@@ -4,6 +4,7 @@ import { filter, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import { loadModules } from 'esri-loader';
 
+import { AggiemapBasemap } from '@tamu-gisc/maps/feature/basemap';
 import { LayerSource } from '@tamu-gisc/common/types';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { MapServiceInstance, MapConfig } from '@tamu-gisc/maps/esri';
@@ -56,24 +57,7 @@ export class MapComponent implements OnInit, OnDestroy {
 
       this.config.next({
         basemap: {
-          basemap: {
-            baseLayers: [
-              {
-                type: 'TileLayer',
-                url: experimentSettings.basemap_url ? experimentSettings.basemap_url : this._connections['basemapUrl'],
-                spatialReference: {
-                  wkid: 102100
-                },
-                listMode: 'hide',
-                visible: true,
-                minScale: 100000,
-                maxScale: 0,
-                title: 'Base Map'
-              }
-            ],
-            id: 'aggie_basemap',
-            title: 'Aggie Basemap'
-          }
+          basemap: AggiemapBasemap
         },
         view: {
           mode: '2d',

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -41,7 +41,8 @@ import {
   AggiemapSidebarComponent,
   SidebarReferenceComponent,
   SidebarTripPlannerComponent,
-  SidebarBusListComponent
+  SidebarBusListComponent,
+  SidebarSettingsComponent
 } from '@tamu-gisc/aggiemap/ngx/ui/desktop';
 import {
   AggiemapNgxUiMobileModule,
@@ -56,6 +57,7 @@ import {
 } from '@tamu-gisc/aggiemap/ngx/ui/mobile';
 
 import { AggiemapNgxPopupsModule } from '@tamu-gisc/aggiemap/ngx/popups';
+import { BasemapGalleryComponent } from '@tamu-gisc/maps/feature/basemap';
 
 import { MapComponent } from './map.component';
 
@@ -78,7 +80,8 @@ const routes: Routes = [
           { path: 'bus', component: SidebarBusListComponent },
           { path: 'trip', component: SidebarTripPlannerComponent },
           { path: 'trip/options', component: TripPlannerOptionsComponent },
-          { path: 'experiments', component: ExperimentsListComponent }
+          { path: 'experiments', component: ExperimentsListComponent },
+          { path: 'settings', component: SidebarSettingsComponent }
         ]
       },
       {
@@ -110,7 +113,8 @@ const routes: Routes = [
             children: [
               { path: '', component: MainMobileSidebarComponent },
               { path: 'legend', component: LegendComponent },
-              { path: 'layers', component: LayerListComponent }
+              { path: 'layers', component: LayerListComponent },
+              { path: 'basemap', component: BasemapGalleryComponent }
             ]
           },
           {

--- a/libs/aggiemap/ngx/ui/desktop/src/index.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/modules/sidebar/sidebar.component';
 export * from './lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component';
 export * from './lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component';
 export * from './lib/modules/sidebar/components/sidebar-bus-list/sidebar-bus-list.component';
+export * from './lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component';

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -3,3 +3,5 @@
 <tamu-gisc-layer-list></tamu-gisc-layer-list>
 
 <tamu-gisc-legend></tamu-gisc-legend>
+
+<tamu-gisc-basemap-gallery></tamu-gisc-basemap-gallery>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -3,5 +3,3 @@
 <tamu-gisc-layer-list></tamu-gisc-layer-list>
 
 <tamu-gisc-legend></tamu-gisc-legend>
-
-<tamu-gisc-basemap-gallery></tamu-gisc-basemap-gallery>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.html
@@ -1,0 +1,1 @@
+<tamu-gisc-basemap-gallery></tamu-gisc-basemap-gallery>>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.html
@@ -1,1 +1,1 @@
-<tamu-gisc-basemap-gallery></tamu-gisc-basemap-gallery>>
+<tamu-gisc-basemap-gallery></tamu-gisc-basemap-gallery>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.spec.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SidebarSettingsComponent } from './sidebar-settings.component';
+
+describe('SidebarSettingsComponent', () => {
+  let component: SidebarSettingsComponent;
+  let fixture: ComponentFixture<SidebarSettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SidebarSettingsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SidebarSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-settings/sidebar-settings.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-sidebar-settings',
+  templateUrl: './sidebar-settings.component.html',
+  styleUrls: ['./sidebar-settings.component.scss']
+})
+export class SidebarSettingsComponent {}

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.component.html
@@ -11,6 +11,8 @@ We are injecting application-specific sidebar tabs and content -->
     <tamu-gisc-sidebar-tab [title]="'Bus Routes'" [description]="'Toggle bus controls (list and timetable)'" [material_icon]="'directions_bus'" [route]="'bus'" (click)="reportSidebarContent('Bus Routes')"></tamu-gisc-sidebar-tab>
 
     <tamu-gisc-sidebar-tab *ngIf="(isDev | async) === true" [title]="'Experiments'" [description]="'Aggiemap Experiments'" [material_icon]="'science'" [route]="'experiments'" (click)="reportSidebarContent('Experiments')"></tamu-gisc-sidebar-tab>
+
+    <tamu-gisc-sidebar-tab [title]="'Settings'" [description]="'Settings'" [material_icon]="'settings'" [route]="'settings'" (click)="reportSidebarContent('Settings')"></tamu-gisc-sidebar-tab>
   </div>
 
   <div class="content">

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.module.ts
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/sidebar.module.ts
@@ -10,11 +10,13 @@ import { MapsFeatureTripPlannerModule } from '@tamu-gisc/maps/feature/trip-plann
 import { LayerListModule } from '@tamu-gisc/maps/feature/layer-list';
 import { LegendModule } from '@tamu-gisc/maps/feature/legend';
 import { TransportationModule } from '@tamu-gisc/aggiemap/ngx/ui/shared';
+import { MapsFeatureBasemapGalleryModule } from '@tamu-gisc/maps/feature/basemap';
 
 import { AggiemapSidebarComponent } from './sidebar.component';
 import { SidebarReferenceComponent } from './components/sidebar-reference/sidebar-reference.component';
 import { SidebarTripPlannerComponent } from './components/sidebar-trip-planner/sidebar-trip-planner.component';
 import { SidebarBusListComponent } from './components/sidebar-bus-list/sidebar-bus-list.component';
+import { SidebarSettingsComponent } from './components/sidebar-settings/sidebar-settings.component';
 
 @NgModule({
   imports: [
@@ -27,9 +29,16 @@ import { SidebarBusListComponent } from './components/sidebar-bus-list/sidebar-b
     MapsFeatureTripPlannerModule,
     LayerListModule,
     LegendModule,
-    TransportationModule
+    TransportationModule,
+    MapsFeatureBasemapGalleryModule
   ],
-  declarations: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent, SidebarBusListComponent],
-  exports: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent]
+  declarations: [
+    AggiemapSidebarComponent,
+    SidebarReferenceComponent,
+    SidebarTripPlannerComponent,
+    SidebarBusListComponent,
+    SidebarSettingsComponent
+  ],
+  exports: [AggiemapSidebarComponent, SidebarReferenceComponent, SidebarTripPlannerComponent, SidebarSettingsComponent]
 })
 export class AggiemapSidebarModule {}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
@@ -28,6 +28,11 @@ export class MainMobileSidebarComponent {
       path: 'layers'
     },
     {
+      name: 'Basemap',
+      type: 'outlet',
+      path: 'basemap'
+    },
+    {
       name: 'Bus Routes',
       type: 'router-path',
       path: '/map/m/bus'

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/mobile-sidebar/mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/mobile-sidebar/mobile-sidebar.component.ts
@@ -17,7 +17,7 @@ export class MobileSidebarComponent {
     // Get the parent route.
     const parent = getPathFromRouteSnapshot(this.route.snapshot).slice(0, -1);
 
-    // Absolute nagivation to the parent.
+    // Absolute navigation to the parent.
     this.router.navigate(parent);
   }
 }

--- a/libs/maps/esri/src/lib/services/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map.service.ts
@@ -876,7 +876,7 @@ interface MapProperties extends esri.MapProperties {
       );
 }
 
-interface BaseMapProperties extends esri.BasemapProperties {
+export interface BaseMapProperties extends esri.BasemapProperties {
   baseLayers: [LayerProperties];
 }
 

--- a/libs/maps/esri/src/lib/services/module-provider.service.ts
+++ b/libs/maps/esri/src/lib/services/module-provider.service.ts
@@ -7,278 +7,20 @@ export class EsriModuleProviderService {
   /**
    * Module dictionary, allows to pass simple class names instead of the class path.
    */
-  private dictionary = [
-    {
-      class: 'esri/Map',
-      name: 'Map'
-    },
-    {
-      class: 'esri/views/MapView',
-      name: 'MapView'
-    },
-    {
-      class: 'esri/views/SceneView',
-      name: 'SceneView'
-    },
-    {
-      class: 'esri/layers/TileLayer',
-      name: 'TileLayer'
-    },
-    {
-      class: 'esri/layers/VectorTileLayer',
-      name: 'VectorTileLayer'
-    },
-    {
-      class: 'esri/Basemap',
-      name: 'Basemap'
-    },
-    {
-      class: 'esri/layers/GraphicsLayer',
-      name: 'GraphicsLayer'
-    },
-    {
-      class: 'esri/core/urlUtils',
-      name: 'urlUtils'
-    },
-    {
-      class: 'esri/geometry/support/webMercatorUtils',
-      name: 'webMercatorUtils'
-    },
-    {
-      class: 'esri/geometry/SpatialReference',
-      name: 'SpatialReference'
-    },
-    {
-      class: 'esri/tasks/RouteTask',
-      name: 'RouteTask'
-    },
-    {
-      class: 'esri/rest/support/RouteParameters',
-      name: 'RouteParameters'
-    },
-    {
-      class: 'esri/rest/support/FeatureSet',
-      name: 'FeatureSet'
-    },
-    {
-      class: 'esri/Graphic',
-      name: 'Graphic'
-    },
-    {
-      class: 'esri/geometry/Point',
-      name: 'Point'
-    },
-    {
-      class: 'esri/geometry/Polygon',
-      name: 'Polygon'
-    },
-    {
-      class: 'esri/geometry/Polyline',
-      name: 'Polyline'
-    },
-    {
-      class: 'esri/layers/FeatureLayer',
-      name: 'FeatureLayer'
-    },
-    {
-      class: 'esri/layers/SceneLayer',
-      name: 'SceneLayer'
-    },
-    {
-      class: 'esri/renderers/UniqueValueRenderer',
-      name: 'UniqueValueRenderer'
-    },
-    {
-      class: 'esri/views/layers/support/FeatureFilter',
-      name: 'FeatureFilter'
-    },
-    {
-      class: 'esri/widgets/Search',
-      name: 'Search'
-    },
-    {
-      class: 'esri/symbols/SimpleFillSymbol',
-      name: 'SimpleFillSymbol'
-    },
-    {
-      class: 'esri/symbols/SimpleLineSymbol',
-      name: 'SimpleLineSymbol'
-    },
-    {
-      class: 'esri/symbols/SimpleMarkerSymbol',
-      name: 'SimpleMarkerSymbol'
-    },
-    {
-      class: 'esri/symbols/PathSymbol3DLayer',
-      name: 'PathSymbol3DLayer'
-    },
-    {
-      class: 'esri/widgets/LayerList',
-      name: 'LayerList'
-    },
-    {
-      class: 'esri/widgets/Track',
-      name: 'Track'
-    },
-    {
-      class: 'esri/widgets/Compass',
-      name: 'Compass'
-    },
-    {
-      class: 'esri/PopupTemplate',
-      name: 'PopupTemplate'
-    },
-    {
-      class: 'esri/rest/support/Query',
-      name: 'Query'
-    },
-    {
-      class: 'esri/tasks/QueryTask',
-      name: 'QueryTask'
-    },
-    {
-      class: 'esri/tasks/support/DataFile',
-      name: 'DataFile'
-    },
-    {
-      class: 'esri/geometry/Geometry',
-      name: 'Geometry'
-    },
-    {
-      class: 'esri/geometry/geometryEngine',
-      name: 'GeometryEngine'
-    },
-    {
-      class: 'esri/core/watchUtils',
-      name: 'WatchUtils'
-    },
-    {
-      class: 'esri/symbols/PictureMarkerSymbol',
-      name: 'PictureMarkerSymbol'
-    },
-    {
-      class: 'esri/layers/GeoJSONLayer',
-      name: 'GeoJSONLayer'
-    },
-    {
-      class: 'esri/layers/CSVLayer',
-      name: 'CSVLayer'
-    },
-    {
-      class: 'esri/widgets/Legend/LegendViewModel',
-      name: 'LegendViewModel'
-    },
-    {
-      class: 'esri/widgets/LayerList/LayerListViewModel',
-      name: 'LayerListViewModel'
-    },
-    {
-      class: 'esri/core/Handles',
-      name: 'Handles'
-    },
-    {
-      class: 'esri/widgets/Sketch/SketchViewModel',
-      name: 'SketchViewModel'
-    },
-    {
-      class: 'esri/widgets/Legend/LegendViewModel',
-      name: 'LegendViewModel'
-    },
-    {
-      class: 'esri/layers/Layer',
-      name: 'Layer'
-    },
-    {
-      class: 'esri/layers/GroupLayer',
-      name: 'GroupLayer'
-    },
-    {
-      class: 'esri/geometry/Circle',
-      name: 'Circle'
-    },
-    {
-      class: 'esri/symbols/Symbol',
-      name: 'Symbol'
-    },
-    {
-      class: 'esri/layers/GroupLayer',
-      name: 'GroupLayer'
-    },
-    {
-      class: 'esri/Color',
-      name: 'Color'
-    },
-    {
-      class: 'esri/geometry/Extent',
-      name: 'Extent'
-    },
-    {
-      class: 'esri/layers/MapImageLayer',
-      name: 'MapImageLayer'
-    },
-    {
-      class: 'esri/widgets/Slider',
-      name: 'Slider'
-    },
-    {
-      class: 'esri/widgets/TimeSlider',
-      name: 'TimeSlider'
-    },
-    {
-      class: 'esri/widgets/Expand',
-      name: 'Expand'
-    },
-    {
-      class: 'esri/widgets/BasemapToggle',
-      name: 'BasemapToggle'
-    },
-    {
-      class: 'esri/layers/support/Field',
-      name: 'Field'
-    },
-    {
-      class: 'esri/rest/route',
-      name: 'route'
-    },
-    {
-      class: 'esri/rest/networkService',
-      name: 'networkService'
-    },
-    {
-      class: 'esri/rest/support/Stop',
-      name: 'Stop'
-    },
-    {
-      class: 'esri/core/Collection',
-      name: 'Collection'
-    },
-    {
-      class: 'esri/identity/IdentityManager',
-      name: 'IdentityManager'
-    },
-    {
-      class: 'esri/identity/OAuthInfo',
-      name: 'OAuthInfo'
-    },
-    {
-      class: 'esri/layers/MapImageLayer',
-      name: 'MapImageLayer'
-    }
-  ];
 
   /**
    * Resolves provided simple module names to class paths, and returns an array of esri class constructors.
    *
-   * @param {string[]} modules Simple module names (e.g. Map, MapView, GraphicLayer)
+   * @param {EsriModuleProviderService[]} modules Simple module names (e.g. Map, MapView, GraphicLayer)
    * @param {boolean} asObject Will return modules as named objects instead of an array of anonymous functions.
    * @returns
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public require(modules: string[]): Promise<any>;
+  public require(modules: EsriAmdModule[]): Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public require(modules: string[], asObject: true): Promise<any>;
+  public require(modules: EsriAmdModule[], asObject: true): Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public require(modules: string[], asObject?: boolean): Promise<any> {
+  public require(modules: EsriAmdModule[], asObject?: boolean): Promise<any> {
     // n is an alias for module name
     const classNames = modules.map((n) => {
       if (n === undefined || n === '') {
@@ -287,7 +29,7 @@ export class EsriModuleProviderService {
       }
 
       // di is an alias for dictionary item
-      const find = this.dictionary.find((di) => {
+      const find = dictionary.find((di) => {
         return di.name === n;
       });
 
@@ -321,3 +63,268 @@ export class EsriModuleProviderService {
       });
   }
 }
+
+const dictionary = [
+  {
+    class: 'esri/Map',
+    name: 'Map'
+  },
+  {
+    class: 'esri/views/MapView',
+    name: 'MapView'
+  },
+  {
+    class: 'esri/views/SceneView',
+    name: 'SceneView'
+  },
+  {
+    class: 'esri/layers/TileLayer',
+    name: 'TileLayer'
+  },
+  {
+    class: 'esri/layers/VectorTileLayer',
+    name: 'VectorTileLayer'
+  },
+  {
+    class: 'esri/Basemap',
+    name: 'Basemap'
+  },
+  {
+    class: 'esri/layers/GraphicsLayer',
+    name: 'GraphicsLayer'
+  },
+  {
+    class: 'esri/core/urlUtils',
+    name: 'urlUtils'
+  },
+  {
+    class: 'esri/geometry/support/webMercatorUtils',
+    name: 'webMercatorUtils'
+  },
+  {
+    class: 'esri/geometry/SpatialReference',
+    name: 'SpatialReference'
+  },
+  {
+    class: 'esri/tasks/RouteTask',
+    name: 'RouteTask'
+  },
+  {
+    class: 'esri/rest/support/RouteParameters',
+    name: 'RouteParameters'
+  },
+  {
+    class: 'esri/rest/support/FeatureSet',
+    name: 'FeatureSet'
+  },
+  {
+    class: 'esri/Graphic',
+    name: 'Graphic'
+  },
+  {
+    class: 'esri/geometry/Point',
+    name: 'Point'
+  },
+  {
+    class: 'esri/geometry/Polygon',
+    name: 'Polygon'
+  },
+  {
+    class: 'esri/geometry/Polyline',
+    name: 'Polyline'
+  },
+  {
+    class: 'esri/layers/FeatureLayer',
+    name: 'FeatureLayer'
+  },
+  {
+    class: 'esri/layers/SceneLayer',
+    name: 'SceneLayer'
+  },
+  {
+    class: 'esri/renderers/UniqueValueRenderer',
+    name: 'UniqueValueRenderer'
+  },
+  {
+    class: 'esri/views/layers/support/FeatureFilter',
+    name: 'FeatureFilter'
+  },
+  {
+    class: 'esri/widgets/Search',
+    name: 'Search'
+  },
+  {
+    class: 'esri/symbols/SimpleFillSymbol',
+    name: 'SimpleFillSymbol'
+  },
+  {
+    class: 'esri/symbols/SimpleLineSymbol',
+    name: 'SimpleLineSymbol'
+  },
+  {
+    class: 'esri/symbols/SimpleMarkerSymbol',
+    name: 'SimpleMarkerSymbol'
+  },
+  {
+    class: 'esri/symbols/PathSymbol3DLayer',
+    name: 'PathSymbol3DLayer'
+  },
+  {
+    class: 'esri/widgets/LayerList',
+    name: 'LayerList'
+  },
+  {
+    class: 'esri/widgets/Track',
+    name: 'Track'
+  },
+  {
+    class: 'esri/widgets/Compass',
+    name: 'Compass'
+  },
+  {
+    class: 'esri/PopupTemplate',
+    name: 'PopupTemplate'
+  },
+  {
+    class: 'esri/rest/support/Query',
+    name: 'Query'
+  },
+  {
+    class: 'esri/tasks/QueryTask',
+    name: 'QueryTask'
+  },
+  {
+    class: 'esri/tasks/support/DataFile',
+    name: 'DataFile'
+  },
+  {
+    class: 'esri/geometry/Geometry',
+    name: 'Geometry'
+  },
+  {
+    class: 'esri/geometry/geometryEngine',
+    name: 'GeometryEngine'
+  },
+  {
+    class: 'esri/core/watchUtils',
+    name: 'WatchUtils'
+  },
+  {
+    class: 'esri/symbols/PictureMarkerSymbol',
+    name: 'PictureMarkerSymbol'
+  },
+  {
+    class: 'esri/layers/GeoJSONLayer',
+    name: 'GeoJSONLayer'
+  },
+  {
+    class: 'esri/layers/CSVLayer',
+    name: 'CSVLayer'
+  },
+  {
+    class: 'esri/widgets/Legend/LegendViewModel',
+    name: 'LegendViewModel'
+  },
+  {
+    class: 'esri/widgets/LayerList/LayerListViewModel',
+    name: 'LayerListViewModel'
+  },
+  {
+    class: 'esri/core/Handles',
+    name: 'Handles'
+  },
+  {
+    class: 'esri/widgets/Sketch/SketchViewModel',
+    name: 'SketchViewModel'
+  },
+  {
+    class: 'esri/widgets/Legend/LegendViewModel',
+    name: 'LegendViewModel'
+  },
+  {
+    class: 'esri/layers/Layer',
+    name: 'Layer'
+  },
+  {
+    class: 'esri/layers/GroupLayer',
+    name: 'GroupLayer'
+  },
+  {
+    class: 'esri/geometry/Circle',
+    name: 'Circle'
+  },
+  {
+    class: 'esri/symbols/Symbol',
+    name: 'Symbol'
+  },
+  {
+    class: 'esri/layers/GroupLayer',
+    name: 'GroupLayer'
+  },
+  {
+    class: 'esri/Color',
+    name: 'Color'
+  },
+  {
+    class: 'esri/geometry/Extent',
+    name: 'Extent'
+  },
+  {
+    class: 'esri/layers/MapImageLayer',
+    name: 'MapImageLayer'
+  },
+  {
+    class: 'esri/widgets/Slider',
+    name: 'Slider'
+  },
+  {
+    class: 'esri/widgets/TimeSlider',
+    name: 'TimeSlider'
+  },
+  {
+    class: 'esri/widgets/Expand',
+    name: 'Expand'
+  },
+  {
+    class: 'esri/widgets/BasemapToggle',
+    name: 'BasemapToggle'
+  },
+  {
+    class: 'esri/layers/support/Field',
+    name: 'Field'
+  },
+  {
+    class: 'esri/rest/route',
+    name: 'route'
+  },
+  {
+    class: 'esri/rest/networkService',
+    name: 'networkService'
+  },
+  {
+    class: 'esri/rest/support/Stop',
+    name: 'Stop'
+  },
+  {
+    class: 'esri/core/Collection',
+    name: 'Collection'
+  },
+  {
+    class: 'esri/identity/IdentityManager',
+    name: 'IdentityManager'
+  },
+  {
+    class: 'esri/identity/OAuthInfo',
+    name: 'OAuthInfo'
+  },
+  {
+    class: 'esri/layers/MapImageLayer',
+    name: 'MapImageLayer'
+  },
+  {
+    class: 'esri/widgets/BasemapGallery/BasemapGalleryViewModel',
+    name: 'BaseMapGalleryViewModel'
+  }
+];
+
+type EsriAmdModule = typeof dictionary[number]['name'];

--- a/libs/maps/esri/src/lib/services/module-provider.service.ts
+++ b/libs/maps/esri/src/lib/services/module-provider.service.ts
@@ -324,6 +324,10 @@ const dictionary = [
   {
     class: 'esri/widgets/BasemapGallery/BasemapGalleryViewModel',
     name: 'BaseMapGalleryViewModel'
+  },
+  {
+    class: 'esri/widgets/BasemapGallery/support/LocalBasemapsSource',
+    name: 'LocalBasemapsSource'
   }
 ];
 

--- a/libs/maps/feature/basemap/.eslintrc.json
+++ b/libs/maps/feature/basemap/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "tamuGisc",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "tamu-gisc",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/maps/feature/basemap/README.md
+++ b/libs/maps/feature/basemap/README.md
@@ -1,7 +1,15 @@
-# maps-feature-basemap
+# Esri Basemap Feature
 
-This library was generated with [Nx](https://nx.dev).
+This library provides a feature module for the Esri Basemap.
 
-## Running unit tests
+## Components
 
-Run `nx test maps-feature-basemap` to execute the unit tests.
+The following components are available in this library:
+
+- `BaseMapGalleryComponent`: A component that displays a gallery of basemaps that can be selected by the user.
+
+## Services
+
+The following services are available in this library:
+
+- `BaseMapGalleryService`: A service that links the basemap gallery component into the esri map and view models to allow the user to select a basemap.

--- a/libs/maps/feature/basemap/README.md
+++ b/libs/maps/feature/basemap/README.md
@@ -1,0 +1,7 @@
+# maps-feature-basemap
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test maps-feature-basemap` to execute the unit tests.

--- a/libs/maps/feature/basemap/jest.config.js
+++ b/libs/maps/feature/basemap/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  displayName: 'maps-feature-basemap',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$'
+    }
+  },
+  coverageDirectory: '../../../../coverage/libs/maps/feature/basemap',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular'
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment'
+  ]
+};

--- a/libs/maps/feature/basemap/project.json
+++ b/libs/maps/feature/basemap/project.json
@@ -1,0 +1,23 @@
+{
+  "projectType": "library",
+  "root": "libs/maps/feature/basemap",
+  "sourceRoot": "libs/maps/feature/basemap/src",
+  "prefix": "tamu-gisc",
+  "targets": {
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/maps/feature/basemap"],
+      "options": {
+        "jestConfig": "libs/maps/feature/basemap/jest.config.js",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["libs/maps/feature/basemap/src/**/*.ts", "libs/maps/feature/basemap/src/**/*.html"]
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/maps/feature/basemap/src/index.ts
+++ b/libs/maps/feature/basemap/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/maps-feature-basemap.module';
+export * from './lib/components/basemap-gallery/basemap-gallery.component';
 
 export * from './lib/shared/basemaps.definition';

--- a/libs/maps/feature/basemap/src/index.ts
+++ b/libs/maps/feature/basemap/src/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/maps-feature-basemap.module';
+
+export * from './lib/shared/basemaps.definition';

--- a/libs/maps/feature/basemap/src/index.ts
+++ b/libs/maps/feature/basemap/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/maps-feature-basemap.module';
 export * from './lib/components/basemap-gallery/basemap-gallery.component';
+export * from './lib/services/basemap-gallery/basemap-gallery.service';
 
 export * from './lib/shared/basemaps.definition';

--- a/libs/maps/feature/basemap/src/index.ts
+++ b/libs/maps/feature/basemap/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/maps-feature-basemap.module';

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
@@ -1,4 +1,5 @@
 <div class="sidebar-component-name">
+  <span class="material-icons" *ngIf="isMobile | async" (click)="backAction()">arrow_back</span>
   <p>Basemap</p>
 </div>
 

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
@@ -1,6 +1,12 @@
-<div *ngIf="(gallery | async) as gallery" class="flex flex-column">
-  <div *ngFor="let basemap of gallery.items" class="basemap flex flex-row align-center" [ngClass]="{active: gallery.activeBasemap.id === basemap.basemap.id}" (click)="selectBasemap(basemap)">
-    <img [src]="basemap.basemap.thumbnailUrl" alt="Basemap thumbnail" />
-    <p class="basemap-title">{{ basemap.basemap.title }}</p>
+<div class="sidebar-component-name">
+  <p>Basemap</p>
+</div>
+
+<div class="sidebar-component-content-container">
+  <div *ngIf="(gallery | async) as gallery" class="flex flex-column">
+    <div *ngFor="let basemap of gallery.items" class="basemap flex flex-row align-center" [ngClass]="{active: gallery.activeBasemap.id === basemap.basemap.id}" (click)="selectBasemap(basemap)">
+      <img [src]="basemap.basemap.thumbnailUrl" alt="Basemap thumbnail" />
+      <p class="basemap-title">{{ basemap.basemap.title }}</p>
+    </div>
   </div>
 </div>

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
@@ -1,1 +1,6 @@
-<p>basemap-gallery works!</p>
+<div *ngIf="(gallery | async) as gallery" class="flex flex-column">
+  <div *ngFor="let basemap of gallery.items" class="basemap flex flex-row align-center" [ngClass]="{active: gallery.activeBasemap.id === basemap.basemap.id}" (click)="selectBasemap(basemap)">
+    <img [src]="basemap.basemap.thumbnailUrl" alt="Basemap thumbnail" />
+    <p class="basemap-title">{{ basemap.basemap.title }}</p>
+  </div>
+</div>

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.html
@@ -1,0 +1,1 @@
+<p>basemap-gallery works!</p>

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.scss
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.scss
@@ -1,3 +1,6 @@
+@import 'libs/sass/components/sidebar';
+@import 'libs/sass/mixins';
+
 .basemap {
   margin-bottom: 0.5rem;
   cursor: pointer;

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.scss
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.scss
@@ -1,0 +1,25 @@
+.basemap {
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+
+  .basemap-title {
+    padding-bottom: 0;
+  }
+
+  &.active {
+    .basemap-title {
+      font-weight: 600;
+    }
+
+    img {
+      border-color: #616161;
+    }
+  }
+}
+
+img {
+  max-width: 25%;
+  margin-right: 0.5rem;
+  border: 2px solid transparent;
+  border-radius: 2pt;
+}

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.spec.ts
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BasemapGalleryComponent } from './basemap-gallery.component';
+
+describe('BasemapGalleryComponent', () => {
+  let component: BasemapGalleryComponent;
+  let fixture: ComponentFixture<BasemapGalleryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BasemapGalleryComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BasemapGalleryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'tamu-gisc-basemap-gallery',
+  templateUrl: './basemap-gallery.component.html',
+  styleUrls: ['./basemap-gallery.component.scss']
+})
+export class BasemapGalleryComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { BasemapGalleryService } from '../../services/basemap-gallery/basemap-gallery.service';
+
+import esri = __esri;
 
 @Component({
   selector: 'tamu-gisc-basemap-gallery',
@@ -6,7 +11,15 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./basemap-gallery.component.scss']
 })
 export class BasemapGalleryComponent implements OnInit {
-  constructor() {}
+  public gallery: Observable<esri.BasemapGalleryViewModel>;
 
-  ngOnInit(): void {}
+  constructor(private readonly bs: BasemapGalleryService) {}
+
+  ngOnInit(): void {
+    this.gallery = this.bs.gallery();
+  }
+
+  public selectBasemap(event: esri.BasemapGalleryItem) {
+    this.bs.setBasemap(event.basemap);
+  }
 }

--- a/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
+++ b/libs/maps/feature/basemap/src/lib/components/basemap-gallery/basemap-gallery.component.ts
@@ -1,5 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
+
+import { Angulartics2 } from 'angulartics2';
+
+import { ResponsiveService } from '@tamu-gisc/dev-tools/responsive';
 
 import { BasemapGalleryService } from '../../services/basemap-gallery/basemap-gallery.service';
 
@@ -12,14 +17,34 @@ import esri = __esri;
 })
 export class BasemapGalleryComponent implements OnInit {
   public gallery: Observable<esri.BasemapGalleryViewModel>;
+  public isMobile: Observable<boolean>;
 
-  constructor(private readonly bs: BasemapGalleryService) {}
+  constructor(
+    private readonly bs: BasemapGalleryService,
+    private readonly rs: ResponsiveService,
+    private readonly router: Router,
+    private readonly route: ActivatedRoute,
+    private readonly anl: Angulartics2
+  ) {}
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.gallery = this.bs.gallery();
+    this.isMobile = this.rs.isMobile;
   }
 
   public selectBasemap(event: esri.BasemapGalleryItem) {
     this.bs.setBasemap(event.basemap);
+
+    this.anl.eventTrack.next({
+      action: 'basemap_select',
+      properties: {
+        category: 'ui_interaction',
+        gstCustom: event.basemap.id
+      }
+    });
+  }
+
+  public backAction(): void {
+    this.router.navigate(['../'], { relativeTo: this.route });
   }
 }

--- a/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
+++ b/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
@@ -2,9 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { BasemapGalleryComponent } from './components/basemap-gallery/basemap-gallery.component';
+import { BasemapGalleryService } from './services/basemap-gallery/basemap-gallery.service';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [BasemapGalleryComponent]
+  declarations: [BasemapGalleryComponent],
+  providers: [BasemapGalleryService],
+  exports: [BasemapGalleryComponent]
 })
 export class MapsFeatureBasemapModule {}

--- a/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
+++ b/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
@@ -10,4 +10,4 @@ import { BasemapGalleryService } from './services/basemap-gallery/basemap-galler
   providers: [BasemapGalleryService],
   exports: [BasemapGalleryComponent]
 })
-export class MapsFeatureBasemapModule {}
+export class MapsFeatureBasemapGalleryModule {}

--- a/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
+++ b/libs/maps/feature/basemap/src/lib/maps-feature-basemap.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { BasemapGalleryComponent } from './components/basemap-gallery/basemap-gallery.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [BasemapGalleryComponent]
+})
+export class MapsFeatureBasemapModule {}

--- a/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.spec.ts
+++ b/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BasemapGalleryService } from './basemap-gallery.service';
+
+describe('BasemapGalleryService', () => {
+  let service: BasemapGalleryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BasemapGalleryService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
+++ b/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BasemapGalleryService {
+  constructor() {}
+}

--- a/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
+++ b/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { combineLatest, map } from 'rxjs';
+import { combineLatest, switchMap } from 'rxjs';
 
 import { EsriMapService, EsriModuleProviderService, MapServiceInstance } from '@tamu-gisc/maps/esri';
+
+import { AggiemapBasemap } from '../../shared/basemaps.definition';
 
 import esri = __esri;
 
@@ -12,14 +14,57 @@ export class BasemapGalleryService {
   constructor(private readonly mp: EsriModuleProviderService, private readonly ms: EsriMapService) {}
 
   public gallery() {
-    return combineLatest([this.mp.require(['BasemapGalleryViewModel']), this.ms.store]).pipe(
-      map(([[BasemapGalleryViewModel], instances]: [[esri.BasemapGalleryViewModelConstructor], MapServiceInstance]) => {
-        const model = new BasemapGalleryViewModel({
-          view: instances.view
-        });
+    return combineLatest([
+      this.mp.require(['BaseMapGalleryViewModel', 'LocalBasemapsSource', 'Basemap', 'TileLayer']),
+      this.ms.store
+    ]).pipe(
+      switchMap(
+        async ([[BasemapGalleryViewModel, LocalBasemapsSource, Basemap, TileLayer], instances]: [
+          [
+            esri.BasemapGalleryViewModelConstructor,
+            esri.LocalBasemapsSourceConstructor,
+            esri.BasemapConstructor,
+            esri.TileLayerConstructor
+          ],
+          MapServiceInstance
+        ]) => {
+          // There is a bug in the current version of the JS API (4.23) that prevents Aggiemap basemap from loading
+          // from an auto-castable source because the baseLayers are not an instance of a class and the load() method does not exist.
+          // To work around this, we need ton construct a new instance of the TileLayer class and pass in the base
 
-        return model;
-      })
+          // Clone the base layer JSON object
+          const baseLayerJSON = JSON.parse(JSON.stringify(AggiemapBasemap.baseLayers[0]));
+
+          // Remove the type property to prevent read-only property assignment error.
+          delete baseLayerJSON.type;
+
+          const baseLayers = new TileLayer({ ...baseLayerJSON });
+
+          const instancedAggiemapBasemap = new Basemap({ ...AggiemapBasemap, baseLayers: [baseLayers] });
+
+          const model = new BasemapGalleryViewModel({
+            view: instances.view,
+            source: new LocalBasemapsSource({
+              basemaps: [
+                instancedAggiemapBasemap,
+                Basemap.fromId('topo-vector'),
+                Basemap.fromId('streets-relief-vector'),
+                Basemap.fromId('streets-navigation-vector'),
+                Basemap.fromId('streets-vector'),
+                Basemap.fromId('gray-vector')
+              ]
+            })
+          });
+
+          return model;
+        }
+      )
     );
+  }
+
+  public setBasemap(basemap: esri.Basemap) {
+    this.ms.store.subscribe((instance) => {
+      instance.map.basemap = basemap;
+    });
   }
 }

--- a/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
+++ b/libs/maps/feature/basemap/src/lib/services/basemap-gallery/basemap-gallery.service.ts
@@ -1,8 +1,25 @@
 import { Injectable } from '@angular/core';
+import { combineLatest, map } from 'rxjs';
+
+import { EsriMapService, EsriModuleProviderService, MapServiceInstance } from '@tamu-gisc/maps/esri';
+
+import esri = __esri;
 
 @Injectable({
   providedIn: 'root'
 })
 export class BasemapGalleryService {
-  constructor() {}
+  constructor(private readonly mp: EsriModuleProviderService, private readonly ms: EsriMapService) {}
+
+  public gallery() {
+    return combineLatest([this.mp.require(['BasemapGalleryViewModel']), this.ms.store]).pipe(
+      map(([[BasemapGalleryViewModel], instances]: [[esri.BasemapGalleryViewModelConstructor], MapServiceInstance]) => {
+        const model = new BasemapGalleryViewModel({
+          view: instances.view
+        });
+
+        return model;
+      })
+    );
+  }
 }

--- a/libs/maps/feature/basemap/src/lib/shared/basemaps.definition.ts
+++ b/libs/maps/feature/basemap/src/lib/shared/basemaps.definition.ts
@@ -1,0 +1,21 @@
+import { BaseMapProperties } from '@tamu-gisc/maps/esri';
+
+export const AggiemapBasemap: BaseMapProperties = {
+  baseLayers: [
+    {
+      type: 'TileLayer',
+      url: `https://gis.tamu.edu/arcgis/rest/services/FCOR/TAMU_BaseMap/MapServer`,
+      spatialReference: {
+        wkid: 102100
+      },
+      listMode: 'hide',
+      visible: true,
+      minScale: 100000,
+      maxScale: 0,
+      title: 'Base Map'
+    }
+  ],
+  id: 'aggie_basemap',
+  title: 'Aggieland',
+  thumbnailUrl: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/TAMU_BaseMap/MapServer/info/thumbnail'
+};

--- a/libs/maps/feature/basemap/src/test-setup.ts
+++ b/libs/maps/feature/basemap/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/maps/feature/basemap/tsconfig.json
+++ b/libs/maps/feature/basemap/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/maps/feature/basemap/tsconfig.lib.json
+++ b/libs/maps/feature/basemap/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/maps/feature/basemap/tsconfig.lib.json
+++ b/libs/maps/feature/basemap/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "types": ["arcgis-js-api"]
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
   "include": ["**/*.ts"]

--- a/libs/maps/feature/basemap/tsconfig.spec.json
+++ b/libs/maps/feature/basemap/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/maps/feature/basemap/tsconfig.spec.json
+++ b/libs/maps/feature/basemap/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "arcgis-js-api"]
   },
   "files": ["src/test-setup.ts"],
   "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -86,6 +86,7 @@
       "@tamu-gisc/mailroom/ngx": ["libs/mailroom/ngx/src/index.ts"],
       "@tamu-gisc/maps/esri": ["libs/maps/esri/src/index.ts"],
       "@tamu-gisc/maps/feature/accessibility": ["libs/maps/feature/accessibility/src/index.ts"],
+      "@tamu-gisc/maps/feature/basemap": ["libs/maps/feature/basemap/src/index.ts"],
       "@tamu-gisc/maps/feature/coordinates": ["libs/maps/feature/coordinates/src/index.ts"],
       "@tamu-gisc/maps/feature/data": ["libs/maps/feature/data/src/index.ts"],
       "@tamu-gisc/maps/feature/draw": ["libs/maps/feature/draw/src/index.ts"],

--- a/workspace.json
+++ b/workspace.json
@@ -96,6 +96,7 @@
     "mailroom-ngx": "libs/mailroom/ngx",
     "maps-esri": "libs/maps/esri",
     "maps-feature-accessibility": "libs/maps/feature/accessibility",
+    "maps-feature-basemap": "libs/maps/feature/basemap",
     "maps-feature-coordinates": "libs/maps/feature/coordinates",
     "maps-feature-data": "libs/maps/feature/data",
     "maps-feature-draw": "libs/maps/feature/draw",


### PR DESCRIPTION
Includes a new library `maps-feature-basemap` which itself exports a new basemap gallery component to support basemap toggling by users.

Component has been added to aggiemap desktop and mobile views. For desktop, it is found under a new settings tab in the sidebar.

![image](https://github.com/user-attachments/assets/6e750591-e622-4f57-be33-37cf962e1140)

For mobile views, it is found as a top-level menu entry in the mobile menu.

![image](https://github.com/user-attachments/assets/25f49e1a-e21a-480b-8630-a004e51f8b0e)



