### PR TITLE
fix(gisday-angular): typos in competitions - Submisisons

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/competitions/papers/papers.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/competitions/papers/papers.component.html
@@ -141,7 +141,7 @@
             <li>You may submit unlimited entries per person.</li>
             <li>A map is not required on your submission, but you are submitting to a TxGIS Day Competition, so...</li>
             <li>Abstract submissions should include introduction, objectives, approach, results, discussion, and conclusions (or their equivalents).</li>
-            <li>Submisisons must be original - unique work.</li>
+            <li>Submissions must be original - unique work.</li>
             <li>Abstract submissions must be in pdf format.</li>
             <li>Abstract Submissions may not to exceed 10MB.</li>
             <li>Winners do not have to be present to win but maintain the responsibility of collecting any prizes that are won in the contest.</li>

--- a/libs/gisday/platform/ngx/core/src/lib/pages/competitions/presentation/presentation.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/competitions/presentation/presentation.component.html
@@ -144,7 +144,7 @@
             <li>You may submit unlimited entries per person.</li>
             <li>A map is not required on your submission, but you are submitting to a GIS Day Competition, so...</li>
             <li>Abstract submissions should include introduction, objectives, approach, results, discussion, and conclusions (or their equivalents).</li>
-            <li>Submisisons must be original - unique work.</li>
+            <li>Submissions must be original - unique work.</li>
             <li>Abstract submissions must be in pdf format.</li>
             <li>Abstract Submissions may not to exceed 10MB.</li>
             <li>Winners do not have to be present to win but maintain the responsibility of collecting any prizes that are won in the contest.</li>


### PR DESCRIPTION
Updated the competition pages to fix typos on competition pages: "Submisisons" -> "Submissions"

Fixes #519