### PR TITLE
fix(aggiemap-angular): Export 3D Layers Env

### DIFF
--- a/apps/aggiemap-angular/src/environments/environment.prod.ts
+++ b/apps/aggiemap-angular/src/environments/environment.prod.ts
@@ -11,7 +11,7 @@ export const environment = {
 };
 
 export * from './notification-events';
-export const { Connections, Definitions, LayerSources, SearchSources, LegendSources } = factory({
+export const { Connections, Definitions, LayerSources, SearchSources, LegendSources, ThreeDLayers } = factory({
   environment: 'prod',
   layerSources: {
     exclude: ['BIKE_LOCATIONS']


### PR DESCRIPTION
This was missed in #416 because it only ever applied to a build that used the .prod configuration. With this configuration, 3dlayers were never exported, and the feature toggle was failing gracefully, however not displaying the 3d buildings.