### PR TITLE
feat(aggiemap-angular): Fixed issue of Aggieland Saturday not appearing on AggieMap

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -1,6 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { ISpecialEventRoot } from '../interfaces/special-event.interface';
+import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
@@ -31,13 +31,13 @@ export const AggielandSaturdayEventDefinitions = {
   EVENT_SPECIAL_POIS: {
     id: AGGIELAND_SATURDAY_LAYERS.SPECIAL_POIS,
     layerId: AGGIELAND_SATURDAY_LAYERS.SPECIAL_POIS,
-    name: 'Points of Interest @ Aggieland Saturday',
+    name: 'Special Points of Interest',
     url: `${eventUrl}/2`
   },
   EVENT_PARKING: {
     id: AGGIELAND_SATURDAY_LAYERS.PARKING,
     layerId: AGGIELAND_SATURDAY_LAYERS.PARKING,
-    name: 'Parking',
+    name: 'Aggieland Saturday Parking',
     url: `${eventUrl}/3`
   }
 };
@@ -51,7 +51,7 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Event} Parking',
-      description: `Type: {attributes.Type}\nLot Name: {attributes.name}`
+      description: 'Type: {attributes.Type}\nLot Name: {attributes.name}'
     },
     visible: true,
     listMode: 'show',
@@ -67,7 +67,7 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
       name: 'Aggieland Saturday Bus Stop ({attributes.StopType})',
-      description: `Stop Name: {attributes.StopName}\nRoute Number: {attributes.Route}`
+      description: 'Stop Name: {attributes.StopName}\nRoute Number: {attributes.Route}'
     },
     visible: true,
     listMode: 'show',
@@ -107,8 +107,8 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
     title: AggielandSaturdayEventDefinitions.EVENT_BUS_ROUTES.name,
     url: AggielandSaturdayEventDefinitions.EVENT_BUS_ROUTES.url,
     visible: true,
+    listMode: 'show',
     native: {
-      listMode: 'show',
       outFields: ['*'],
       renderer: {
         type: 'unique-value',
@@ -153,8 +153,8 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
     url: AggielandSaturdayEventDefinitions.EVENT_SPECIAL_POIS.url,
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
-      name: `Aggieland Saturday Points of Interest`,
-      description: `Type: {attributes.Type}`
+      name: 'Aggieland Saturday Points of Interest',
+      description: 'Type: {attributes.Type}'
     },
     visible: true,
     listMode: 'show',
@@ -220,14 +220,27 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
   }
 ];
 
+export const AggielandSaturdayConfiguration: EventConfiguration = {
+  id: 'aggieland-saturday',
+  name: 'Aggieland Saturday',
+  applicationName: 'Aggieland Saturday Transportation Map',
+  shortApplicationName: 'Aggieland Saturday',
+  introductionText: 'Transportation, parking, and bus route information for Aggieland Saturday.',
+  eventDates: ['2026-02-28'],
+  mapCenter: [-96.339, 30.611],
+  zoom: 15
+};
+
+export const AggielandSaturdayOptions: SpecialEventOptions = [];
+
 export const AggielandSaturdayEventTs: ISpecialEventRoot = {
-  configuration: null,
-  options: null,
+  configuration: AggielandSaturdayConfiguration,
+  options: AggielandSaturdayOptions,
   sources: AggielandSaturdayEventColdLayerSources,
   references: AGGIELAND_SATURDAY_LAYERS,
   discover: {
-    id: 'aggieland-saturday',
-    name: 'Aggieland Saturday',
+    id: AggielandSaturdayConfiguration.id,
+    name: AggielandSaturdayConfiguration.name,
     description: 'Transportation and parking information for Aggieland Saturday.',
     source: 'internal',
     type: 'event',


### PR DESCRIPTION
Aggieland Saturday was not searchable nor accessible on AggieMap:

(Before): 
<img width="2476" height="1209" alt="Screenshot 2026-02-02 112602" src="https://github.com/user-attachments/assets/7396b4e8-24a6-42fc-8f81-c74d1f4dca5a" />

Opening https://aggiemap.tamu.edu/map/events/aggieland-saturday also redirects to the homepage.

In addition, the original Aggieland Saturday definition file was missing date information.

This PR re-adds Aggieland Saturday with updated formatting to match the rest of the codebase and adds a date.

<img width="1781" height="1010" alt="Screenshot 2026-02-02 113136" src="https://github.com/user-attachments/assets/acda2057-f57c-40c7-a07b-d97cb835d384" />
<img width="2401" height="1213" alt="Screenshot 2026-02-02 113145" src="https://github.com/user-attachments/assets/4afb4bf7-c221-4e5a-a761-82f3d97ba094" />
<img width="1784" height="725" alt="Screenshot 2026-02-02 113201" src="https://github.com/user-attachments/assets/b2c26d7f-afb4-4255-b094-c5fc58e13ac7" />

Part of #593 
