### PR TITLE
feat(aggiemap-angular): Support Selective Layer Loading

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -29,6 +29,7 @@ export function LayerSources(
       popupComponent: definitions.BUILDINGS.popupComponent,
       listMode: 'hide',
       visible: true,
+      essential: true,
       layerIndex: 1,
       native: {
         ...commonLayerProps,
@@ -54,6 +55,7 @@ export function LayerSources(
       popupComponent: definitions.CONSTRUCTION.popupComponent,
       listMode: 'show',
       visible: true,
+      essential: true,
       layerIndex: 2,
       native: {
         ...commonLayerProps,
@@ -192,6 +194,7 @@ export function LayerSources(
       title: 'Selected Buildings',
       listMode: 'hide',
       visible: true,
+      essential: true,
       popupComponent: definitions.BUILDINGS.popupComponent,
       native: {
         ...commonLayerProps

--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -292,6 +292,10 @@ export type LayerSource = LayerSourceType & {
    * Defaults to `true`
    *
    * @deprecated Property has no function since implementation of esri's LayerListViewModel.
+   *
+   * Prefer the use of the `visible` property to control the initial visibility of the layer.
+   * Do note that layer visibility still ads the layer to the map, but it will not be rendered until the layer is visible.
+   * There is no support for lazy loading layers at the moment.
    */
   loadOnInit?: boolean;
 
@@ -301,6 +305,19 @@ export type LayerSource = LayerSourceType & {
    * Will default to true;
    */
   visible?: boolean;
+
+  /**
+   * Determines whether this layer is essential and should always be added to the map,
+   * regardless of specific layer requests or filtering.
+   *
+   * Essential layers are typically foundational layers like base buildings, roads,
+   * or other infrastructure that provide necessary context for the map.
+   *
+   * If layer visibility is set to `false`, it will be overridden in favor of `true`
+   *
+   * Defaults to `false`
+   */
+  essential?: boolean;
 
   /**
    * Template that is shows when a feature from this layer is selected.

--- a/libs/maps/esri/src/lib/services/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Component, Type } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Observable, BehaviorSubject, lastValueFrom } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -47,6 +47,7 @@ export class EsriMapService {
   constructor(
     private moduleProvider: EsriModuleProviderService,
     private router: Router,
+    private route: ActivatedRoute,
     private searchService: SearchService,
     private environment: EnvironmentService,
     private http: HttpClient
@@ -116,7 +117,7 @@ export class EsriMapService {
       view: this._modules.view
     });
 
-    const layerSources: Array<LayerSource> = this.environment.value('LayerSources');
+    const layerSources: Array<LayerSource> = this.filterLayerSources(null, { params: true });
 
     // Filter list of layers that need to be added on map load
     await this.loadLayers(layerSources);
@@ -636,6 +637,50 @@ export class EsriMapService {
    */
   public clearHitTest() {
     this._hitTest.next({ graphics: [] });
+  }
+
+  /**
+   * Returns a list of layer sources, applying various filters if specified. This is used
+   * to limit the number of layers that are loaded on map load when requested.
+   *
+   * @param {LayerSource} sources
+   * @param {{ params?: boolean }} [filters] Optional filters to apply to the layer sources.
+   * If `params` is set to true, it will return only those layers that have an `essential` property defined AND
+   * the current application route contains 'layers' query params.
+   * @return {*}  {Array<LayerSource>}
+   * @memberof EsriMapService
+   */
+  public filterLayerSources(sources?: LayerSource, filters?: { params?: boolean }): Array<LayerSource> {
+    // Get the layer sources from the environment
+    let ret: Array<LayerSource> = sources || this.environment.value('LayerSources');
+
+    if (!ret || ret.length === 0) {
+      // If no layer sources are defined, return an empty array
+      console.warn('No layer sources defined in the environment. Not loading any layers.');
+
+      return [];
+    }
+
+    if (filters && filters?.params) {
+      const queryParams = this.route.snapshot.queryParams;
+
+      if (queryParams && queryParams['layers']) {
+        const requestedLayerIds: Array<string> = queryParams['layers'].split(',');
+
+        // If the filters parameter is set, filter out any layer sources that do not have a params property
+        ret = ret
+          .filter((source) => {
+            return source?.essential || requestedLayerIds.includes(source.id);
+          })
+          .map((s) => {
+            s.visible = true;
+
+            return s;
+          });
+      }
+    }
+
+    return ret;
   }
 
   /**

--- a/libs/maps/esri/src/lib/services/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map.service.ts
@@ -643,14 +643,12 @@ export class EsriMapService {
    * Returns a list of layer sources, applying various filters if specified. This is used
    * to limit the number of layers that are loaded on map load when requested.
    *
-   * @param {LayerSource} sources
+   * @param {LayerSource[]} sources
    * @param {{ params?: boolean }} [filters] Optional filters to apply to the layer sources.
    * If `params` is set to true, it will return only those layers that have an `essential` property defined AND
    * the current application route contains 'layers' query params.
-   * @return {*}  {Array<LayerSource>}
-   * @memberof EsriMapService
    */
-  public filterLayerSources(sources?: LayerSource, filters?: { params?: boolean }): Array<LayerSource> {
+  public filterLayerSources(sources?: LayerSource[], filters?: { params?: boolean }): Array<LayerSource> {
     // Get the layer sources from the environment
     let ret: Array<LayerSource> = sources || this.environment.value('LayerSources');
 
@@ -673,9 +671,7 @@ export class EsriMapService {
             return source?.essential || requestedLayerIds.includes(source.id);
           })
           .map((s) => {
-            s.visible = true;
-
-            return s;
+            return { ...s, visible: true };
           });
       }
     }


### PR DESCRIPTION
This enables the loading of a thin version of Aggiemap from existing layers which is useful for reducing the number of default layers inside application wrappers or embeds.

Resolved layers from ID are additionally enabled on load, overwriting their LayerSource definition setting.