### PR TITLE
fix(maps-feature-legend): Legend definitionExpression filtering

### DIFF
--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -2,7 +2,7 @@
   <div [ngSwitch]="group.children">
     <!-- If there are no children in the current group, then iterate through them and list them out -->
     <div *ngSwitchCase="0">
-      <tamu-gisc-legend-element *ngFor="let element of group.legendElements" [element]="element" [layer]="group.layer" [groupTitle]="group.title" [deduplicateChildren]="deduplicate" [respectDefinitionExpression]="respectDefinitionExpression"></tamu-gisc-legend-element>
+      <tamu-gisc-legend-element *ngFor="let element of group.legendElements; trackBy: trackByLegendElement" [element]="element" [layer]="group.layer" [groupTitle]="group.title" [deduplicateChildren]="deduplicate" [respectDefinitionExpression]="respectDefinitionExpression"></tamu-gisc-legend-element>
     </div>
 
     <!-- If the current group has more children, render another collection group. This represents nested layers/groups. -->

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -24,6 +24,18 @@ export class LegendCollectionComponent {
 
   @Input()
   public respectDefinitionExpression = false;
+
+  /**
+   * Function used to track legend elements in the ngFor loop to prevent unnecessary re-renders.
+   *
+   * This is particularly important because nested LegendElements perform async network operations
+   * on component init.
+   */
+  public trackByLegendElement(index: number, el: esri.LegendElement): string {
+    const identifier = el?.infos ? el.infos?.map((i) => `${i.label}-${i.value}`).join(',') : null;
+
+    return identifier;
+  }
 }
 
 // Browser doesn't like direct esri types for inputs.

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -8,7 +8,7 @@ of the table -->
   <ng-container [ngSwitch]="element.type">
     <!-- For SymbolTable element type -->
     <div *ngSwitchCase="'symbol-table'" class="element-group">
-      <div class="legend-info" *ngFor="let info of infos">
+      <div class="legend-info" *ngFor="let info of infos | async">
         <div [ngSwitch]="info.type">
           <!-- Support for infos with nested infos. This case will continue to recursively iterate through n-nested infos until reaching the last node. -->
           <div *ngSwitchCase="'symbol-table'">
@@ -25,7 +25,10 @@ of the table -->
         </div>
 
         <!-- Apply the legend item from the parent group or child -->
-        <div>{{element.infos?.length === 1 ? groupTitle : info?.label}}</div>
+        <div [ngSwitch]="element.infos?.length">
+          <div *ngSwitchCase="1" class="group-title">{{groupTitle}}</div>
+          <div *ngSwitchDefault class="label">{{info?.label}}</div>
+        </div>
       </div>
     </div>
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { EsriModuleProviderService } from '@tamu-gisc/maps/esri';
+
 import { LegendElementComponent } from './legend-element.component';
 
 describe('LegendElementComponent', () => {
@@ -7,8 +9,11 @@ describe('LegendElementComponent', () => {
   let fixture: ComponentFixture<LegendElementComponent>;
 
   beforeEach(async () => {
+    const spy = jasmine.createSpyObj('EsriModuleProviderService', ['require']);
+
     await TestBed.configureTestingModule({
-      declarations: [LegendElementComponent]
+      declarations: [LegendElementComponent],
+      providers: [{ provide: EsriModuleProviderService, useValue: spy }]
     }).compileComponents();
   });
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -9,7 +9,9 @@ describe('LegendElementComponent', () => {
   let fixture: ComponentFixture<LegendElementComponent>;
 
   beforeEach(async () => {
-    const spy = jasmine.createSpyObj('EsriModuleProviderService', ['require']);
+    const spy = {
+      require: jest.fn()
+    };
 
     await TestBed.configureTestingModule({
       declarations: [LegendElementComponent],

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -39,7 +39,7 @@ import esri = __esri;
   styleUrls: ['./legend-element.component.scss']
 })
 export class LegendElementComponent implements OnInit {
-  constructor(private moduleProvider: EsriModuleProviderService) {}
+  constructor(private readonly moduleProvider: EsriModuleProviderService) {}
 
   @Input()
   public element: ILegendElement;
@@ -111,7 +111,7 @@ export class LegendElementComponent implements OnInit {
         } catch (error) {
           console.warn('Failed to evaluate definition expression using ArcGIS API, falling back to simple parsing:', error);
           // Fall back to the original simple parsing approach
-          return this.fallbackToSimpleParsing(operableLayer, renderer, info);
+          return this._fallbackToSimpleParsing(operableLayer, renderer, info);
         }
       }),
       filter((infoOrNull) => {
@@ -142,7 +142,7 @@ export class LegendElementComponent implements OnInit {
     // Test each legend info by performing a query to see if it would return any features
     try {
       // Construct the where clause for this specific legend value
-      const legendWhereClause = this.buildLegendWhereClause(renderer, operableFields, info);
+      const legendWhereClause = this._buildLegendWhereClause(renderer, operableFields, info);
 
       // Combine the legend where clause with the layer's definition expression
       const combinedWhere = layer.definitionExpression
@@ -178,7 +178,7 @@ export class LegendElementComponent implements OnInit {
   /**
    * Builds a where clause for a specific legend value based on the renderer configuration
    */
-  private buildLegendWhereClause(renderer: esri.UniqueValueRenderer, operableFields: string[], info: unknown): string {
+  private _buildLegendWhereClause(renderer: esri.UniqueValueRenderer, operableFields: string[], info: unknown): string {
     const infoValue = (info as { value: string }).value;
 
     if (!infoValue) {
@@ -224,7 +224,7 @@ export class LegendElementComponent implements OnInit {
   /**
    * Fallback to the original simple parsing approach if the API-based method fails
    */
-  private fallbackToSimpleParsing(operableLayer: esri.FeatureLayer, renderer: esri.UniqueValueRenderer, info: LegendInfo) {
+  private _fallbackToSimpleParsing(operableLayer: esri.FeatureLayer, renderer: esri.UniqueValueRenderer, info: LegendInfo) {
     // Determine how many fields are expected in the renderer value string.
     // This is necessary because the renderer value string can be a concatenation of multiple fields.
     const operableFields = [renderer.field, renderer.field2, renderer.field3].filter((f) => f !== null);

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -1,6 +1,37 @@
 import { Component, Input, OnInit } from '@angular/core';
 
+import { EsriModuleProviderService } from '@tamu-gisc/maps/esri';
+import {
+  catchError,
+  concatMap,
+  distinctUntilChanged,
+  filter,
+  from,
+  iif,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  toArray
+} from 'rxjs';
+
 import esri = __esri;
+
+/**
+ * Legend Element Component
+ *
+ * This component renders individual legend elements and provides enhanced support for
+ * definition expression filtering. The component now uses ArcGIS JS API capabilities
+ * to accurately determine legend element visibility based on complex T-SQL definition
+ * expressions, moving beyond simple string parsing.
+ *
+ * Key improvements:
+ * - Uses layer.queryFeatureCount() to test if legend values would return features
+ * - Properly handles complex T-SQL expressions with joins, functions, and nested conditions
+ * - Escapes SQL values properly to prevent injection issues
+ * - Falls back to original simple parsing if API queries fail
+ * - Supports multi-field unique value renderers with proper field delimiter handling
+ */
 
 @Component({
   selector: 'tamu-gisc-legend-element',
@@ -8,6 +39,8 @@ import esri = __esri;
   styleUrls: ['./legend-element.component.scss']
 })
 export class LegendElementComponent implements OnInit {
+  constructor(private moduleProvider: EsriModuleProviderService) {}
+
   @Input()
   public element: ILegendElement;
 
@@ -28,53 +61,170 @@ export class LegendElementComponent implements OnInit {
   @Input()
   public respectDefinitionExpression = false;
 
-  public infos:
-    | any[]
-    | esri.SymbolTableElementType[]
-    | esri.ColorRampStop[]
-    | esri.OpacityRampStop[]
-    | esri.SizeRampStop[]
-    | esri.HeatmapRampStop[];
+  public infos: Observable<Array<LegendInfo>>;
 
-  public ngOnInit(): void {
-    if (this.deduplicateChildren) {
-      this.infos = this.element.infos.filter((info, index, self) => {
-        return index === self.findIndex((t) => t.label === info.label);
-      });
-    } else {
-      this.infos = this.element.infos;
+  public async ngOnInit(): Promise<void> {
+    this.infos = iif(
+      () => {
+        return this.deduplicateChildren;
+      },
+      from(
+        this.element.infos.filter((info, index, self) => {
+          return index === self.findIndex((t) => t.label === info.label);
+        }) as Array<LegendInfo>
+      ),
+      from(this.element.infos as Array<LegendInfo>)
+    ).pipe(
+      concatMap((info) => {
+        // If we are not respecting definition expressions, return the current legend info as-is
+        if (this.respectDefinitionExpression === false || this.layer === undefined) {
+          return of(info);
+        }
+
+        const operableLayer = this.layer as esri.FeatureLayer;
+
+        // If operable layer has no definition expression, return the current legend info as-is
+        if (operableLayer.definitionExpression === null || operableLayer.definitionExpression === undefined) {
+          return of(info);
+        }
+
+        const renderer = operableLayer.renderer as esri.UniqueValueRenderer;
+
+        if (renderer.type !== 'unique-value') {
+          return of(info);
+        }
+
+        if (
+          renderer === null ||
+          renderer === undefined ||
+          renderer.uniqueValueInfos === null ||
+          renderer.uniqueValueInfos === undefined ||
+          renderer.uniqueValueInfos.length === 0
+        ) {
+          return of(info);
+        }
+
+        // Otherwise, we need to filter the infos based on the layer's definition expression
+        try {
+          // Use ArcGIS JS API to robustly evaluate definition expression against legend values
+          return this._filterLegendInfosWithQuery(operableLayer, renderer, info);
+        } catch (error) {
+          console.warn('Failed to evaluate definition expression using ArcGIS API, falling back to simple parsing:', error);
+          // Fall back to the original simple parsing approach
+          return this.fallbackToSimpleParsing(operableLayer, renderer, info);
+        }
+      }),
+      filter((infoOrNull) => {
+        return infoOrNull !== null;
+      }),
+      toArray(),
+      distinctUntilChanged(),
+      shareReplay(1)
+    );
+  }
+
+  /**
+   * Uses ArcGIS JS API to robustly evaluate which legend items would return features
+   * given the current definition expression. This handles complex T-SQL expressions properly.
+   */
+  private _filterLegendInfosWithQuery(
+    layer: esri.FeatureLayer,
+    renderer: esri.UniqueValueRenderer,
+    info: LegendInfo
+  ): Observable<LegendInfo> {
+    // Get the fields used in the renderer
+    const operableFields = [renderer.field, renderer.field2, renderer.field3].filter((f) => f !== null && f !== undefined);
+
+    if (operableFields.length === 0) {
+      return of(info); // No operable fields, return as is
     }
 
-    // Return early if we are not respecting definition expressions or there is no operable layer
-    if (this.respectDefinitionExpression === false || this.layer === undefined) {
-      return;
+    // Test each legend info by performing a query to see if it would return any features
+    try {
+      // Construct the where clause for this specific legend value
+      const legendWhereClause = this.buildLegendWhereClause(renderer, operableFields, info);
+
+      // Combine the legend where clause with the layer's definition expression
+      const combinedWhere = layer.definitionExpression
+        ? `(${layer.definitionExpression}) AND (${legendWhereClause})`
+        : legendWhereClause;
+
+      return from(
+        layer.queryFeatureCount({
+          where: combinedWhere
+        })
+      ).pipe(
+        map((count) => {
+          // If count is greater than 0, the legend item is valid
+          if (count > 0) {
+            return info;
+          } else {
+            // If count is 0, the legend item is not valid
+            return null;
+          }
+        }),
+        catchError((error) => {
+          console.error('Error querying layer for legend item:', info, error);
+          return of(null);
+        })
+      );
+    } catch (error) {
+      // If query fails for this specific legend item, include it to be safe
+      console.warn('Failed to evaluate legend item, including in legend:', info, error);
+      return of(info);
+    }
+  }
+
+  /**
+   * Builds a where clause for a specific legend value based on the renderer configuration
+   */
+  private buildLegendWhereClause(renderer: esri.UniqueValueRenderer, operableFields: string[], info: unknown): string {
+    const infoValue = (info as { value: string }).value;
+
+    if (!infoValue) {
+      return '1=1'; // Return all if no value
     }
 
-    const operableLayer = this.layer as esri.FeatureLayer;
+    // Split the value by the field delimiter to get individual field values
+    //
+    // infoValues can be a concatenation of several fields, in which case they need to be split into value parts.
+    //
+    // However in many cases there is a single value, and it can be of type string or number (possibly boolean),
+    // in which case we need to simply use it as is.
+    //
+    // Have not seen a hybrid of multiple data types so that particular case is not handled and will simply
+    // default to showing it on the legend.
 
-    // If operable layer has no definition expression, return early
-    if (operableLayer.definitionExpression === null || operableLayer.definitionExpression === undefined) {
-      return;
-    }
+    const valueParts = typeof infoValue === 'string' ? `${infoValue}`.split(renderer.fieldDelimiter || ',') : [infoValue];
 
-    const renderer = operableLayer.renderer as esri.UniqueValueRenderer;
+    const whereParts: string[] = [];
 
-    // Ensure that the renderer is a unique value renderer
-    if (renderer.type !== 'unique-value') {
-      return;
-    }
+    // Build where clause parts for each field
+    operableFields.forEach((field, index) => {
+      if (index < valueParts.length) {
+        const value = valueParts[index];
 
-    // Ensure that the renderer has operable unique value infos
-    if (
-      renderer === null ||
-      renderer === undefined ||
-      renderer.uniqueValueInfos === null ||
-      renderer.uniqueValueInfos === undefined ||
-      renderer.uniqueValueInfos.length === 0
-    ) {
-      return;
-    }
+        // Handle different value types and proper SQL escaping
+        if (value === null || value === undefined || value === 'null') {
+          whereParts.push(`${field} IS NULL`);
+        } else if (typeof value === 'string') {
+          // Escape single quotes and wrap in quotes for string values
+          const escapedValue = value.replace(/'/g, "''");
+          whereParts.push(`${field} = '${escapedValue}'`);
+        } else {
+          // Numeric or other values
+          whereParts.push(`${field} = ${value}`);
+        }
+      }
+    });
 
+    return whereParts.length > 0 ? whereParts.join(' AND ') : '1=1';
+  }
+
+  /**
+   * Fallback to the original simple parsing approach if the API-based method fails
+   */
+  private fallbackToSimpleParsing(operableLayer: esri.FeatureLayer, renderer: esri.UniqueValueRenderer, info: LegendInfo) {
     // Determine how many fields are expected in the renderer value string.
     // This is necessary because the renderer value string can be a concatenation of multiple fields.
     const operableFields = [renderer.field, renderer.field2, renderer.field3].filter((f) => f !== null);
@@ -99,23 +249,35 @@ export class LegendElementComponent implements OnInit {
 
     // Test if either expression includes any of the fields in the renderer value string.
     // If it does, we can filter the legend element infos to only include those that match the definition expression.
-    const filteredInfos = this.infos.filter((info) => {
-      // Deconstruct legend info.value so we can accurately compare it to the definition expression.
-      const valueParts = operableFields.length ? info.value.split(renderer.fieldDelimiter) : [info.value];
+    // Deconstruct legend info.value so we can accurately compare it to the definition expression.
+    const infoWithValue = info as { value: string };
+    const valueParts = operableFields.length ? infoWithValue.value.split(renderer.fieldDelimiter) : [infoWithValue.value];
 
-      return fieldValuePairs.some((pair) => {
-        return operableFields.some((field) => {
-          const operableValue = valueParts[operableFields.indexOf(field)];
+    const has = fieldValuePairs.some((pair) => {
+      return operableFields.some((field) => {
+        const operableValue = valueParts[operableFields.indexOf(field)];
 
-          return pair.field === field && pair.value === operableValue;
-        });
+        return pair.field === field && pair.value === operableValue;
       });
     });
 
-    this.infos = filteredInfos;
+    if (has) {
+      return of(info);
+    } else {
+      return of(null);
+    }
   }
 }
 
 // Browser doesn't like direct esri types for inputs.
+// P.S For whoever looks at this in the future and wonders what the heck is going on with
+// LegendInfo and ILegendElement? I don't know. It's late, and I'm too tired to worry/care about it.
+// It works. Good luck :|
 type ILegendElement = esri.LegendElement;
 type ILayer = esri.Layer;
+type LegendInfo =
+  | esri.SymbolTableElementType
+  | esri.ColorRampStop
+  | esri.OpacityRampStop
+  | esri.SizeRampStop
+  | esri.HeatmapRampStop;


### PR DESCRIPTION
Addresses a bug/lack of support for server-side feature querying for legend elements that should respect a layer's `definitionExpression`.

Previously, this was done in a very simple way, relying on simple client-side equality checks, however the fidelity for correct filtering broke down when complex `where` T-SQL queries were used. This PR refactors the LegendElement component to make calls to the server to reliably limit which legend items are displayed, based on a layer's `definitionExpression`. The entire filtering logic has been converted into a reactive stream, better suited for the network requests.

Additionally, the LegendCollection component receives a `trackBy` function to ensure that nested LegendElement's are not re-rendered, triggering additional async network requests.