### PR TITLE
fix(gisday-angular): Add client-side presenter view sorting

### DIFF
--- a/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-view/people-view.component.ts
+++ b/libs/gisday/platform/ngx/core/src/lib/pages/people/pages/people-view/people-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { Observable, shareReplay } from 'rxjs';
+import { Observable, shareReplay, map } from 'rxjs';
 
 import { SpeakerService } from '@tamu-gisc/gisday/platform/ngx/data-access';
 import { Speaker } from '@tamu-gisc/gisday/platform/data-api';
@@ -16,6 +16,17 @@ export class PeopleViewComponent implements OnInit {
   constructor(private speakerService: SpeakerService) {}
 
   public ngOnInit() {
-    this.people$ = this.speakerService.getParticipatingPresenters().pipe(shareReplay(1));
+    this.people$ = this.speakerService.getParticipatingPresenters().pipe(
+      map((speakers) =>
+        speakers.sort((a, b) => {
+          const firstNameCompare = (a.firstName || '').localeCompare(b.firstName || '');
+          if (firstNameCompare !== 0) {
+            return firstNameCompare;
+          }
+          return (a.lastName || '').localeCompare(b.lastName || '');
+        })
+      ),
+      shareReplay(1)
+    );
   }
 }


### PR DESCRIPTION
This pull request updates the `PeopleViewComponent` to improve the way participating presenters are displayed. The main change is that the list of speakers is now sorted alphabetically by first name, and then by last name if the first names are identical.

**People list sorting:**

* The observable `people is updated to sort the array of speakers by `firstName`, and then by `lastName` as a secondary criterion, ensuring a consistent and user-friendly order in the UI. (`people-view.component.ts`)

**Dependency update:**

* The `map` operator from `rxjs` is imported to enable the sorting logic within the observable pipeline. (`people-view.component.ts`)Something in the db driver isn't sorting correctly