### PR TITLE
fix(aggiemap-angular): Remove "friday" from fall graduation Lot 97

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -180,7 +180,7 @@ export const GraduationColdLayerSources: LayerSource[] = [
       labelingInfo: [
         {
           labelExpressionInfo: {
-            expression: '"Lot 97" + TextFormatting.NewLine + "Available After 5PM Friday"'
+            expression: '"Lot 97" + TextFormatting.NewLine + "Available After 5PM"'
           },
           maxScale: 0,
           minScale: 0,


### PR DESCRIPTION
This pull request makes a minor update to the labeling information for the "Lot 97" graduation parking layer. The label now reads "Available After 5PM" instead of "Available After 5PM Friday".

- Updated the `labelExpressionInfo.expression` in the `GraduationColdLayerSources` array to remove "Friday" from the label for "Lot 97", clarifying that availability begins after 5PM without specifying a day.