### PR TITLE
fix(aggiemap-angular): Fix dining location date parsing for Safari 

### DIFF
--- a/libs/aggiemap/ngx/popups/src/lib/components/dining/dining.component.ts
+++ b/libs/aggiemap/ngx/popups/src/lib/components/dining/dining.component.ts
@@ -78,8 +78,14 @@ export class DiningPopupComponent extends BaseDirectionsComponent implements OnI
         concatMap((days) => Object.entries(days)),
         reduce((acc, [datestamp, info]) => {
           const formattedHours = info.hours.map((hour) => {
-            const start = new Date(`${datestamp}, ${hour.start_hour}:${hour.start_minutes}:00`);
-            const end = new Date(`${datestamp}, ${hour.end_hour}:${hour.end_minutes}:00`);
+            const start = new Date(
+              `${datestamp}T${hour.start_hour.toString().padStart(2, '0')}:${hour.start_minutes
+                .toString()
+                .padStart(2, '0')}:00`
+            );
+            const end = new Date(
+              `${datestamp}T${hour.end_hour.toString().padStart(2, '0')}:${hour.end_minutes.toString().padStart(2, '0')}:00`
+            );
 
             return {
               start,


### PR DESCRIPTION
Safari parses dates differently than chromium (being stricter about the input format, surprise) which caused dining location popup schedule to not show up, or the open/close time