### PR TITLE
feat(aggiemap-angular): Update fall graduation and create spring + summer

### DIFF
--- a/libs/ts/events/ngx/src/index.ts
+++ b/libs/ts/events/ngx/src/index.ts
@@ -5,7 +5,7 @@ export * from './lib/interfaces/special-event.interface';
 
 export * from './lib/definitions/all.definitions';
 
-export * from './lib/definitions/graduation.definitions';
+export * from './lib/definitions/graduation-spring.definitions';
 export * from './lib/definitions/aggieland-saturday.definitions';
 export * from './lib/definitions/big-event.definitions';
 export * from './lib/definitions/phys-engineering-festival.definitions';
@@ -18,7 +18,7 @@ export * from './lib/definitions/troubadour-festival.definitions';
 export * from './lib/definitions/hs-graduation.definitions';
 export * from './lib/definitions/4h-roundup.definitions';
 export * from './lib/definitions/softball-regionals.definitions';
-export * from './lib/definitions/summer-graduation.definitions';
+export * from './lib/definitions/graduation-summer.definitions';
 export * from './lib/definitions/football-parking.definitions';
 export * from './lib/definitions/ring-day.definitions';
 export * from './lib/definitions/womens-basketball.definitions';

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -2,7 +2,9 @@ import { FourHRoundupTs } from './4h-roundup.definitions';
 import { AggielandSaturdayEventTs } from './aggieland-saturday.definitions';
 import { BigEventTs } from './big-event.definitions';
 import { FamilyWeekendTs } from './family-weekend.definitions';
-import { GraduationEventTs } from './graduation.definitions';
+import { GraduationSpringEventTs } from './graduation-spring.definitions';
+import { GraduationFallEventTs } from './graduation-fall.definitions';
+import { SummerCommencementTs } from './graduation-summer.definitions';
 import { HsGraduationTs } from './hs-graduation.definitions';
 import { MaroonWhiteTs } from './maroon-white-game.definitions';
 import { MS150Ts } from './ms150.definitions';
@@ -22,7 +24,9 @@ export const EventDefinitions: Array<ISpecialEventRoot> = [
   AggielandSaturdayEventTs,
   BigEventTs,
   FamilyWeekendTs,
-  GraduationEventTs,
+  GraduationFallEventTs,
+  GraduationSpringEventTs,
+  SummerCommencementTs,
   HsGraduationTs,
   MaroonWhiteTs,
   MensBasketball_Ts,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -273,7 +273,7 @@ export const GraduationConfiguration: EventConfiguration = {
   name: 'Commencement Ceremony',
   applicationName: 'Commencement Transportation Map',
   shortApplicationName: 'Commencement Map',
-  introductionText: 'Get the best transportation and parking information for the fall commencement ceremony.',
+  introductionText: 'Get the best transportation and parking information for the fall commencement ceremonies.',
   eventDates: ['2025-12-17', '2025-12-18'],
   mapCenter: [-96.34458, 30.60629],
   zoom: 16
@@ -294,7 +294,7 @@ export const GraduationOptions: SpecialEventOptions = [
     choices: [
       {
         value: GraduationAttendanceDateChoices.DayOne,
-         label: 'Wednesday, December 17th'
+        label: 'Wednesday, December 17th'
       },
       {
         value: GraduationAttendanceDateChoices.DayTwo,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -1,0 +1,341 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
+import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+
+import esri = __esri;
+
+export enum GRADUATION_LAYERS {
+  GRADUATION_LINE_PAINT = 'graduation-line-paint',
+  GRADUATION_CONSTRUCTION = 'graduation-construction',
+  GRADUATION_EVENT_PARKING_LOTS = 'graduation-event-parking-lots',
+  GRADUATION_TRAFFIC_FLOW = 'graduation-traffic-flow',
+  GRADUATION_ROAD_CLOSURES = 'graduation-road-closed'
+}
+
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/GraduationMuster/MapServer';
+
+const GraduationEventDefinitions = {
+  GRADUATION_TRAFFIC_FLOW: {
+    id: GRADUATION_LAYERS.GRADUATION_TRAFFIC_FLOW,
+    layerId: GRADUATION_LAYERS.GRADUATION_TRAFFIC_FLOW,
+    name: 'Graduation Traffic Flow',
+    url: `${eventUrl}/1`
+  },
+  GRADUATION_LINE_PAINT: {
+    id: GRADUATION_LAYERS.GRADUATION_LINE_PAINT,
+    layerId: GRADUATION_LAYERS.GRADUATION_LINE_PAINT,
+    name: 'Graduation Line Paint',
+    url: `${eventUrl}/2`
+  },
+  GRADUATION_CONSTRUCTION: {
+    id: GRADUATION_LAYERS.GRADUATION_CONSTRUCTION,
+    layerId: GRADUATION_LAYERS.GRADUATION_CONSTRUCTION,
+    name: 'Graduation Construction',
+    url: `${eventUrl}/3`
+  },
+  GRADUATION_EVENT_PARKING_LOTS: {
+    id: GRADUATION_LAYERS.GRADUATION_EVENT_PARKING_LOTS,
+    layerId: GRADUATION_LAYERS.GRADUATION_EVENT_PARKING_LOTS,
+    name: 'Graduation Event Parking Lots',
+    url: `${eventUrl}/4`
+  },
+
+  GRADUATION_ROAD_CLOSURES: {
+    id: GRADUATION_LAYERS.GRADUATION_ROAD_CLOSURES,
+    layerId: GRADUATION_LAYERS.GRADUATION_ROAD_CLOSURES,
+    name: 'Graduation Road Closures',
+    url: `${eventUrl}/7`
+  }
+};
+
+export const GraduationColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: GraduationEventDefinitions.GRADUATION_TRAFFIC_FLOW.id,
+    title: GraduationEventDefinitions.GRADUATION_TRAFFIC_FLOW.name,
+    url: GraduationEventDefinitions.GRADUATION_TRAFFIC_FLOW.url,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.LotName',
+      description: 'attributes.STF_Notes'
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*'],
+      renderer: {
+        type: 'unique-value',
+        field: 'Type',
+        uniqueValueInfos: [
+          {
+            value: 'Green',
+            label: 'Recommended Routes',
+            symbol: {
+              type: 'simple-line',
+              color: 'rgb(56, 168, 0)',
+              width: 3,
+              marker: {
+                style: 'arrow',
+                color: 'rgb(56, 168, 0)',
+                placement: 'end'
+              }
+            } as unknown as esri.SimpleLineSymbolProperties
+          },
+          {
+            value: 'Red',
+            label: 'Expect Delays',
+            symbol: {
+              type: 'simple-line',
+              color: 'rgb(230, 0, 0)',
+              width: 2,
+              marker: {
+                style: 'arrow',
+                color: 'rgb(230, 0, 0)',
+                placement: 'end'
+              }
+            } as unknown as esri.SimpleLineSymbolProperties
+          }
+        ]
+      },
+      labelingInfo: [
+        {
+          labelExpressionInfo: {
+            expression: '$feature.STF_Notes'
+          },
+          minScale: 0,
+          maxScale: 0,
+          useCodedValues: true,
+          allowOverrun: true,
+          symbol: {
+            type: 'text', // autocasts as new TextSymbol()
+            color: 'red',
+            haloColor: 'white',
+            haloSize: 1,
+            angle: 0,
+            font: {
+              // autocast as new Font()
+              family: 'Arial Unicode MS',
+              size: 12,
+              weight: 'bold'
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    type: 'feature',
+    id: GraduationEventDefinitions.GRADUATION_LINE_PAINT.id,
+    title: GraduationEventDefinitions.GRADUATION_LINE_PAINT.name,
+    url: GraduationEventDefinitions.GRADUATION_LINE_PAINT.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: 'attributes.LotName',
+      description: 'attributes.Note'
+    },
+    visible: false,
+    native: {
+      listMode: 'hide',
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: GraduationEventDefinitions.GRADUATION_CONSTRUCTION.id,
+    title: GraduationEventDefinitions.GRADUATION_CONSTRUCTION.name,
+    url: GraduationEventDefinitions.GRADUATION_CONSTRUCTION.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: 'attributes.LotName',
+      description: 'attributes.Note'
+    },
+    visible: false,
+    listMode: 'hide',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: GraduationEventDefinitions.GRADUATION_EVENT_PARKING_LOTS.id,
+    title: GraduationEventDefinitions.GRADUATION_EVENT_PARKING_LOTS.name,
+    url: GraduationEventDefinitions.GRADUATION_EVENT_PARKING_LOTS.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.SpEv_Lot_Notes.GraduationN',
+        collapsed: true
+      }
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*'],
+      labelingInfo: [
+        {
+          labelExpressionInfo: {
+            expression: '"Lot 97" + TextFormatting.NewLine + "Available After 5PM Friday"'
+          },
+          maxScale: 0,
+          minScale: 0,
+          where: "GIS.TS.ParkingLots.Name = '97'",
+          useCodedValues: true,
+          allowOverrun: true,
+          symbol: {
+            type: 'text', // autocasts as new TextSymbol()
+            color: 'red',
+            haloColor: 'white',
+            haloSize: 1,
+            angle: 0,
+            font: {
+              // autocast as new Font()
+              family: 'Arial Unicode MS',
+              size: 12,
+              weight: 'bold'
+            }
+          }
+        },
+        {
+          labelExpressionInfo: {
+            expression: '$feature["GIS.TS.ParkingLots.LotName"]'
+          },
+          maxScale: 0,
+          minScale: 0,
+          where: "GIS.TS.ParkingLots.Name NOT LIKE '97'",
+          useCodedValues: true,
+          symbol: {
+            type: 'text', // autocasts as new TextSymbol()
+            color: 'black',
+            haloColor: 'white',
+            haloSize: 1,
+            angle: 0,
+            font: {
+              // autocast as new Font()
+              family: 'Arial Unicode MS',
+              size: 10,
+              weight: 'bold'
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    type: 'feature',
+    id: GraduationEventDefinitions.GRADUATION_ROAD_CLOSURES.id,
+    title: GraduationEventDefinitions.GRADUATION_ROAD_CLOSURES.name,
+    url: GraduationEventDefinitions.GRADUATION_ROAD_CLOSURES.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: 'attributes.A_Name',
+      description: 'attributes.SP_SH_Notes'
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*'],
+      labelingInfo: [
+        {
+          labelExpressionInfo: {
+            expression: '$feature.SP_SH_Notes'
+          },
+          minScale: 0,
+          maxScale: 0,
+          useCodedValues: true,
+          allowOverrun: true,
+          symbol: {
+            type: 'text', // autocasts as new TextSymbol()
+            color: 'red',
+            haloColor: 'white',
+            haloSize: 1,
+            angle: 0,
+            font: {
+              // autocast as new Font()
+              family: 'Arial Unicode MS',
+              size: 12,
+              weight: 'bold'
+            }
+          }
+        }
+      ]
+    }
+  }
+];
+
+export const GraduationConfiguration: EventConfiguration = {
+  id: 'graduation-fall',
+  name: 'Commencement Ceremony',
+  applicationName: 'Commencement Transportation Map',
+  shortApplicationName: 'Commencement Map',
+  introductionText: 'Get the best transportation and parking information for the fall commencement ceremony.',
+  eventDates: ['2025-12-17', '2025-12-18'],
+  mapCenter: [-96.34458, 30.60629],
+  zoom: 16
+};
+
+enum GraduationAttendanceDateChoices {
+  DayOne = '2025-12-17T05:00:00.000Z',
+  DayTwo = '2025-12-18T05:00:00.000Z'
+}
+
+export const GraduationOptions: SpecialEventOptions = [
+  {
+    value: 'date',
+    description:
+      'Please select the day of your commencement or commissioning ceremony to provide the most accurate transportation and parking information.',
+    shortDescription: 'Event Day',
+    label: 'Event Day',
+    choices: [
+      {
+        value: GraduationAttendanceDateChoices.DayOne,
+         label: 'Wednesday, December 17th'
+      },
+      {
+        value: GraduationAttendanceDateChoices.DayTwo,
+        label: 'Thursday, December 18th'
+      }
+    ],
+    effects: {
+      layers: [
+        {
+          layerId: GRADUATION_LAYERS.GRADUATION_EVENT_PARKING_LOTS,
+          conversions: [
+            {
+              input: GraduationAttendanceDateChoices.DayOne,
+              propOverrides: {
+                visible: true
+              }
+            },
+            {
+              input: GraduationAttendanceDateChoices.DayTwo,
+              propOverrides: {
+                visible: true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+];
+
+export const GraduationFallEventTs: ISpecialEventRoot = {
+  configuration: GraduationConfiguration,
+  options: GraduationOptions,
+  sources: GraduationColdLayerSources,
+  references: GRADUATION_LAYERS,
+  discover: {
+    id: GraduationConfiguration.id,
+    name: GraduationConfiguration.name,
+    description: 'Transportation and parking information for graduation ceremonies.',
+    source: 'internal',
+    type: 'event',
+    keywords: ['graduation', 'commencement', 'parking', 'transportation']
+  }
+};

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -344,11 +344,11 @@ export const GraduationColdLayerSources: LayerSource[] = [
 ];
 
 export const GraduationConfiguration: EventConfiguration = {
-  id: 'graduation-2025',
-  name: 'Graduation',
-  applicationName: 'Graduation Transportation Map',
-  shortApplicationName: 'Graduation Map',
-  introductionText: 'Get the best transportation and parking information for the commencement and commissioning ceremonies.',
+  id: 'graduation-spring',
+  name: 'Commencement Ceremony',
+  applicationName: 'Commencement Transportation Map',
+  shortApplicationName: 'Commencement Map',
+  introductionText: 'Get the best transportation and parking information for the spring commencement ceremony.',
   eventDates: ['2025-05-08', '2025-05-09', '2025-05-10'],
   mapCenter: [-96.34458, 30.60629],
   zoom: 16
@@ -435,7 +435,7 @@ export const GraduationOptions: SpecialEventOptions = [
   }
 ];
 
-export const GraduationEventTs: ISpecialEventRoot = {
+export const GraduationSpringEventTs: ISpecialEventRoot = {
   configuration: GraduationConfiguration,
   options: GraduationOptions,
   sources: GraduationColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -348,7 +348,7 @@ export const GraduationConfiguration: EventConfiguration = {
   name: 'Commencement Ceremony',
   applicationName: 'Commencement Transportation Map',
   shortApplicationName: 'Commencement Map',
-  introductionText: 'Get the best transportation and parking information for the spring commencement ceremony.',
+  introductionText: 'Get the best transportation and parking information for the spring commencement ceremonies.',
   eventDates: ['2025-05-08', '2025-05-09', '2025-05-10'],
   mapCenter: [-96.34458, 30.60629],
   zoom: 16

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -118,7 +118,7 @@ export const SummerCommencementConfiguration: EventConfiguration = {
   name: 'Commencement Ceremony',
   applicationName: 'Commencement Transportation Map',
   shortApplicationName: 'Commencement Map',
-  introductionText: 'Get the best transportation and parking information for the summer commencement ceremony.',
+  introductionText: 'Get the best transportation and parking information for the summer commencement ceremonies.',
   eventDates: ['2025-08-09'],
   mapCenter: [-96.34458, 30.60629],
   zoom: 17

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -1,7 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, SpecialEventOptions } from '../interfaces/special-event.interface';
+import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -114,7 +114,7 @@ export const SummerCommencementColdLayerSources: LayerSource[] = [
 ];
 
 export const SummerCommencementConfiguration: EventConfiguration = {
-  id: 'summer-commencement-2025',
+  id: 'graduation-summer',
   name: 'Commencement Ceremony',
   applicationName: 'Commencement Transportation Map',
   shortApplicationName: 'Commencement Map',
@@ -130,7 +130,7 @@ enum SummerCommencementAttendanceDateChoices {
 
 export const SummerCommencementOptions: SpecialEventOptions = [];
 
-export const SummerCommencementTs = {
+export const SummerCommencementTs: ISpecialEventRoot = {
   configuration: SummerCommencementConfiguration,
   options: SummerCommencementOptions,
   sources: SummerCommencementColdLayerSources,


### PR DESCRIPTION
This pull request refactors the graduation event definitions in the codebase to provide clearer separation between spring, summer, and fall commencement ceremonies. It introduces a new fall graduation definition, renames and updates the spring and summer graduation files and their exports, and updates the main event registry to use these new definitions. This improves maintainability and clarity for handling different graduation events.

**Graduation Event Definitions Refactor**

* Added a new `graduation-fall.definitions.ts` file, defining all configuration, layers, and options for the fall commencement ceremony, including event dates, map settings, and layer sources.
* Renamed `graduation.definitions.ts` to `graduation-spring.definitions.ts` and updated its configuration and exports to specifically represent the spring ceremony. [[1]](diffhunk://#diff-68350ebe8d484b7c83a48e8c9fb20026935d707f6a46a834b2ecfefb403438feL347-R351) [[2]](diffhunk://#diff-68350ebe8d484b7c83a48e8c9fb20026935d707f6a46a834b2ecfefb403438feL438-R438)
* Renamed `summer-graduation.definitions.ts` to `graduation-summer.definitions.ts`, updated its configuration, and ensured it exports the correct event root object. [[1]](diffhunk://#diff-27079c4a614af1c109a06800c6495808f28a967f900c1db1db21659329a2b6a8L4-R4) [[2]](diffhunk://#diff-27079c4a614af1c109a06800c6495808f28a967f900c1db1db21659329a2b6a8L117-R117) [[3]](diffhunk://#diff-27079c4a614af1c109a06800c6495808f28a967f900c1db1db21659329a2b6a8L133-R133)

**Main Event Registry Updates**

* Updated `all.definitions.ts` to import and register the new `GraduationSpringEventTs`, `GraduationFallEventTs`, and `SummerCommencementTs` event roots instead of the previous single graduation event. [[1]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5L5-R7) [[2]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5L25-R29)

**Public API Adjustments**

* Updated the main `index.ts` export file to use the new graduation event definition files for spring, summer, and fall, replacing the old graduation and summer-graduation exports. [[1]](diffhunk://#diff-2da29940d14421c8c4a2f468820df400dc56b49b60e25f95075796cba1bfcbc9L8-R8) [[2]](diffhunk://#diff-2da29940d14421c8c4a2f468820df400dc56b49b60e25f95075796cba1bfcbc9L21-R21)…tion event and adjusted number of days (2) and visibility settings accordingly.

Separated the graduation event definitions into distinct files for spring, fall, and summer graduations so we don't have to modify the number of days per each graduation event, nor have to specify the baseball parking across all graduations when it only affects spring.

Fixes #560