### PR TITLE
fix(devcontainer): Fix config causing container build errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,10 +27,11 @@
       ]
     }
   },
-
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installOhMyZsh": true,
       "installOhMyZshConfig": true
@@ -40,16 +41,12 @@
       "omzPlugins": "https://github.com/zsh-users/zsh-autosuggestions.git" // Space separated list of Oh-My-ZSH custom plugin Git URLs that will be cloned
     }
   }
-
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "yarn install",
-
   // Configure tool-specific properties.
   // "customizations": {},
-
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,13 +40,11 @@
       "plugins": "zsh-autosuggestions", // Space separated list of ZSH plugin names that will be added to .zshrc
       "omzPlugins": "https://github.com/zsh-users/zsh-autosuggestions.git" // Space separated list of Oh-My-ZSH custom plugin Git URLs that will be cloned
     }
-  }
+  },
+  // Install Python build dependencies for node-gyp
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y python3-setuptools && npm ci"
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "yarn install",
-  // Configure tool-specific properties.
-  // "customizations": {},
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,10 @@ jobs:
         id: check-apps
         run: |
           if [ -d "./apps" ]; then
+            echo "✅ Apps directory found - proceeding with image build matrix generation"
             echo "exists=true" >> $GITHUB_OUTPUT
           else
+            echo "⚠️  Apps directory not found - skipping image builds"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Set matrix'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   list-publishable:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.set-matrix.outputs.matrix || '[]' }}
     steps:
       - name: 'Download artifacts'
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.sha }}
+      - name: 'Check for produced artifacts'
+        id: check-apps
+        run: |
+          if [ -d "./apps" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - name: 'Set matrix'
         id: set-matrix
+        if: steps.check-apps.outputs.exists == 'true'
         # Run script to generate matrix by getting a list of all directories that have a dockerfile as json array in the /artifact directory
         run: |
           cd ./apps


### PR DESCRIPTION
This pull request introduces improvements to the development container configuration and enhances robustness in the GitHub Actions workflow for publishing. The main changes focus on customizing Docker feature settings, ensuring build dependencies are installed automatically, and making the CI pipeline more resilient when expected artifacts are missing.

**Devcontainer configuration improvements:**

* The `docker-outside-of-docker` feature in `.devcontainer/devcontainer.json` is now configured with `"moby": false` to control which Docker engine is used.
* A `postCreateCommand` has been added to install Python build dependencies (specifically `python3-setuptools`) and run `npm ci` automatically after the container is created, ensuring that `node-gyp` builds work out of the box.

**CI/CD workflow robustness:**

* In `.github/workflows/publish.yml`, the matrix output for the `list-publishable` job now defaults to an empty array if no matrix is set, preventing workflow errors when no artifacts are found.
* A new step checks for the existence of the `apps` directory before attempting to generate the build matrix, skipping image builds gracefully if the directory is missing.Update devcontainer config to include a post create command to install python3 setuptools.

The typescript-node images were updated recently with a python version greater than 3.11.x. After 3.12, `disttools` is no longer included in python and the base devcontainer image does not come prebundled with it either, so it has to setuptools need to be installed separately on container post install so `npm ci` doesn't fail. 

https://docs.python.org/3/library/distutils.html