### PR TITLE
feat(common-ngx-environment): Consolidate environment traceability

### DIFF
--- a/apps/geoservices-angular/src/environments/definitions.ts
+++ b/apps/geoservices-angular/src/environments/definitions.ts
@@ -1,6 +1,8 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 import { SearchSource } from '@tamu-gisc/ui-kits/ngx/search';
 
+export { metadata } from '@tamu-gisc/common/ngx/environment';
+
 export const NotificationEvents = [];
 
 export const SearchSources: SearchSource[] = [];

--- a/apps/geoservices-angular/src/environments/environment.dev.ts
+++ b/apps/geoservices-angular/src/environments/environment.dev.ts
@@ -2,15 +2,14 @@ export const environment = {
   production: true
 };
 
+export { metadata } from '@tamu-gisc/common/ngx/environment';
+
 export const api_url = `https://nodes.geoservices.tamu.edu/api/gsvcs-transport/`;
 export const legacy_host = 'https://geoservices-dev.geoservices.tamu.edu';
 export const legacy_api_url = `https://geoservices-dev.geoservices.tamu.edu/rest/`;
 export const accounts_url = `https://geoservices-dev.geoservices.tamu.edu`;
 export const geoprocessing_api_host_override = `https://geoservices-dev.geoservices.tamu.edu/api`;
 
-export const release_id = '___RELEASE_ID___';
-export const machine_name = '___MACHINE_NAME___';
-export const environment_mode = '___ENVIRONMENT_MODE___';
 export const turnstile_sitekey = '___TURNSTILE_SITE_KEY___';
 
 export * from './definitions';

--- a/apps/geoservices-angular/src/environments/environment.prod.ts
+++ b/apps/geoservices-angular/src/environments/environment.prod.ts
@@ -2,15 +2,14 @@ export const environment = {
   production: true
 };
 
+export { metadata } from '@tamu-gisc/common/ngx/environment';
+
 export const api_url = `___API_URL___`;
 export const legacy_host = '___LEGACY_HOST___';
 export const legacy_api_url = `___LEGACY_API_URL___`;
 export const accounts_url = `___ACCOUNTS_URL___`;
 export const geoprocessing_api_host_override = `___GEOPROCESSING_API_HOST_OVERRIDE___`;
 
-export const release_id = '___RELEASE_ID___';
-export const machine_name = '___MACHINE_NAME___';
-export const environment_mode = '___ENVIRONMENT_MODE___';
 export const turnstile_sitekey = '___TURNSTILE_SITE_KEY___';
 
 export * from './definitions';

--- a/apps/gisday-angular/src/environments/common.config.ts
+++ b/apps/gisday-angular/src/environments/common.config.ts
@@ -2,6 +2,8 @@ import { NotificationProperties } from '@tamu-gisc/common/ngx/ui/notification';
 import { LayerSource } from '@tamu-gisc/common/types';
 import { SearchSource } from '@tamu-gisc/ui-kits/ngx/search';
 
+export { metadata } from '@tamu-gisc/common/ngx/environment';
+
 export const api_url = '___ANGULAR_API_URL___';
 
 export const auth0 = {
@@ -11,14 +13,6 @@ export const auth0 = {
   audience: '___ANGULAR_AUTH0_AUDIENCE___',
   roles_claim: '___ANGULAR_AUTH0_ROLES_CLAIM___',
   urls: ['___ANGULAR_AUTH0_URLS___']
-};
-
-export const metadata = {
-  buildDate: '___BUILD_DATE___',
-  gitCommit: '___GIT_COMMIT___',
-  gitTag: '___GIT_TAG___',
-  containerName: '___CONTAINER_NAME___',
-  nodeName: '___NODE_NAME___'
 };
 
 export const NotificationEvents: NotificationProperties[] = [

--- a/libs/common/ngx/environment/src/index.ts
+++ b/libs/common/ngx/environment/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/common-ngx-environment.module';
 
 export * from './lib/services/environment.service';
+export * from './lib/constants/build-traceability.constants';

--- a/libs/common/ngx/environment/src/lib/constants/build-traceability.constants.ts
+++ b/libs/common/ngx/environment/src/lib/constants/build-traceability.constants.ts
@@ -1,0 +1,17 @@
+export const metadata = {
+  buildDate: '___BUILD_DATE___',
+  gitCommit: '___GIT_COMMIT___',
+  gitTag: '___GIT_TAG___',
+  containerName: '___CONTAINER_NAME___',
+  nodeName: '___NODE_NAME___',
+  environment: '___ENVIRONMENT_MODE___'
+};
+
+export interface ReleaseMetadata {
+  buildDate: string;
+  gitCommit: string;
+  gitTag: string;
+  containerName: string;
+  nodeName: string;
+  environment: string;
+}

--- a/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.html
+++ b/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.html
@@ -1,5 +1,5 @@
 <div class="container12">
   <div class="column12">
-    <p><span>{{ release_meta?.nodeName }}</span> | <span>{{(release_meta)?.gitTag}} |</span> {{ release_meta?.environment }}</p>
+    <p><span>{{ release_meta?.containerName }}</span> | <span clipboard-copy [text]="release_meta?.gitCommit">{{(release_meta)?.gitTag}} |</span> {{ release_meta?.environment }}</p>
   </div>
 </div>

--- a/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.html
+++ b/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.html
@@ -1,5 +1,5 @@
 <div class="container12">
   <div class="column12">
-    <p><span>{{ (release_meta.args | async)?.machine_name }}</span> | <span *ngIf="release_meta.isRelease | async">{{(release_meta.args | async)?.release}} |</span> {{ (release_meta.args | async)?.environment }}</p>
+    <p><span>{{ release_meta?.nodeName }}</span> | <span>{{(release_meta)?.gitTag}} |</span> {{ release_meta?.environment }}</p>
   </div>
 </div>

--- a/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.ts
+++ b/libs/geoservices/ngx/src/lib/core/components/footer/release-info/release-info.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { map, ReplaySubject } from 'rxjs';
 
-import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+import { EnvironmentService, ReleaseMetadata } from '@tamu-gisc/common/ngx/environment';
 
 @Component({
   selector: 'tamu-gisc-release-info',
@@ -9,36 +8,11 @@ import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
   styleUrls: ['./release-info.component.scss']
 })
 export class ReleaseInfoComponent implements OnInit {
-  public release_meta: ReleaseInfo;
+  public release_meta: ReleaseMetadata;
 
   constructor(private readonly env: EnvironmentService) {}
 
   public ngOnInit(): void {
-    this.release_meta = new ReleaseInfo({
-      release: this.env.value('release_id', true) || null,
-      machine_name: this.env.value('machine_name', true) || 'localhost',
-      environment: this.env.value('environment_mode', true) || 'local'
-    });
+    this.release_meta = this.env.value('metadata');
   }
-}
-
-export class ReleaseInfo {
-  private _args: ReplaySubject<ReleaseMetaData> = new ReplaySubject(1);
-  public args = this._args.asObservable();
-
-  public isRelease = this.args.pipe(
-    map((a: ReleaseMetaData) => {
-      return a.release !== null;
-    })
-  );
-
-  constructor(a: ReleaseMetaData) {
-    this._args.next(a);
-  }
-}
-
-export interface ReleaseMetaData {
-  release: string;
-  machine_name: string;
-  environment: string;
 }

--- a/libs/geoservices/ngx/src/lib/core/geoservices-core-ngx.module.ts
+++ b/libs/geoservices/ngx/src/lib/core/geoservices-core-ngx.module.ts
@@ -6,6 +6,7 @@ import { PipesModule } from '@tamu-gisc/common/ngx/pipes';
 import { UILayoutModule } from '@tamu-gisc/ui-kits/ngx/layout';
 import { UITileNavigationModule } from '@tamu-gisc/ui-kits/ngx/navigation/mobile-tile';
 import { UINavigationTriggersModule } from '@tamu-gisc/ui-kits/ngx/navigation/triggers';
+import { UIClipboardModule } from '@tamu-gisc/ui-kits/ngx/interactions/clipboard';
 
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
@@ -18,7 +19,15 @@ import { RevivalModalComponent } from './components/modals/revival-modal/revival
 import { RevivalBannerComponent } from './components/revival-banner/revival-banner.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule, PipesModule, UILayoutModule, UITileNavigationModule, UINavigationTriggersModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    PipesModule,
+    UILayoutModule,
+    UITileNavigationModule,
+    UINavigationTriggersModule,
+    UIClipboardModule
+  ],
   declarations: [
     HeaderComponent,
     FooterComponent,


### PR DESCRIPTION
Pull the common image build traceability variables used in gisday-angular so they can be used across all ngx projects without requiring specific application-specific implementation.