### PR TITLE
feat(cloudfare-turnstile): Add turnstile client and backend integration

### DIFF
--- a/apps/geoservices-angular/src/environments/environment.dev.ts
+++ b/apps/geoservices-angular/src/environments/environment.dev.ts
@@ -3,6 +3,7 @@ export const environment = {
 };
 
 export const api_url = `https://nodes.geoservices.tamu.edu/api/gsvcs-transport/`;
+export const legacy_host = 'https://geoservices-dev.geoservices.tamu.edu';
 export const legacy_api_url = `https://geoservices-dev.geoservices.tamu.edu/rest/`;
 export const accounts_url = `https://geoservices-dev.geoservices.tamu.edu`;
 export const geoprocessing_api_host_override = `https://geoservices-dev.geoservices.tamu.edu/api`;

--- a/apps/geoservices-angular/src/environments/environment.dev.ts
+++ b/apps/geoservices-angular/src/environments/environment.dev.ts
@@ -11,5 +11,6 @@ export const geoprocessing_api_host_override = `https://geoservices-dev.geoservi
 export const release_id = '___RELEASE_ID___';
 export const machine_name = '___MACHINE_NAME___';
 export const environment_mode = '___ENVIRONMENT_MODE___';
+export const turnstile_sitekey = '___TURNSTILE_SITE_KEY___';
 
 export * from './definitions';

--- a/apps/geoservices-angular/src/environments/environment.prod.ts
+++ b/apps/geoservices-angular/src/environments/environment.prod.ts
@@ -11,5 +11,6 @@ export const geoprocessing_api_host_override = `___GEOPROCESSING_API_HOST_OVERRI
 export const release_id = '___RELEASE_ID___';
 export const machine_name = '___MACHINE_NAME___';
 export const environment_mode = '___ENVIRONMENT_MODE___';
+export const turnstile_sitekey = '___TURNSTILE_SITE_KEY___';
 
 export * from './definitions';

--- a/apps/geoservices-angular/src/environments/environment.prod.ts
+++ b/apps/geoservices-angular/src/environments/environment.prod.ts
@@ -3,6 +3,7 @@ export const environment = {
 };
 
 export const api_url = `___API_URL___`;
+export const legacy_host = '___LEGACY_HOST___';
 export const legacy_api_url = `___LEGACY_API_URL___`;
 export const accounts_url = `___ACCOUNTS_URL___`;
 export const geoprocessing_api_host_override = `___GEOPROCESSING_API_HOST_OVERRIDE___`;

--- a/apps/geoservices-angular/src/environments/environment.ts
+++ b/apps/geoservices-angular/src/environments/environment.ts
@@ -15,7 +15,8 @@ export const environment = {
  */
 // import 'zone.js/plugins/zone-error';  // Included with Angular CLI.
 
-export const api_url = `http://localhost:3334`;
+export const api_url = `http://localhost:3333`;
+export const legacy_host = 'http://localhost/wap.geoservices.tamu.edu';
 export const legacy_api_url = `/legacy/`;
 export const accounts_url = `${window.location.protocol}//${window.location.hostname}/wap.accounts.geoservices.tamu.edu`;
 export const geoprocessing_api_host_override = 'http://localhost/wap.api.geoservices.tamu.edu.5.0.0/';

--- a/apps/geoservices-angular/src/environments/environment.ts
+++ b/apps/geoservices-angular/src/environments/environment.ts
@@ -24,5 +24,6 @@ export const geoprocessing_api_host_override = 'http://localhost/wap.api.geoserv
 export const release_id = 'v0.0.0';
 export const machine_name = 'localhost';
 export const environment_mode = 'Local';
+export const turnstile_sitekey = 'TURNSTILE_SITE_KEY';
 
 export * from './definitions';

--- a/apps/geoservices-nest/.env.sample
+++ b/apps/geoservices-nest/.env.sample
@@ -6,3 +6,6 @@ LOGGING= # Enable logging
 
 MAILROOM_URL= # Mailroom service URL
 MAILROOM_FROM_ADDRESS= # Mailroom from address
+
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=

--- a/apps/geoservices-nest/.env.sample
+++ b/apps/geoservices-nest/.env.sample
@@ -5,7 +5,7 @@ ORIGINS= # Allowed origins for CORS
 LOGGING= # Enable logging
 
 MAILROOM_URL= # Mailroom service URL
-MAILROOM_FROM_ADDRESS= # Mailroom from address
+MAILROOM_TO_ADDRESS= # Mailroom from address
 
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=

--- a/apps/geoservices-nest/src/environments/environment.prod.ts
+++ b/apps/geoservices-nest/src/environments/environment.prod.ts
@@ -8,7 +8,7 @@ export const environment = {
   logging: process.env?.LOGGING === 'true' ? true : false,
   globalPrefix: process.env?.GLOBAL_PREFIX || '',
   mailroomUrl: process.env.MAILROOM_URL,
-  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS,
+  mailroomToAddress: process.env.MAILROOM_TO_ADDRESS,
   turnstileClientKey: process.env.TURNSTILE_SITE_KEY,
   turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY
 };

--- a/apps/geoservices-nest/src/environments/environment.prod.ts
+++ b/apps/geoservices-nest/src/environments/environment.prod.ts
@@ -8,5 +8,7 @@ export const environment = {
   logging: process.env?.LOGGING === 'true' ? true : false,
   globalPrefix: process.env?.GLOBAL_PREFIX || '',
   mailroomUrl: process.env.MAILROOM_URL,
-  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS
+  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS,
+  turnstileClientKey: process.env.TURNSTILE_SITE_KEY,
+  turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY
 };

--- a/apps/geoservices-nest/src/environments/environment.ts
+++ b/apps/geoservices-nest/src/environments/environment.ts
@@ -5,5 +5,7 @@ export const environment = {
   logging: process.env?.LOGGING === 'true' ? true : false,
   globalPrefix: process.env?.GLOBAL_PREFIX || '',
   mailroomUrl: process.env.MAILROOM_URL,
-  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS
+  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS,
+  turnstileClientKey: process.env.TURNSTILE_SITE_KEY,
+  turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY
 };

--- a/apps/geoservices-nest/src/environments/environment.ts
+++ b/apps/geoservices-nest/src/environments/environment.ts
@@ -5,7 +5,7 @@ export const environment = {
   logging: process.env?.LOGGING === 'true' ? true : false,
   globalPrefix: process.env?.GLOBAL_PREFIX || '',
   mailroomUrl: process.env.MAILROOM_URL,
-  mailroomFromAddress: process.env.MAILROOM_FROM_ADDRESS,
+  mailroomToAddress: process.env.MAILROOM_TO_ADDRESS,
   turnstileClientKey: process.env.TURNSTILE_SITE_KEY,
   turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY
 };

--- a/libs/common/nest/services/src/index.ts
+++ b/libs/common/nest/services/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/common-nest-services.module';
 
 // Services
 export * from './lib/mailer/mailer.service';
+export * from './lib/turnstile-verify/turnstile-verify.service';

--- a/libs/common/nest/services/src/lib/common-nest-services.module.ts
+++ b/libs/common/nest/services/src/lib/common-nest-services.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 
 import { MailerService } from './mailer/mailer.service';
+import { TurnstileVerifyService } from './turnstile-verify/turnstile-verify.service';
 
 @Module({
   controllers: [],
-  providers: [MailerService],
-  exports: [MailerService]
+  providers: [MailerService, TurnstileVerifyService],
+  exports: [MailerService, TurnstileVerifyService]
 })
 export class CommonNestServicesModule {}

--- a/libs/common/nest/services/src/lib/turnstile-verify/turnstile-verify.service.spec.ts
+++ b/libs/common/nest/services/src/lib/turnstile-verify/turnstile-verify.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TurnstileVerifyService } from './turnstile-verify.service';
+
+describe('TurnstileVerifyService', () => {
+  let service: TurnstileVerifyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TurnstileVerifyService]
+    }).compile();
+
+    service = module.get<TurnstileVerifyService>(TurnstileVerifyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/libs/common/nest/services/src/lib/turnstile-verify/turnstile-verify.service.ts
+++ b/libs/common/nest/services/src/lib/turnstile-verify/turnstile-verify.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+
+import axios from 'axios';
+import * as FormData from 'form-data';
+
+import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
+
+@Injectable()
+export class TurnstileVerifyService {
+  constructor(private readonly env: EnvironmentService) {}
+
+  public async verify(token: string) {
+    const formData = new FormData();
+
+    formData.append('secret', this.env.value('turnstileSecretKey'));
+    formData.append('response', token);
+
+    try {
+      const response: TurnstileVerifyResponse = await axios({
+        method: 'POST',
+        url: 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+        data: formData,
+        responseType: 'json'
+      });
+
+      if (response.data.success) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+export interface TurnstileVerifyResponse {
+  data: {
+    success: boolean;
+    'error-codes': string[];
+    challenge_ts: string;
+    hostname: string;
+  };
+}

--- a/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
+++ b/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
@@ -26,4 +26,6 @@ export class ContactMessageDto {
 
   @IsNotEmpty()
   public text: string;
+
+  public token: string;
 }

--- a/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
+++ b/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
@@ -1,13 +1,24 @@
 import { Injectable } from '@nestjs/common';
 
-import { MailerService } from '@tamu-gisc/common/nest/services';
+import { MailerService, TurnstileVerifyService } from '@tamu-gisc/common/nest/services';
 
 import { IsEmail, IsNotEmpty } from 'class-validator';
 @Injectable()
 export class ContactService {
-  constructor(private readonly ms: MailerService) {}
+  constructor(private readonly ms: MailerService, private readonly ts: TurnstileVerifyService) {}
 
-  public sendMessage(body: ContactMessageDto) {
+  public async sendMessage(body: ContactMessageDto) {
+    if (!body.token) {
+      return;
+    }
+
+    // Verify the token
+    const verified = await this.ts.verify(body.token);
+
+    if (!verified) {
+      return;
+    }
+
     return this.ms.sendMail({
       from: undefined,
       to: body.from,

--- a/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
+++ b/libs/geoservices/data-api/src/lib/modules/contact/contact.service.ts
@@ -1,13 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { EnvironmentService } from '@tamu-gisc/common/nest/environment';
 
 import { MailerService, TurnstileVerifyService } from '@tamu-gisc/common/nest/services';
 
 import { IsEmail, IsNotEmpty } from 'class-validator';
 @Injectable()
 export class ContactService {
-  constructor(private readonly ms: MailerService, private readonly ts: TurnstileVerifyService) {}
+  constructor(
+    private readonly ms: MailerService,
+    private readonly ts: TurnstileVerifyService,
+    private readonly env: EnvironmentService
+  ) {}
 
   public async sendMessage(body: ContactMessageDto) {
+    const to = this.env.value('mailroomToAddress');
+
+    if (!to) {
+      throw new InternalServerErrorException('Unset mailroom settings.');
+    }
+
     if (!body.token) {
       return;
     }
@@ -21,7 +32,8 @@ export class ContactService {
 
     return this.ms.sendMail({
       from: undefined,
-      to: body.from,
+      to,
+      replyTo: body.from,
       subject: body.subject,
       text: body.text
     });

--- a/libs/geoservices/ngx/src/lib/core/components/footer/shortcuts/shortcuts.component.html
+++ b/libs/geoservices/ngx/src/lib/core/components/footer/shortcuts/shortcuts.component.html
@@ -29,7 +29,7 @@
       <li><a routerLink="./contact/bug-report">Bug Reporting</a></li>
       <li><a routerLink="./contact/address-correction">Submit Address Correction</a></li>
       <li><a routerLink="./contact">Contact Us</a></li>
-      <li><a href="https://legacy.geoservices.tamu.edu" target="_blank">Legacy Site</a></li>
+      <li><a [href]="legacyHost" target="_blank">Legacy Site</a></li>
     </ul>
   </div>
 

--- a/libs/geoservices/ngx/src/lib/core/components/footer/shortcuts/shortcuts.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/components/footer/shortcuts/shortcuts.component.ts
@@ -1,8 +1,14 @@
 import { Component } from '@angular/core';
 
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
 @Component({
   selector: 'tamu-gisc-footer-shortcuts',
   templateUrl: './shortcuts.component.html',
   styleUrls: ['./shortcuts.component.scss']
 })
-export class FooterShortcutsComponent {}
+export class FooterShortcutsComponent {
+  public legacyHost: string = this.env.value('legacy_host');
+
+  constructor(private readonly env: EnvironmentService) {}
+}

--- a/libs/geoservices/ngx/src/lib/core/components/modals/revival-modal/revival-modal.component.html
+++ b/libs/geoservices/ngx/src/lib/core/components/modals/revival-modal/revival-modal.component.html
@@ -32,4 +32,4 @@
 
 <p>If you would prefer to use the old version of Geoservices, you may continue to do so.</p>
 
-<p>The old version of Geoservices will remain accessible at <a href="https://legacy.geoservices.tamu.edu" target="_blank">legacy.geoservices.tamu.edu</a> for the forseeable future but updates to that version will cease at the end of 2023. We have made every effort to ensure we have feature parity for our most utilized products. If we have missed any or have any other feedback, please reach out and <a routerLink="contact/bug-report">let us know</a>.</p>
+<p>The old version of Geoservices will remain accessible at <a [href]="legacyHost" target="_blank">{{legacyHost}}</a> for the foreseeable future but updates to that version will cease at the end of 2023. We have made every effort to ensure we have feature parity for our most utilized products. If we have missed any or have any other feedback, please reach out and <a routerLink="contact/bug-report">let us know</a>.</p>

--- a/libs/geoservices/ngx/src/lib/core/components/modals/revival-modal/revival-modal.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/components/modals/revival-modal/revival-modal.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 import { ModalRefService } from '@tamu-gisc/ui-kits/ngx/layout/modal';
 
@@ -8,7 +9,9 @@ import { ModalRefService } from '@tamu-gisc/ui-kits/ngx/layout/modal';
   styleUrls: ['./revival-modal.component.scss']
 })
 export class RevivalModalComponent {
-  constructor(private readonly mr: ModalRefService) {}
+  public legacyHost: string = this.env.value('legacy_host');
+
+  constructor(private readonly mr: ModalRefService, private readonly env: EnvironmentService) {}
 
   public dismiss() {
     this.mr.close(true);

--- a/libs/geoservices/ngx/src/lib/core/components/revival-banner/revival-banner.component.html
+++ b/libs/geoservices/ngx/src/lib/core/components/revival-banner/revival-banner.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="(acknowledged$ | async) === false">
   <div class="container12" id="banner-container">
     <div class="column12">
-      <p>Texas A&amp;M University Geoservices has received a new look! Looking for the old version? You can find a link to it in the footer or visit &#64; <a href="https://legacy.geoservices.tamu.edu">legacy.geoservices.tamu.edu</a>.</p>
+      <p>Texas A&amp;M University Geoservices has received a new look! Looking for the old version? You can find a link to it in the footer or visit &#64; <a [href]="legacyHost">{{legacyHost}}</a>.</p>
 
       <span id="banner-dismiss" (click)="dismiss()"> [ Hide this message and don't show again ] </span>
     </div>

--- a/libs/geoservices/ngx/src/lib/core/components/revival-banner/revival-banner.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/components/revival-banner/revival-banner.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { BehaviorSubject, delay } from 'rxjs';
 
 import { SettingsService } from '@tamu-gisc/common/ngx/settings';
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 @Component({
   selector: 'tamu-gisc-revival-banner',
@@ -11,8 +12,9 @@ import { SettingsService } from '@tamu-gisc/common/ngx/settings';
 export class RevivalBannerComponent implements OnInit {
   private _acknowledged$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public acknowledged$ = this._acknowledged$.asObservable().pipe(delay(25));
+  public legacyHost: string;
 
-  constructor(private readonly ss: SettingsService) {}
+  constructor(private readonly ss: SettingsService, private readonly env: EnvironmentService) {}
 
   public ngOnInit(): void {
     this.ss
@@ -30,6 +32,8 @@ export class RevivalBannerComponent implements OnInit {
       .subscribe((settings) => {
         this._acknowledged$.next(settings['reskin_banner_acknowledge'] as boolean);
       });
+
+    this.legacyHost = this.env.value('legacy_host');
   }
 
   public dismiss() {

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/contact-form/contact-form.component.html
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/contact-form/contact-form.component.html
@@ -23,6 +23,10 @@
     </div>
 
     <div class="form-collection column">
+      <tamu-gisc-turnstile-challenge formControlName="turnstile_token"></tamu-gisc-turnstile-challenge>
+    </div>
+
+    <div class="form-collection column">
       <ng-container *ngIf="(submissionState | async) as ss">
         <ng-container *ngIf="ss === 'complete' || ss === 'error'">
           <div class="inform-context trailer-1 flex justify-center" [ngClass]="{alert: ss === 'error' }">

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/contact-form/contact-form.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/contact-form/contact-form.component.ts
@@ -29,7 +29,8 @@ export class ContactFormComponent implements OnInit {
       fullName: ['', Validators.required],
       email: ['', Validators.required],
       subject: ['', Validators.required],
-      body: ['', Validators.required]
+      body: ['', Validators.required],
+      turnstile_token: [null, Validators.required]
     });
 
     if (this.route.snapshot.queryParams.subject !== undefined) {
@@ -48,7 +49,8 @@ export class ContactFormComponent implements OnInit {
       .postFormMessage({
         from: value.email,
         subject: `Contact - ${value.subject} ${value.fullName !== '' ? '- from ' + value.fullName : ''}`,
-        text: `${value.body}`
+        text: `${value.body}`,
+        token: value.turnstile_token
       })
       .subscribe({
         next: () => {

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/geocode-correction-form/geocode-correction-form.component.html
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/geocode-correction-form/geocode-correction-form.component.html
@@ -29,6 +29,10 @@
     </div>
 
     <div class="form-collection column">
+      <tamu-gisc-turnstile-challenge formControlName="turnstile_token"></tamu-gisc-turnstile-challenge>
+    </div>
+
+    <div class="form-collection column">
       <ng-container *ngIf="(submissionState | async) as ss">
         <ng-container *ngIf="ss === 'complete' || ss === 'error'">
           <div class="inform-context trailer-1 flex justify-center" [ngClass]="{alert: ss === 'error' }">

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/geocode-correction-form/geocode-correction-form.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/geocode-correction-form/geocode-correction-form.component.ts
@@ -34,7 +34,8 @@ export class GeocodeCorrectionFormComponent implements OnInit {
       state: [null, Validators.required],
       zip: ['', Validators.required],
       correctedLat: ['', Validators.required],
-      correctedLon: ['', Validators.required]
+      correctedLon: ['', Validators.required],
+      turnstile_token: [null, Validators.required]
     });
   }
 
@@ -57,7 +58,8 @@ export class GeocodeCorrectionFormComponent implements OnInit {
           Zip: ${value.zip}
           Corrected latitude: ${value.correctedLat}
           Corrected longitude: ${value.correctedLon}
-        `
+        `,
+        token: value.turnstile_token
       })
       .subscribe({
         next: () => {

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/partner-program-form/partner-program-form.component.html
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/partner-program-form/partner-program-form.component.html
@@ -89,6 +89,10 @@
   </div>
 
   <div class="form-collection column">
+    <tamu-gisc-turnstile-challenge formControlName="turnstile_token"></tamu-gisc-turnstile-challenge>
+  </div>
+
+  <div class="form-collection column">
     <ng-container *ngIf="(submissionState | async) as ss">
       <ng-container *ngIf="ss === 'complete' || ss === 'error'">
         <div class="inform-context trailer-1 flex justify-center" [ngClass]="{alert: ss === 'error' }">

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/partner-program-form/partner-program-form.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/partner-program-form/partner-program-form.component.ts
@@ -60,7 +60,8 @@ export class PartnerProgramFormComponent implements OnInit {
       partnerWebsite: [null, Validators.required],
       partnerOrgDescription: [null, Validators.required],
       partnerUsageDescription: [null, Validators.required],
-      partnerTermsOfUseAgree: [false, Validators.requiredTrue]
+      partnerTermsOfUseAgree: [false, Validators.requiredTrue],
+      turnstile_token: [null, Validators.required]
     });
   }
 
@@ -106,7 +107,8 @@ export class PartnerProgramFormComponent implements OnInit {
       .postFormMessage({
         from: value.email,
         subject: 'Partner Application',
-        text: message
+        text: message,
+        token: value.turnstile_token
       })
       .subscribe({
         next: () => {

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/submit-bug-form/submit-bug-form.component.html
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/submit-bug-form/submit-bug-form.component.html
@@ -19,6 +19,10 @@
     </div>
 
     <div class="form-collection column">
+      <tamu-gisc-turnstile-challenge formControlName="turnstile_token"></tamu-gisc-turnstile-challenge>
+    </div>
+
+    <div class="form-collection column">
       <ng-container *ngIf="(submissionState | async) as ss">
         <ng-container *ngIf="ss === 'complete' || ss === 'error'">
           <div class="inform-context trailer-1 flex justify-center" [ngClass]="{alert: ss === 'error' }">

--- a/libs/geoservices/ngx/src/lib/core/modules/forms/submit-bug-form/submit-bug-form.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/modules/forms/submit-bug-form/submit-bug-form.component.ts
@@ -27,7 +27,8 @@ export class SubmitBugFormComponent implements OnInit {
       subject: ['Bug report', Validators.required],
       fullName: ['', Validators.required],
       email: ['', Validators.required],
-      body: ['', Validators.required]
+      body: ['', Validators.required],
+      turnstile_token: [null, Validators.required]
     });
   }
 
@@ -42,7 +43,8 @@ export class SubmitBugFormComponent implements OnInit {
       .postFormMessage({
         from: value.email,
         subject: `${value.subject} ${value.fullName !== '' ? '- from ' + value.fullName : ''}`,
-        text: value.body
+        text: value.body,
+        token: value.turnstile_token
       })
       .subscribe({
         next: () => {

--- a/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.html
+++ b/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.html
@@ -1,0 +1,1 @@
+<div class="turnstile-container"></div>

--- a/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.scss
+++ b/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.scss
@@ -1,0 +1,3 @@
+:host {
+  min-height: 72px; // Set static height to avoid layout shift
+}

--- a/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.spec.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TurnstileChallengeComponent } from './turnstile-challenge.component';
+
+describe('TurnstileChallengeComponent', () => {
+  let component: TurnstileChallengeComponent;
+  let fixture: ComponentFixture<TurnstileChallengeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TurnstileChallengeComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TurnstileChallengeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/components/turnstile-challenge/turnstile-challenge.component.ts
@@ -1,0 +1,57 @@
+import { DOCUMENT } from '@angular/common';
+import { ChangeDetectorRef, Component, forwardRef, Inject, OnInit, Renderer2 } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+
+import { AbstractValueAccessorFormComponent } from '../../models/abstract-value-accessor-form/abstract-value-accessor-form.component';
+
+@Component({
+  selector: 'tamu-gisc-turnstile-challenge',
+  templateUrl: './turnstile-challenge.component.html',
+  styleUrls: ['./turnstile-challenge.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TurnstileChallengeComponent),
+      multi: true
+    }
+  ]
+})
+export class TurnstileChallengeComponent extends AbstractValueAccessorFormComponent<string> implements OnInit {
+  constructor(
+    private cdd: ChangeDetectorRef,
+    private readonly renderer: Renderer2,
+    @Inject(DOCUMENT) private _document: Document,
+    private readonly env: EnvironmentService
+  ) {
+    super(cdd);
+  }
+
+  public ngOnInit(): void {
+    const script = this.renderer.createElement('script');
+    script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    script.type = 'text/javascript';
+    script.defer = true;
+
+    this.renderer.appendChild(this._document.body, script);
+
+    script.onload = () => {
+      this.initChallenge();
+    };
+  }
+
+  private initChallenge(): void {
+    const turnstile = window['turnstile'];
+    if (turnstile) {
+      turnstile.render('.turnstile-container', {
+        sitekey: this.env.value('turnstile_sitekey'),
+        callback: (token) => {
+          this.value = token;
+        }
+      });
+    } else {
+      console.error('Error initializing Turnstile challenge.');
+    }
+  }
+}

--- a/libs/ui-kits/ngx/forms/src/lib/ui-kits-ngx-forms.module.ts
+++ b/libs/ui-kits/ngx/forms/src/lib/ui-kits-ngx-forms.module.ts
@@ -19,6 +19,7 @@ import { FileComponent } from './components/file/file.component';
 import { RadioGroupComponent } from './components/radio-group/radio-group.component';
 import { SlideToggleComponent } from './components/slide-toggle/slide-toggle.component';
 import { SelectListComponent } from './components/select-list/select-list.component';
+import { TurnstileChallengeComponent } from './components/turnstile-challenge/turnstile-challenge.component';
 
 @NgModule({
   imports: [
@@ -41,7 +42,8 @@ import { SelectListComponent } from './components/select-list/select-list.compon
     RadioGroupComponent,
     RangeComponent,
     SlideToggleComponent,
-    SelectListComponent
+    SelectListComponent,
+    TurnstileChallengeComponent
   ],
   exports: [
     SelectComponent,
@@ -54,7 +56,8 @@ import { SelectListComponent } from './components/select-list/select-list.compon
     RadioGroupComponent,
     RangeComponent,
     SlideToggleComponent,
-    SelectListComponent
+    SelectListComponent,
+    TurnstileChallengeComponent
   ]
 })
 export class UIFormsModule {}


### PR DESCRIPTION
Adds a turnstile front-end widget as a form component and back-end token validation.  

Applied to GSVCS contact forms.