### PR TITLE
fix(gisday-angular): Point level sponsor image uses incorrect url

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/sponsors/sponsors-main/sponsors-main.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/sponsors/sponsors-main/sponsors-main.component.html
@@ -81,7 +81,7 @@
 
       <div class="sponsor-list">
         <div class="icon-grid">
-          <div class="icon-item large" *ngFor="let s of pointSponsors$ | async"><a [href]="s.website" target="_blank" [style.background-image]="'url(' + (s?.logos['0']?.guid | assetUrl | async) + ')' " [title]="s.name"></a></div>
+          <div class="icon-item large" *ngFor="let s of pointSponsors$ | async"><a [href]="s.website" target="_blank" [style.background-image]="'url(' + (s?.logos['0']?.path | assetUrl | async) + ')' " [title]="s.name"></a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Updates the url source param for the images in the point level sponsorship.

fixes #502