### PR TITLE
fix(gisday-angular): Inset ol/ul list element styles

### DIFF
--- a/apps/gisday-angular/src/styles.scss
+++ b/apps/gisday-angular/src/styles.scss
@@ -151,8 +151,11 @@ h6 {
   }
 }
 
-ul {
+ul,
+ol {
+  list-style-position: inside;
   margin-bottom: 1rem;
+  padding-left: 1.25rem;
 
   &.no-list {
     list-style: none;
@@ -190,8 +193,6 @@ ul {
       }
     }
   }
-
-  padding-left: 1.25rem;
 
   ul {
     margin-bottom: 0;


### PR DESCRIPTION
Fixes #456 

To prevent bullet poitns/numbers from overflowing out of the text starting y axis

<img width="1091" height="885" alt="image" src="https://github.com/user-attachments/assets/b6bbeb18-dd3d-47d1-bc9a-fb71c0f9fe8b" />


