### PR TITLE
fix(gisday-angular): Remove link to High School Portal

### DIFF
--- a/libs/gisday/platform/ngx/common/src/lib/modules/header/header.component.html
+++ b/libs/gisday/platform/ngx/common/src/lib/modules/header/header.component.html
@@ -66,9 +66,6 @@
 
     <div class="desktop-menu">
       <div class="aux">
-        <ul>
-          <li><a href="http://www.houstonareagisday.org/" target="_blank">High School Portal</a></li>
-        </ul>
 
         <ul class="dropdown" *ngIf="(places$ | async) as places">
           <p>Organizations <span class="material-icons">arrow_drop_down</span></p>


### PR DESCRIPTION
Removes the link to the High School Portal on the GIS Day website.

Does not remove the page itself.

Resolves #568 

