### PR TITLE
Change Nearmap Satellite name to Aerial Imagery

### DIFF
--- a/libs/maps/feature/basemap/src/lib/shared/basemaps.definition.ts
+++ b/libs/maps/feature/basemap/src/lib/shared/basemaps.definition.ts
@@ -33,6 +33,6 @@ export const NearmapCSBasemap: BaseMapProperties = {
     }
   ],
   id: 'nearmap_cs_basemap',
-  title: 'Nearmap Satellite',
+  title: 'Aerial Imagery',
   thumbnailUrl: 'https://aggiemap.tamu.edu/images/basemap_thumbnails/nearmap_imagery.png'
 };


### PR DESCRIPTION
Fixes typo with Nearmap Satellite, changes name to Aerial Imagery

Resolves #561
