### PR TITLE
feat(gisday): Add presenting events for presenter details

### DIFF
--- a/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
+++ b/libs/gisday/competitions/ngx/common/src/lib/modules/forms/components/submission/submission.component.html
@@ -9,7 +9,7 @@
     <div class="block-input">
       <div class="block-input-presentation" *ngIf="(file | async) === undefined">
         <div class="material-icons">photo_camera</div>
-        <p class="title">Upload Photo of Art Installation</p>
+        <p class="title">Upload Photo of Your Submission</p>
         <p class="description">Tap to take a picture</p>
       </div>
 

--- a/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
+++ b/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
@@ -594,6 +594,12 @@ export class Speaker extends GuidIdentity {
   @Column({ nullable: true })
   public accountGuid: string;
 
+  @JoinTable({
+    name: 'event_speakers'
+  })
+  @ManyToMany(() => Event, (event) => event.speakers)
+  public events: Event[];
+
   @ManyToOne(() => Season, (season) => season.speakers, { nullable: true })
   public season: Season;
 

--- a/libs/gisday/platform/data-api/src/lib/speaker/speaker.provider.ts
+++ b/libs/gisday/platform/data-api/src/lib/speaker/speaker.provider.ts
@@ -97,7 +97,13 @@ export class SpeakerProvider extends BaseProvider<Speaker> {
       where: {
         guid: In(eventGuids)
       },
-      relations: ['speakers', 'speakers.images', 'speakers.organization', 'speakers.university']
+      relations: ['speakers', 'speakers.images', 'speakers.organization', 'speakers.university'],
+      order: {
+        speakers: {
+          firstName: 1,
+          lastName: 1
+        }
+      }
     });
 
     // Extract ALL speakers from ALL events

--- a/libs/gisday/platform/data-api/src/lib/speaker/speaker.provider.ts
+++ b/libs/gisday/platform/data-api/src/lib/speaker/speaker.provider.ts
@@ -53,7 +53,15 @@ export class SpeakerProvider extends BaseProvider<Speaker> {
       where: {
         guid: guid
       },
-      relations: ['organization', 'university', 'images']
+      relations: ['organization', 'university', 'images', 'events', 'events.day'],
+      order: {
+        events: {
+          day: {
+            date: 'ASC'
+          },
+          startTime: 'ASC'
+        }
+      }
     });
   }
 

--- a/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.component.html
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.component.html
@@ -18,6 +18,17 @@
         <ng-template #noDescription>
           <p>There is no description for this presenter yet. Please check back at a later time.</p>
         </ng-template>
+
+        <div *ngIf="person.events && person.events.length > 0" class="events-section leader-2">
+          <div class="border-divider trailer-2"></div>
+          <h3 class="trailer-1">Presenting At</h3>
+          <div class="events-list">
+            <div *ngFor="let event of person.events" class="event-item">
+              <div class="event-time">{{event?.day?.date | parseDateTimeStrings : event.startTime | date:'MMM d, y, h:mm a'}} - {{ event?.day?.date| parseDateTimeStrings : event.endTime | date:'h:mm a'}}</div>
+              <div class="event-name"><a [routerLink]="['/sessions', 'details', event.guid]">{{ event.name }}</a></div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.component.scss
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.component.scss
@@ -1,0 +1,55 @@
+@import 'libs/gisday/sass/variables';
+
+.presenter-details-item {
+  .image-container {
+    position: sticky;
+    top: 1rem;
+    align-self: flex-start;
+
+    @media (max-width: 767px) {
+      position: static;
+    }
+  }
+}
+
+.events-section {
+  .events-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .event-item {
+    padding: 1rem;
+    border-left: 3pt solid $gisday-blue;
+    background: rgba($gisday-blue, 0.02);
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba($gisday-blue, 0.05);
+      border-left-width: 4px;
+    }
+  }
+
+  .event-time {
+    font-size: 0.875rem;
+    color: $gisday-blue-support;
+    margin-bottom: 0.25rem;
+    font-weight: 500;
+  }
+
+  .event-name {
+    margin: 0;
+
+    a {
+      color: $gisday-blue;
+      text-decoration: none;
+      font-weight: 600;
+
+      &:hover {
+        color: $gisday-blue-secondary;
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.module.ts
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-details/people-details.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Routes, RouterModule } from '@angular/router';
 
-import { GisDayPeopleModule } from '@tamu-gisc/gisday/platform/ngx/common';
+import { GisDayPeopleModule, GISDayPipesModule } from '@tamu-gisc/gisday/platform/ngx/common';
 import { PipesModule } from '@tamu-gisc/common/ngx/pipes';
 
 import { PeopleDetailsComponent } from './people-details.component';
@@ -15,7 +15,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(routes), GisDayPeopleModule, PipesModule],
+  imports: [CommonModule, RouterModule.forChild(routes), GisDayPeopleModule, GISDayPipesModule, PipesModule],
   declarations: [PeopleDetailsComponent],
   exports: [RouterModule]
 })


### PR DESCRIPTION
This pull request enhances the presenter (speaker) details page by displaying the events each presenter is associated with and improves backend support for querying and ordering this information. It also includes UI and styling improvements for a better user experience, as well as a minor update to a submission form label.

**Backend: Speaker–Event Relationship and Query Enhancements**
- Added a many-to-many relationship between `Speaker` and `Event` entities, enabling each speaker to be linked to multiple events and vice versa. (`all.entity.ts`)
- Updated the `SpeakerProvider` to include related `events` (and their `day`) when fetching a speaker, and to order these events by date and start time. (`speaker.provider.ts`)
- When fetching events by GUIDs, the related speakers are now ordered by first and last name for consistency. (`speaker.provider.ts`)

**Frontend: Presenter Details Page Improvements**
- Updated the presenter details page to display a "Presenting At" section, listing all events the person is speaking at, with event times and links to session details. (`people-details.component.html`)
- Added new styles for the "Presenting At" section and improved presenter image container styling for better layout and responsiveness. (`people-details.component.scss`)
- Imported the necessary pipes module to support event time formatting in the presenter details view. (`people-details.module.ts`) [[1]](diffhunk://#diff-8c78095c3068afabb35d9cde9a71603e6d371615933d457d0de56aa94e3f9a0cL5-R5) [[2]](diffhunk://#diff-8c78095c3068afabb35d9cde9a71603e6d371615933d457d0de56aa94e3f9a0cL18-R18)

**Minor UI Update**
- Updated the photo upload prompt in the submission form to say "Upload Photo of Your Submission" for clarity. (`submission.component.html`)

Fixes #528 
Fixes #467 
Fixes #467 