### PR TITLE
fix(ts-events-ngx): Routing between mobile <=> desktop

### DIFF
--- a/apps/aggiemap-angular/src/styles.scss
+++ b/apps/aggiemap-angular/src/styles.scss
@@ -657,13 +657,19 @@ body.mapping {
   }
 }
 
+.overlay-zone.bottom.right {
+  right: 0.95rem !important;
+  bottom: 5rem !important;
+}
+
 .esri-component.esri-track.esri-widget--button.esri-widget {
   margin-left: 0;
   border-radius: 99rem;
-  padding: 1rem;
+  padding: 1.25rem;
+  margin-top: 0.5rem;
 
   span {
-    font-size: 1rem;
+    font-size: 1.25rem;
   }
 }
 

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/mobile-sidebar/mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/mobile-sidebar/mobile-sidebar.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { getPathFromRouteSnapshot } from '@tamu-gisc/common/utils/routing';
+import { getUrlSegmentsFromRouteSnapshot } from '@tamu-gisc/common/utils/routing';
 
 @Component({
   selector: 'tamu-gisc-mobile-sidebar',
@@ -15,7 +15,7 @@ export class MobileSidebarComponent {
    */
   public close() {
     // Get the parent route.
-    const parent = getPathFromRouteSnapshot(this.route.snapshot).slice(0, -1);
+    const parent = getUrlSegmentsFromRouteSnapshot(this.route.snapshot).slice(0, -1);
 
     // Absolute navigation to the parent.
     this.router.navigate(parent);

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/omnisearch/omnisearch.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/omnisearch/omnisearch.component.ts
@@ -182,9 +182,9 @@ export class OmnisearchComponent implements OnInit, OnDestroy {
    */
   public handleLeftAction() {
     if ('id' in this.route.snapshot.params) {
-      this.router.navigate(['map/d/trip']);
+      this.router.navigate(['./trip'], { relativeTo: this.route });
     } else if (this.searchComponentLeftAction === 'menu') {
-      this.router.navigate(['map/m/sidebar']);
+      this.router.navigate(['./sidebar'], { relativeTo: this.route });
     } else {
       this.clearFocus();
     }

--- a/libs/common/utils/device/guards/src/lib/desktop/desktop.guard.ts
+++ b/libs/common/utils/device/guards/src/lib/desktop/desktop.guard.ts
@@ -3,7 +3,7 @@ import { CanActivate, ActivatedRouteSnapshot, CanActivateChild, Router } from '@
 import { Observable } from 'rxjs';
 
 import { ResponsiveService } from '@tamu-gisc/dev-tools/responsive';
-import { getPathFromRouteSnapshot, routeSubstitute } from '@tamu-gisc/common/utils/routing';
+import { getUrlSegmentsFromRouteSnapshot, routeSubstitute } from '@tamu-gisc/common/utils/routing';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +13,7 @@ export class DesktopGuard implements CanActivate, CanActivateChild {
 
   public canActivate(next: ActivatedRouteSnapshot): Observable<boolean> | Promise<boolean> | boolean {
     if (this.rp.snapshot.isMobile) {
-      const snapshotPath = getPathFromRouteSnapshot(next);
+      const snapshotPath = getUrlSegmentsFromRouteSnapshot(next);
       const pathSegments = routeSubstitute(snapshotPath, 'd', 'm');
       this.router.navigate(pathSegments, { queryParams: next.queryParams });
     }

--- a/libs/common/utils/device/guards/src/lib/mobile/mobile.guard.ts
+++ b/libs/common/utils/device/guards/src/lib/mobile/mobile.guard.ts
@@ -3,7 +3,7 @@ import { CanActivate, ActivatedRouteSnapshot, CanActivateChild, Router } from '@
 import { Observable } from 'rxjs';
 
 import { ResponsiveService } from '@tamu-gisc/dev-tools/responsive';
-import { getPathFromRouteSnapshot, routeSubstitute } from '@tamu-gisc/common/utils/routing';
+import { getUrlSegmentsFromRouteSnapshot, routeSubstitute } from '@tamu-gisc/common/utils/routing';
 
 @Injectable({
   providedIn: 'root'
@@ -13,7 +13,7 @@ export class MobileGuard implements CanActivate, CanActivateChild {
 
   public canActivate(next: ActivatedRouteSnapshot): Observable<boolean> | Promise<boolean> | boolean {
     if (!this.rp.snapshot.isMobile) {
-      const snapshotPath = getPathFromRouteSnapshot(next);
+      const snapshotPath = getUrlSegmentsFromRouteSnapshot(next);
       const pathSegments = routeSubstitute(snapshotPath, 'm', 'd');
       this.router.navigate(pathSegments, { queryParams: next.queryParams });
     }

--- a/libs/common/utils/routing/src/lib/common-utils-routing.spec.ts
+++ b/libs/common/utils/routing/src/lib/common-utils-routing.spec.ts
@@ -1,6 +1,6 @@
 import { ActivatedRouteSnapshot } from '@angular/router';
 
-import { getPathFromRouteSnapshot, makeUrlParams, routeSubstitute } from '..';
+import { getPathFromRouteSnapshot, getUrlSegmentsFromRouteSnapshot, makeUrlParams, routeSubstitute } from '..';
 
 describe('getPathFromRouteSnapshot', () => {
   it('should work', () => {
@@ -34,5 +34,29 @@ describe('routeSubstitute', () => {
   it('should replace the documentation example', () => {
     expect(routeSubstitute(['map', 'd', 'trip'], 'd', 'm')).toEqual(['map', 'm', 'trip']);
     expect(routeSubstitute(['map', 'm', 'trip'], 'd', 'm')).toEqual(['map', 'm', 'trip']);
+  });
+});
+
+describe('getUrlSegmentsFromRouteSnapshot', () => {
+  it('should extract actual URL segments', () => {
+    expect(
+      getUrlSegmentsFromRouteSnapshot({
+        pathFromRoot: [
+          { url: [] },
+          { url: [{ path: 'events' }] },
+          { url: [{ path: 'my-event-id' }] },
+          { url: [{ path: 'map' }] },
+          { url: [{ path: 'd' }] }
+        ]
+      } as unknown as ActivatedRouteSnapshot)
+    ).toEqual(['events', 'my-event-id', 'map', 'd']);
+  });
+
+  it('should handle empty URL segments', () => {
+    expect(
+      getUrlSegmentsFromRouteSnapshot({
+        pathFromRoot: [{ url: [] }, { url: [{ path: 'map' }] }, { url: [{ path: 'd' }] }]
+      } as unknown as ActivatedRouteSnapshot)
+    ).toEqual(['map', 'd']);
   });
 });

--- a/libs/common/utils/routing/src/lib/common-utils-routing.ts
+++ b/libs/common/utils/routing/src/lib/common-utils-routing.ts
@@ -11,6 +11,20 @@ export function getPathFromRouteSnapshot(snapshot: ActivatedRouteSnapshot): stri
     .filter((segment) => segment);
 }
 
+/**
+ * Returns a string segment array representing the actual URL segments from the app root.
+ * This resolves parameter values (e.g., ':eventId' becomes 'my-event-id').
+ */
+export function getUrlSegmentsFromRouteSnapshot(snapshot: ActivatedRouteSnapshot): string[] {
+  return snapshot.pathFromRoot
+    .map((route) => {
+      // Use the actual URL segments instead of route configuration paths
+      return route.url.length > 0 ? route.url.map((segment) => segment.path) : [];
+    })
+    .filter((segments) => segments.length > 0)
+    .flat();
+}
+
 export function makeUrlParams(params: object, encode: boolean, prefix?: string): string {
   if (!params) {
     throw new Error('Could not make URL params because no params were provided.');

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -28,8 +28,8 @@
       <div class="overlay-zone bottom right">
         <div *ngIf="hasSettings" class="esri-component esri-track esri-widget--button esri-widget" role="button" alt="URL Share" clipboard-copy [text]="shareUrl"><span class="material-icons" (click)="notifyUrlCopy()">share</span></div>
         <!-- <div routerLink="/builder/review" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Map Settings">settings</span></div> -->
-        <div routerLink="/map/m/sidebar/legend" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Legend">format_list_bulleted</span></div>
-        <div routerLink="/map/m/sidebar/layers" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Layer List">layers</span></div>
+        <div routerLink="./m/sidebar/legend" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Legend">format_list_bulleted</span></div>
+        <div routerLink="./m/sidebar/layers" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Layer List">layers</span></div>
       </div>
     </div>
   </tamu-gisc-esri-map>

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -27,7 +27,7 @@
 
       <div class="overlay-zone bottom right">
         <div *ngIf="hasSettings" class="esri-component esri-track esri-widget--button esri-widget" role="button" alt="URL Share" clipboard-copy [text]="shareUrl"><span class="material-icons" (click)="notifyUrlCopy()">share</span></div>
-        <!-- <div routerLink="/builder/review" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Map Settings">settings</span></div> -->
+        <div *ngIf="hasOptions" routerLink="../builder/review" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Map Settings">settings</span></div>
         <div routerLink="./m/sidebar/legend" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Legend">format_list_bulleted</span></div>
         <div routerLink="./m/sidebar/layers" class="esri-component esri-track esri-widget--button esri-widget"><span class="material-icons" role="button" alt="Layer List">layers</span></div>
       </div>


### PR DESCRIPTION
These are cherry-picked commits from `football-parking-map` branch that impact Aggiemap since Events and Aggiemap are now integrated into the same application.

The source of the issues was absolute routing relative to the root of the application, instead of routing relative to the root of the module. This was manifested in events such from builder => map going to `/map/d/` instead of `/events/<event-id/map/d`. 

This PR further re-includes the builder review widget button on the map on mobile which had been removed in a previous event application build, before applications and routes were merged. This button is now dynamic depending on whether a particular `<event-id` has configurable event builder options.