### PR TITLE
feat(common-utils-string): Add nullish value support to TemplateRenderer class

### DIFF
--- a/libs/common/utils/string/src/lib/common-utils-string.ts
+++ b/libs/common/utils/string/src/lib/common-utils-string.ts
@@ -10,6 +10,7 @@ export class TemplateRenderer {
   public template: TemplateRendererOptions['template'];
   public lookup: TemplateRendererOptions['lookup'];
   public replacement: TemplateRendererOptions['replacement'];
+  public options: TemplateRendererOptions['options'];
 
   /**
    * Creates an instance of TemplateRenderer.
@@ -23,6 +24,7 @@ export class TemplateRenderer {
     this.template = props.template || undefined;
     this.lookup = props.lookup || undefined;
     this.replacement = props.replacement || undefined;
+    this.options = props.options || {};
   }
 
   /**
@@ -36,8 +38,18 @@ export class TemplateRenderer {
       });
     } else if (this.template && this.lookup) {
       return this.template.replace(/\{.*?\}/g, (match: string) => {
+        const resolved = getPropertyValue<string>(this.lookup, match.replace('{', '').replace('}', ''));
         // Remove template braces before setting value from lookup object.
-        return getPropertyValue<string>(this.lookup, match.replace('{', '').replace('}', ''));
+
+        if (this.options?.nullishReplacement !== undefined && (resolved === undefined || resolved === null)) {
+          return this.options.nullishReplacement;
+        }
+
+        if (this.options?.trim) {
+          return resolved.trim();
+        }
+
+        return resolved;
       });
     }
   }
@@ -78,4 +90,22 @@ export interface TemplateRendererOptions {
    * If using inputObject, values will be derived from property value lookup.
    */
   replacement?: string;
+
+  options?: {
+    /**
+     * String to replace null\undefined values with.
+     *
+     * This is useful when rendering templates that may contain nullish values.
+     *
+     * Default behavior is to render the template as is.
+     */
+    nullishReplacement?: string;
+
+    /**
+     * Trim the resulting string.
+     *
+     * Default is `false`: behavior is to not trim the resulting string.
+     */
+    trim?: boolean;
+  };
 }

--- a/libs/maps/feature/popup/src/lib/services/popup.service.ts
+++ b/libs/maps/feature/popup/src/lib/services/popup.service.ts
@@ -69,7 +69,11 @@ export class PopupService {
               if (dotNotationPathOrDefinition.includes('{') && dotNotationPathOrDefinition.includes('}')) {
                 acc[key] = new TemplateRenderer({
                   template: dotNotationPathOrDefinition,
-                  lookup: topGraphic
+                  lookup: topGraphic,
+                  options: {
+                    nullishReplacement: '',
+                    trim: true
+                  }
                 }).render();
               } else {
                 acc[key] = getPropertyValue(topGraphic, dotNotationPathOrDefinition);

--- a/libs/ts/events/ngx/src/lib/modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="popup-section">
-  <p class="trailer-1" *ngIf="data?.attributes?.description" [innerHTML]="data.attributes?.description"></p>
+  <p class="trailer-1" *ngIf="isContentLengthZero === false" [innerHTML]="data.attributes?.description"></p>
 
   <div class="button" tabindex="0" role="button" (click)="startDirections()">Directions To Here</div>
 </div>

--- a/libs/ts/events/ngx/src/lib/modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component.ts
@@ -10,6 +10,7 @@ import { BaseDirectionsComponent } from '@tamu-gisc/aggiemap/ngx/popups';
 export class MarkdownWDirectionsPopupComponent extends BaseDirectionsComponent implements OnInit {
   public title: string;
   public isContentTheSame: boolean;
+  public isContentLengthZero: boolean;
 
   public override ngOnInit(): void {
     super.ngOnInit();
@@ -17,6 +18,9 @@ export class MarkdownWDirectionsPopupComponent extends BaseDirectionsComponent i
     this.title = this.data?.attributes?.name ? this.data.attributes.name : this.data.layer.title;
 
     this.isContentTheSame = this.data?.attributes?.description === this.data?.attributes?.Notes;
+
+    this.isContentLengthZero =
+      typeof this.data?.attributes?.description === 'string' && this.data?.attributes?.description.trim().length === 0;
   }
 
   public override startDirections() {


### PR DESCRIPTION
Adds additional options when rendering a template with a lookup object that enable the resolved strings to be cleaned up before getting sent back.

Options include:

- ability to replace nullish values with a defined string
- ability to trim a resolved template