### PR TITLE
fix(gisday-nest): Event speaker add/remove

### DIFF
--- a/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
+++ b/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
@@ -372,9 +372,6 @@ export class Event extends GuidIdentity {
   public season: Season;
 
   @ManyToMany(() => Speaker, { nullable: true })
-  @JoinTable({
-    name: 'event_speakers'
-  })
   public speakers?: Speaker[];
 
   @ManyToMany(() => Tag, { nullable: true })

--- a/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
+++ b/libs/gisday/platform/data-api/src/lib/entities/all.entity.ts
@@ -371,7 +371,10 @@ export class Event extends GuidIdentity {
   @ManyToOne(() => Season, (season) => season.events)
   public season: Season;
 
-  @ManyToMany(() => Speaker, { nullable: true })
+  @ManyToMany(() => Speaker, (speaker) => speaker.events, { nullable: true })
+  @JoinTable({
+    name: 'event_speakers'
+  })
   public speakers?: Speaker[];
 
   @ManyToMany(() => Tag, { nullable: true })
@@ -591,9 +594,6 @@ export class Speaker extends GuidIdentity {
   @Column({ nullable: true })
   public accountGuid: string;
 
-  @JoinTable({
-    name: 'event_speakers'
-  })
   @ManyToMany(() => Event, (event) => event.speakers)
   public events: Event[];
 


### PR DESCRIPTION
This pull request updates the relationship definitions between the `Event` and `Speaker` entities to ensure proper bidirectional mapping and corrects the placement of the `@JoinTable` decorator for the many-to-many association.

**Entity relationship improvements:**

* Updated the `@ManyToMany` decorator in the `Event` entity to specify the inverse side (`(speaker) => speaker.events`) and ensured the `@JoinTable` decorator is only present on the owning side of the relationship.
* Removed the `@JoinTable` decorator from the `Speaker` entity, as it should only be present on one side of a many-to-many relationship (the owning side, which is now correctly set on `Event`).