### PR TITLE
fix(gisday-angular): Missing VGI link button

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/competitions/landing/landing.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/competitions/landing/landing.component.html
@@ -39,7 +39,7 @@
       <div class="column6 clr-md-grey-900">
         <h2 class="trailer-1">VGI Competitions</h2>
         <p>Each year, TxGIS Day hosts a Volunteered Geographic Information (VGI) data collection competition to engage students, faculty, staff, and other GIS Day participants to get out there and collect some data that is meaningful to the mission of TxGIS Day. The competition has prizes, and allows participants to have an impact on our campus and surrounding community.</p>
-        <a class="button snug tertiary leader-1" [routerLink]="['/competitions/vgi']">Explore Competitions</a>
+        <a class="button snug secondary leader-1" [routerLink]="['/competitions/vgi']">Explore Competitions</a>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes an "invisible" button due to blending with the background, text color, and border (they all are the same color). There's no visual indicator about how to get to the details page. 

Before:

<img width="1163" height="537" alt="image" src="https://github.com/user-attachments/assets/a42eff6c-99e7-48b3-9e19-466e25355e83" />

After:

<img width="1156" height="526" alt="image" src="https://github.com/user-attachments/assets/98e5e137-e6f8-4f0a-a5c6-b84a6157649c" />
