### PR TITLE
fix(gisday-angular): Use routerlink to prevent full page refresh

### DIFF
--- a/libs/gisday/platform/ngx/common/src/lib/modules/people/components/presenter-card/presenter-card.component.html
+++ b/libs/gisday/platform/ngx/common/src/lib/modules/people/components/presenter-card/presenter-card.component.html
@@ -9,7 +9,7 @@
     <div class="name">
       <div [ngSwitch]="linkable">
         <p *ngSwitchCase="false">{{speaker.firstName}} {{speaker.lastName}}</p>
-        <a *ngSwitchDefault href="/presenters/details/{{speaker.guid}}"> {{speaker.firstName}} {{speaker.lastName}} </a>
+        <a *ngSwitchDefault [routerLink]="['/presenters', 'details', speaker.guid]"> {{speaker.firstName}} {{speaker.lastName}} </a>
       </div>
     </div>
 


### PR DESCRIPTION
This pull request makes a minor update to the `presenter-card.component.html` template to improve routing behavior for presenter links.

- Updated the presenter name link to use Angular's `[routerLink]` directive instead of a static `href`, ensuring client-side navigation and better integration with Angular's router. `href` costs a needless auth request and content shifting while it resolves