### PR TITLE
Add link to gisday competition page

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/competitions/art/art.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/competitions/art/art.component.html
@@ -44,7 +44,7 @@
 
         <h2 class="trailer-1 leader-2">How to participate</h2>
         <ul class="numbered-custom">
-          <li>Download the official TxGIS Day Competitions App on your mobile device.</li>
+          <li>Download and install the <a href="/app">Official TxGIS Day Competitions App</a> on your mobile device.</li>
           <li>Using the app's map view, navigate to areas with art on campus. Each art piece can only be documented once, so make sure to mark locations accurately.</li>
           <li>At each art location, open the survey in the competitions app and allow it to automatically use your GPS location. Take a clear photo of the art that shows its current condition and informational plaques, if present.</li>
           <li>Fill out the survey, including information about the art's medium, artist, year, and condition.</li>


### PR DESCRIPTION
Adds the missing link to https://txgisday.org/competitions/art the competitions app from the VGI competition for 2025.

Fixes #500 