### PR TITLE
feat(aggiemap-angular): add family friendly restrooms to aggie map

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions.ts
@@ -95,8 +95,15 @@ export function Definitions(Connections: IComposedConnections): IComposedIDefini
     AGGIEPRINT_LOCATIONS: {
       id: 'aggieprint-locations',
       layerId: 'aggieprint-locations-layer',
-      name: 'AggiePrint Locations',
+      name: 'Aggieprint Locations',
       url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/TAMUPrinters/FeatureServer/0',
+      popupComponent: Popups.MarkdownWDirectionsPopupComponent
+    },
+    FAMILY_FRIENDLY_BATHROOMS: {
+      id: 'family-friendly-bathrooms-locations',
+      layerId: 'family-friendly-bathrooms-locations-layer',
+      name: 'Family Friendly Bathroom Locations',
+      url: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer/1',
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     }
   };
@@ -125,4 +132,5 @@ export interface IComposedIDefinitions {
   BIKE_LOCATIONS: IDefinition;
   DINING_LOCATIONS: IDefinition;
   AGGIEPRINT_LOCATIONS: IDefinition;
+  FAMILY_FRIENDLY_BATHROOMS: IDefinition;
 }

--- a/libs/aggiemap/ngx/common/src/lib/definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions.ts
@@ -95,7 +95,7 @@ export function Definitions(Connections: IComposedConnections): IComposedIDefini
     AGGIEPRINT_LOCATIONS: {
       id: 'aggieprint-locations',
       layerId: 'aggieprint-locations-layer',
-      name: 'Aggieprint Locations',
+      name: 'AggiePrint Locations',
       url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/TAMUPrinters/FeatureServer/0',
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     },

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -318,7 +318,26 @@ export function LayerSources(
           ]
         } as unknown as esri.UniqueValueRenderer
       }
-    }
+    },
+    {
+      type: 'feature',
+      id: definitions.FAMILY_FRIENDLY_BATHROOMS.layerId,
+      title: definitions.FAMILY_FRIENDLY_BATHROOMS.name,
+      url: definitions.FAMILY_FRIENDLY_BATHROOMS.url,
+      popupComponent: definitions.FAMILY_FRIENDLY_BATHROOMS.popupComponent,
+      listMode: 'show',
+      visible: false,
+      popupData: {
+        description:
+          '<strong>Building</strong>: {attributes.Name}\n' + 
+          '<strong>Bathroom Location(s)</strong>: {attributes.Notes}'
+      },
+      native: {
+        ...commonLayerProps,
+      }
+    },
+
+
   ];
 
   return all.filter((source) => {

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -329,15 +329,12 @@ export function LayerSources(
       visible: false,
       popupData: {
         description:
-          '<strong>Building</strong>: {attributes.Name}\n' + 
-          '<strong>Bathroom Location(s)</strong>: {attributes.Notes}'
+          '<strong>Building</strong>: {attributes.Name}\n' + '<strong>Bathroom Location(s)</strong>: {attributes.Notes}'
       },
       native: {
-        ...commonLayerProps,
+        ...commonLayerProps
       }
-    },
-
-
+    }
   ];
 
   return all.filter((source) => {


### PR DESCRIPTION
Adds the layer of family friendly bathrooms to back to aggie map. Each point shows popup info of the building name and room number(s) of all family friendly bathrooms in said building.

Resolves #507 