### PR TITLE
fix(gisday-angular): update vgi competition start date

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/competitions/art/art.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/competitions/art/art.component.html
@@ -9,6 +9,16 @@
   <div class="container12 flex flex-row">
     <div class="column8">
       <div class="trailer-4">
+        <p>
+          <strong>Please note that due to technical reasons, the 2025 VGI Competition start has been delayed until November 17, 2025, the first day of Texas A&M GIS Day week. We apologize for the inconvenience and appreciate your understanding.</strong>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="container12 flex flex-row">
+    <div class="column8">
+      <div class="trailer-4">
         <p>The TxGIS Day Organizing Committee is excited to invite participants to participate in this year's VGI competition by documenting art on Texas A&M's campus! Art is an essential part of creating a compelling atmosphere at Texas A&M and across universities worldwide, providing opportunities for thoughtful reflection and enriching the spirit and culture of the University.</p>
 
         <p>The challenge aims to survey and document art across campus to help:</p>
@@ -35,7 +45,7 @@
           </div>
         </div>
 
-        <p>In the week of and prior to Texas A&M GIS Day (November 10-21), participants can use their mobile devices to survey all points of Texas A&M's campus in search of art in the following categories:</p>
+        <p>In the week of Texas A&M GIS Day (November 17-21), participants can use their mobile devices to survey all points of Texas A&M's campus in search of art in the following categories:</p>
         <ul>
           <li>Unknown Art (Not on TAMU Art Registry)</li>
           <li>Statues and Monuments</li>


### PR DESCRIPTION
Dates for start of the VGI competition have been updated to be the start of GIS Day week

Fixes #510