### PR TITLE
feat(aggiemap-angular): Updates 3D endpoint + enable production

### DIFF
--- a/apps/aggiemap-angular/src/assets/directory.html
+++ b/apps/aggiemap-angular/src/assets/directory.html
@@ -13,7 +13,9 @@
 
     <h3>3D</h3>
     <ul>
-      <li><a href="https://dev.aggiemap.tamu.edu/3d/arch-angular" target="_blank" rel="noopener noreferrer">Architecture Master Plan Buildings</a></li>
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/3d/arch-angular" target="_blank" rel="noopener noreferrer">Architecture Master Plan Buildings</a>
+      </li>
 
       <li>
         <a href="https://dev.aggiemap.tamu.edu/3d/dom" target="_blank" rel="noopener noreferrer">Dominic 3D Sketchup Buildings</a>
@@ -68,9 +70,11 @@
           <li>Different color meshes with detailed exterior features.</li>
         </ul>
       </li>
+    </ul>
 
-      <h3>2D</h3>
+    <h3>2D</h3>
 
+    <ul>
       <li>
         <a href="https://dev.aggiemap.tamu.edu/graduation/arrival" target="_blank" rel="noopener noreferrer">Graduation Arrival</a>
       </li>
@@ -97,6 +101,66 @@
 
       <li>
         <a href="https://dev.aggiemap.tamu.edu/vector" target="_blank" rel="noopener noreferrer">Vector</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/dining" target="_blank" rel="noopener noreferrer">Dining</a>
+      </li>
+    </ul>
+
+    <h3>Events</h3>
+
+    <ul>
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/aggieland-saturday" target="_blank" rel="noopener noreferrer">Aggieland Saturday</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/big-event" target="_blank" rel="noopener noreferrer">Big Event</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/phys-eng-festival" target="_blank" rel="noopener noreferrer">Physics and Engineering Festival</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/family-weekend" target="_blank" rel="noopener noreferrer">Family Weekend</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/maroon-white-game" target="_blank" rel="noopener noreferrer">Maroon &amp; White Game</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/muster" target="_blank" rel="noopener noreferrer">Muster</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/ms150" target="_blank" rel="noopener noreferrer">Bike MS 150</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/ringday" target="_blank" rel="noopener noreferrer">Ring Day</a>
+      </li>
+
+      <li>
+        <a href="https://aggiemap.tamu.edu/showdown-rivalry" target="_blank" rel="noopener noreferrer">Showdown Rivalry</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/troubadour-festival" target="_blank" rel="noopener noreferrer">Troubadour Festival</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/4h-roundup" target="_blank" rel="noopener noreferrer">4-H Roundup</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/graduation" target="_blank" rel="noopener noreferrer">TAMU Graduation</a>
+      </li>
+
+      <li>
+        <a href="https://dev.aggiemap.tamu.edu/hs-graduation/" target="_blank" rel="noopener noreferrer">High School Graduation</a>
       </li>
     </ul>
   </body>

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Popups } from '@tamu-gisc/aggiemap/ngx/popups';
 
 import { IComposedIDefinitions } from '../definitions';
 import { IComposedConnections } from '../connections';
@@ -316,13 +317,37 @@ export const ThreeDLayers: Array<LayerSource> = [
     url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/SketchupCampus_2082019/SceneServer',
     listMode: 'show',
     visible: true,
+    popupComponent: Popups.BasePopupComponent,
     native: {
+      outFields: ['*'],
+      definitionExpression: "WhereFrom = 'arch'",
       popupEnabled: false,
       elevationInfo: {
         mode: 'absolute-height',
         offset: -107,
         unit: 'meters'
-      }
+      },
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'mesh-3d',
+          symbolLayers: [
+            {
+              type: 'fill',
+              material: {
+                color: 'rgba(209, 210, 202, 1)',
+                colorMixMode: 'replace'
+              },
+              edges: {
+                type: 'solid',
+                color: 'rgba(0, 0, 0, 0.75)',
+                size: '1px'
+              },
+              castShadows: true
+            }
+          ]
+        }
+      } as any
     }
   }
 ];

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -317,7 +317,7 @@ export const ThreeDLayers: Array<LayerSource> = [
     url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/SketchupCampus_2082019/SceneServer',
     listMode: 'show',
     visible: true,
-    popupComponent: Popups.BasePopupComponent,
+    // popupComponent: Popups.BasePopupComponent,
     native: {
       outFields: ['*'],
       definitionExpression: "WhereFrom = 'arch'",

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -313,11 +313,16 @@ export const ThreeDLayers: Array<LayerSource> = [
     type: 'scene',
     id: 'three-d-buildings-scene-layer',
     title: '3D Buildings',
-    url: 'https://arcportal.ts.tamu.edu/arcgis/rest/services/Hosted/ESRI_3D_Presentation_2_0_WSL1/SceneServer',
+    url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/SketchupCampus_2082019/SceneServer',
     listMode: 'show',
     visible: true,
     native: {
-      popupEnabled: false
+      popupEnabled: false,
+      elevationInfo: {
+        mode: 'absolute-height',
+        offset: -107,
+        unit: 'meters'
+      }
     }
   }
 ];

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -26,7 +26,7 @@
   <tamu-gisc-esri-map [config]="c" (loaded)="continue($event)" [ngClass]="{ mobile: isMobile }">
     <div class="map-overlay-ui">
       <div class="overlay-zone top left">
-        <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers" *ngIf="(isDev | async) === true"></tamu-gisc-perspective-toggle>
+        <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers"></tamu-gisc-perspective-toggle>
       </div>
 
       <div class="overlay-zone bottom right">


### PR DESCRIPTION
Corrects 3D endpoint URL, limits 3d features to only existing (exclude future buildings) per the master plan, and restyles to increase contrast

<img width="1080" height="768" alt="image" src="https://github.com/user-attachments/assets/70009196-da0c-46c7-9300-05da430490dd" />
