### PR TITLE
feat(aggiemap-angular): Update dates for 2026 Spring Semester Events

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -198,7 +198,7 @@ export const BigEventConfiguration: EventConfiguration = {
   name: 'Big Event',
   applicationName: 'Big Event Transportation Map',
   shortApplicationName: 'Big Event Map',
-  eventDates: ['2025-03-22']
+  eventDates: ['2026-03-21']
 };
 
 export const BigEventOptions: SpecialEventOptions = [

--- a/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
@@ -82,21 +82,21 @@ export const FamilyWeekendColdLayerSources: LayerSource[] = [
 ];
 
 export const FamilyWeekendConfiguration: EventConfiguration = {
-  id: 'family-weekend-2025',
+  id: 'family-weekend-2026',
   name: 'Family Weekend',
   applicationName: 'Family Weekend Transportation Map',
   shortApplicationName: 'Family Weekend Map',
   introductionText: 'Get the best parking information for',
-  eventDates: ['2025-04-04', '2025-04-05', '2025-04-06'],
+  eventDates: ['2026-04-10', '2026-04-11', '2026-04-12'],
   mapCenter: [-96.3405, 30.61114],
   zoom: 16
 };
 
 enum FamilyWeekendAttendanceDateChoices {
-  DayOne = '2025-04-04T05:00:00.000Z', //  Apr 4, 12AM UTC
-  DayTwo = '2025-04-05T05:00:00.000Z', // Apr5, 12AM UTC
-  DayThree = '2025-04-06T05:00:00.000Z', // Apr 6, 12AM UTC
-  Conclusion = '2025-04-07T05:00:00.000Z' // Apr 7, 12AM UTC
+  DayOne = '2026-04-10T05:00:00.000Z', //  Apr 10, 12AM UTC
+  DayTwo = '2026-04-11T05:00:00.000Z', // Apr 11, 12AM UTC
+  DayThree = '2026-04-12T05:00:00.000Z', // Apr 12, 12AM UTC
+  Conclusion = '2026-04-13T05:00:00.000Z' // Apr 13, 12AM UTC
 }
 
 export const FamilyWeekendOptions: SpecialEventOptions = [
@@ -109,15 +109,15 @@ export const FamilyWeekendOptions: SpecialEventOptions = [
     choices: [
       {
         value: FamilyWeekendAttendanceDateChoices.DayOne,
-        label: 'Friday, April 4th'
+        label: 'Friday, April 10th'
       },
       {
         value: FamilyWeekendAttendanceDateChoices.DayTwo,
-        label: 'Saturday, April 5th'
+        label: 'Saturday, April 11th'
       },
       {
         value: FamilyWeekendAttendanceDateChoices.DayThree,
-        label: 'Sunday, April 6th'
+        label: 'Sunday, April 12th'
       }
     ],
     effects: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -355,10 +355,10 @@ export const GraduationConfiguration: EventConfiguration = {
 };
 
 enum GraduationAttendanceDateChoices {
-  DayOne = '2026-05-07T05:00:00.000Z', // May 8, 12AM UTC
-  DayTwo = '2026-05-08T05:00:00.000Z', // May 9, 12AM UTC
-  DayThree = '2026-05-09T05:00:00.000Z', // May 10, 12AM UTC
-  Conclusion = '2026-05-10T05:00:00.000Z' // May 11, 12AM UTC
+  DayOne = '2026-05-07T05:00:00.000Z', // May 7, 12AM UTC
+  DayTwo = '2026-05-08T05:00:00.000Z', // May 8, 12AM UTC
+  DayThree = '2026-05-09T05:00:00.000Z', // May 9, 12AM UTC
+  Conclusion = '2026-05-10T05:00:00.000Z' // May 10, 12AM UTC
 }
 
 export const GraduationOptions: SpecialEventOptions = [

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -349,16 +349,16 @@ export const GraduationConfiguration: EventConfiguration = {
   applicationName: 'Commencement Transportation Map',
   shortApplicationName: 'Commencement Map',
   introductionText: 'Get the best transportation and parking information for the spring commencement ceremonies.',
-  eventDates: ['2025-05-08', '2025-05-09', '2025-05-10'],
+  eventDates: ['2026-05-07', '2026-05-08', '2026-05-09'],
   mapCenter: [-96.34458, 30.60629],
   zoom: 16
 };
 
 enum GraduationAttendanceDateChoices {
-  DayOne = '2025-05-08T05:00:00.000Z', // May 8, 12AM UTC
-  DayTwo = '2025-05-09T05:00:00.000Z', // May 9, 12AM UTC
-  DayThree = '2025-05-10T05:00:00.000Z', // May 10, 12AM UTC
-  Conclusion = '2025-05-11T05:00:00.000Z' // May 11, 12AM UTC
+  DayOne = '2026-05-07T05:00:00.000Z', // May 8, 12AM UTC
+  DayTwo = '2026-05-08T05:00:00.000Z', // May 9, 12AM UTC
+  DayThree = '2026-05-09T05:00:00.000Z', // May 10, 12AM UTC
+  Conclusion = '2026-05-10T05:00:00.000Z' // May 11, 12AM UTC
 }
 
 export const GraduationOptions: SpecialEventOptions = [
@@ -371,15 +371,15 @@ export const GraduationOptions: SpecialEventOptions = [
     choices: [
       {
         value: GraduationAttendanceDateChoices.DayOne,
-        label: 'Thursday, May 8th'
+        label: 'Thursday, May 7th'
       },
       {
         value: GraduationAttendanceDateChoices.DayTwo,
-        label: 'Friday, May 9th'
+        label: 'Friday, May 8th'
       },
       {
         value: GraduationAttendanceDateChoices.DayThree,
-        label: 'Saturday, May 10th'
+        label: 'Saturday, May 9th'
       }
     ],
     effects: {

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -38,12 +38,12 @@ export const MaroonWhiteGameColdLayerSources: LayerSource[] = [
 ];
 
 export const MaroonWhiteGameConfiguration: EventConfiguration = {
-  id: 'maroon-white-game-2025',
+  id: 'maroon-white-game-2026',
   name: 'Maroon & White Game',
   applicationName: 'Maroon & White Game Transportation Map',
   shortApplicationName: 'Maroon & White Game Map',
   introductionText: 'Get the best parking information for',
-  eventDates: ['2025-04-20'],
+  eventDates: ['2026-04-19'],
   mapCenter: [-96.34046, 30.60798],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
@@ -75,7 +75,7 @@ export const MS150Configuration: EventConfiguration = {
   name: 'Bike MS 150',
   applicationName: 'Bike MS 150 Parking Map',
   shortApplicationName: 'Bike MS 150 Map',
-  eventDates: ['2025-04-27'],
+  eventDates: ['2026-04-26'],
   zoom: 16,
   mapCenter: [-96.3434, 30.61017]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
@@ -97,7 +97,7 @@ export const MusterConfiguration: EventConfiguration = {
   name: 'Muster',
   applicationName: 'Muster Parking Map',
   shortApplicationName: 'Muster Map',
-  eventDates: ['2025-04-21'],
+  eventDates: ['2026-04-21'],
   zoom: 16
 };
 

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -76,7 +76,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   applicationName: 'Physics and Engineering Festival Transportation Map',
   shortApplicationName: 'Physics and Engineering Festival Map',
   introductionText: 'Get the best parking information for the',
-  eventDates: ['2025-04-05'],
+  eventDates: ['2026-03-21'],
   mapCenter: [-96.33771, 30.62143],
   zoom: 17
 };

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -76,7 +76,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   applicationName: 'Physics and Engineering Festival Transportation Map',
   shortApplicationName: 'Physics and Engineering Festival Map',
   introductionText: 'Get the best parking information for the',
-  eventDates: ['2026-03-21'],
+  eventDates: ['2026-03-28'],
   mapCenter: [-96.33771, 30.62143],
   zoom: 17
 };

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -10,8 +10,8 @@ export enum RING_DAY_LAYERS {
 }
 
 enum RingDayDates {
-  DAY1 = '2025-11-06',
-  DAY2 = '2025-11-07'
+  DAY1 = '2026-04-09',
+  DAY2 = '2026-04-10'
 }
 
 const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Ring_Day/MapServer';


### PR DESCRIPTION
Updates the following dates for these outdated spring semester events:

- **Big Event:** 3/22/2025 -> 3/21/2026
- **Family Weekend:** 4/4/2025 - 4/6/2025 -> 4/10/2026 -> 4/12/2026
- **Spring Graduation:** 5/8/2025 - 5/11/2025 -> 5/7/2026 - 5/10/2026
- **Maroon & White Game:** 4/20/2025 -> 4/19/2026 (Estimated date)
- **Bike MS 150:** 4/27/2025 -> 4/26/2026
- **Muster:** 4/21/2025 -> 4/21/2026
- **Physics and Engineering Festival:** 4/5/2025 -> 3/28/2026
- **Ring Day:** 11/6/2025 - 11/7/2025 -> 4/9/2026 - 4/10/2026

Part of #593 

