### PR TITLE
feat(aggiemap-angular): Add nginx cache busting + app tracing metadata

### DIFF
--- a/apps/aggiemap-angular/src/.nginx/nginx.conf
+++ b/apps/aggiemap-angular/src/.nginx/nginx.conf
@@ -5,6 +5,14 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    # Enable gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml+rss application/rss+xml font/truetype font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_disable "msie6";
+
     # Cache static assets with hash-based names (e.g., main.abc123.js)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         root   /usr/share/nginx/html;

--- a/apps/aggiemap-angular/src/.nginx/nginx.conf
+++ b/apps/aggiemap-angular/src/.nginx/nginx.conf
@@ -5,6 +5,22 @@ server {
 
     #access_log  /var/log/nginx/host.access.log  main;
 
+    # Cache static assets with hash-based names (e.g., main.abc123.js)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        root   /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
+    # Never cache index.html - always serve fresh for cache-busting
+    location = /index.html {
+        root   /usr/share/nginx/html;
+        expires -1;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        add_header Pragma "no-cache";
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;

--- a/apps/aggiemap-angular/src/environments/environment.dev.ts
+++ b/apps/aggiemap-angular/src/environments/environment.dev.ts
@@ -4,6 +4,7 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 import { factory } from '@tamu-gisc/aggiemap/ngx/common';
+export { metadata } from '@tamu-gisc/common/ngx/environment';
 
 export const environment = {
   production: true

--- a/apps/aggiemap-angular/src/environments/environment.prod.ts
+++ b/apps/aggiemap-angular/src/environments/environment.prod.ts
@@ -4,6 +4,7 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 import { factory } from '@tamu-gisc/aggiemap/ngx/common';
+export { metadata } from '@tamu-gisc/common/ngx/environment';
 
 export const environment = {
   production: true

--- a/apps/aggiemap-angular/src/environments/environment.ts
+++ b/apps/aggiemap-angular/src/environments/environment.ts
@@ -3,6 +3,7 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 import { factory } from '@tamu-gisc/aggiemap/ngx/common';
+export { metadata } from '@tamu-gisc/common/ngx/environment';
 
 export const environment = {
   production: false


### PR DESCRIPTION
This pull request introduces improvements to the `nginx` configuration for better performance and caching, and updates the Angular environment files to export `metadata` from a common package. The main changes are grouped into server configuration enhancements and environment file updates.

**Server configuration enhancements:**

* Enabled gzip compression in `nginx.conf` to reduce the size of transferred assets and improve load times.
* Added caching rules for static assets with hash-based names to leverage long-term browser caching, and set headers to prevent caching of `index.html` for proper cache-busting on deployments.

**Environment file updates:**

* Updated all environment files (`environment.ts`, `environment.dev.ts`, `environment.prod.ts`) to export `metadata` from `@tamu-gisc/common/ngx/environment`, ensuring consistent access to environment metadata across builds. [[1]](diffhunk://#diff-67a5ccc2c6ac1fae6d061926887a43020d0ee9128367867085fe07afb8f7e7f5R6) [[2]](diffhunk://#diff-d8ba873ab92b7e1efa66523eb34988d3440326e99c92d190b1f5788b41460445R7) [[3]](diffhunk://#diff-eb2f3e7a4c3dcd71b55f713c7557c6807d8966a5a20bd440049d1756e3f5eca3R7)