### PR TITLE
fix(ts-events): Add description to MSC and Rudder buildings on GIS Day event map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
@@ -27,7 +27,7 @@ export const GisDayLayerSources: LayerSource[] = [
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
       name: 'attributes.BldgName',
-      description: 'attributes.Description'
+      description: 'attributes.EventInfo'
     },
     visible: true,
     listMode: 'show',


### PR DESCRIPTION
Adds a small description and link to GIS Day events on Rudder and MSC buildings.