### PR TITLE
feat(aggiemap-angular):Add support for discrete event/parking maps

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/aggiemap-ngx-core.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/aggiemap-ngx-core.module.ts
@@ -26,6 +26,10 @@ const hybridRoutes: Routes = [
     loadChildren: () => import('@tamu-gisc/ts/events/ngx').then((m) => m.TsEventsNgxModule)
   },
   {
+    path: 'parking',
+    loadChildren: () => import('@tamu-gisc/ts/events/ngx').then((m) => m.TsEventsNgxModule)
+  },
+  {
     path: '**',
     redirectTo: 'map'
   }

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -55,6 +55,18 @@
         </ng-template>
       </div>
 
+      <!-- Parking Maps Section -->
+      <div class="parking-maps-section trailer-3" *ngIf="parkingApplications.length > 0">
+        <h2>Parking Maps</h2>
+        <p class="section-description">Ordered list of parking maps.</p>
+
+        <ol class="parking-links">
+          <li class="parking-link-item" *ngFor="let app of parkingApplications">
+            <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
+          </li>
+        </ol>
+      </div>
+
       <!-- Experimental Applications Section -->
       <div class="experimental-applications-section" *ngIf="(isDev | async) === true">
         <h2>Experimental Applications</h2>

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -20,7 +20,7 @@
               <div class="flex flex-column">
                 <div class="flex flex-row align-center title">
                   <span class="app-name">{{ app.name }}</span>
-                  <span class="chip chip-internal" *ngIf="app.source === 'internal'">Event</span>
+                  <span class="chip chip-internal" *ngIf="app.source === 'internal'">{{app.type | uppercase}}</span>
                   <span class="chip chip-external" *ngIf="app.source === 'external'">Experimental</span>
                   <span class="chip chip-label" *ngFor="let label of app.labels">{{ label | uppercase}}</span>
                 </div>

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -190,6 +190,42 @@
   gap: 1rem;
 }
 
+.parking-maps-section {
+  h2 {
+    color: #500000;
+    margin-bottom: 0.5rem;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}
+
+.parking-links {
+  margin: 0;
+  padding-left: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 2rem;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.parking-link-item {
+  margin: 0;
+}
+
+.parking-link {
+  color: #500000;
+  text-decoration: none;
+  font-weight: 600;
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+}
+
 .application-description {
   font-size: 0.875rem;
   color: #666;

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -129,7 +129,8 @@ export class DiscoverComponent implements OnInit {
     } else if (app.source === 'internal') {
       const config = (app as InternalDiscoverApplication).configuration;
       // Navigate to events intro page
-      this.rt.navigate([`/events`, config.id]);
+      const routeSegment = app.type === 'event' ? 'events' : app.type;
+      this.rt.navigate([`/${routeSegment}`, config.id]);
     }
   }
 

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -25,6 +25,7 @@ export class DiscoverComponent implements OnInit {
   public allApplications: DiscoverApplication[];
   private allEvents: EventConfiguration[];
   public upcomingEvents: EventConfiguration[];
+  public parkingApplications: InternalDiscoverApplication[];
 
   public searchControl = new FormControl();
   public filteredApplications: Observable<DiscoverApplication[]>;
@@ -58,6 +59,15 @@ export class DiscoverComponent implements OnInit {
 
     // Calculate upcoming events
     this.upcomingEvents = this.getUpcomingEvents();
+
+    // Build ordered parking list
+    this.parkingApplications = this.getParkingApplications();
+  }
+
+  private getParkingApplications(): InternalDiscoverApplication[] {
+    return this.eventDiscoverApplications
+      .filter((app) => app.type === 'parking')
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   private _filterApplications(value: string, isDev: boolean): DiscoverApplication[] {

--- a/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
@@ -22,7 +22,7 @@ export interface ExternalDiscoverApplication extends BaseDiscoverApplication {
 
 export interface InternalDiscoverApplication extends BaseDiscoverApplication {
   source: 'internal';
-  type: 'event' | 'general';
+  type: 'event' | 'parking';
   configuration: EventConfiguration;
 }
 

--- a/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
@@ -22,7 +22,7 @@ export interface ExternalDiscoverApplication extends BaseDiscoverApplication {
 
 export interface InternalDiscoverApplication extends BaseDiscoverApplication {
   source: 'internal';
-  type: 'event';
+  type: 'event' | 'general';
   configuration: EventConfiguration;
 }
 

--- a/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
@@ -20,11 +20,12 @@ export class DiscoveryService {
     ).map((event) => ({
       id: event.discover?.id || event.configuration.id,
       source: 'internal' as const,
-      type: 'event' as const,
+      type: event.discover?.type || 'event',
       name: event.discover?.name || event.configuration.name,
       description: event.discover?.description || event.configuration.introductionText || '',
       configuration: event.configuration,
-      keywords: event.discover?.keywords || []
+      keywords: event.discover?.keywords || [],
+      labels: event.discover?.labels || []
     }));
   }
 

--- a/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
@@ -3,7 +3,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum FOUR_H_ROUNDUP_LAYERS {
   FOUR_H_ROUNDUP_PARKING = 'four-h-roundup-parking',
@@ -75,11 +79,12 @@ export const FourHRoundupConfiguration: EventConfiguration = {
 
 export const FourHRoundupOptions: SpecialEventOptions = [];
 
-export const FourHRoundupTs: ISpecialEventRoot = {
+export const FourHRoundupTs: AggiemapCustomMapConfiguration = {
   configuration: FourHRoundupConfiguration,
   options: FourHRoundupOptions,
   sources: FourHColdLayerSources,
   references: FOUR_H_ROUNDUP_LAYERS,
+  type: 'special-event',
   discover: {
     id: FourHRoundupConfiguration.id,
     name: FourHRoundupConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum ACCESSIBLE_PARKING_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -93,17 +97,18 @@ export const AccessibleParkingConfiguration: EventConfiguration = {
 
 export const AccessibleParkingOptions: SpecialEventOptions = [];
 
-export const AccessibleParkingTs: ISpecialEventRoot = {
+export const AccessibleParkingTs: AggiemapCustomMapConfiguration = {
   configuration: AccessibleParkingConfiguration,
   options: AccessibleParkingOptions,
   sources: AccessibleParkingColdLayerSources,
   references: ACCESSIBLE_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: AccessibleParkingConfiguration.id,
     name: AccessibleParkingConfiguration.name,
     description: 'Accessible parking areas and spaces (including construction overlays).',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['accessible', 'disability', 'parking', 'handicap']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -238,6 +238,7 @@ export const AggielandSaturdayEventTs: ISpecialEventRoot = {
   options: AggielandSaturdayOptions,
   sources: AggielandSaturdayEventColdLayerSources,
   references: AGGIELAND_SATURDAY_LAYERS,
+  type: 'special-event',
   discover: {
     id: AggielandSaturdayConfiguration.id,
     name: AggielandSaturdayConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -14,7 +14,7 @@ import { SoftballRegionalsTs } from './softball-regionals.definitions';
 import { TroubadourTs } from './troubadour-festival.definitions';
 import { FootballParkingEvent } from './football-parking.definitions';
 import { RingDayEvent } from './ring-day.definitions';
-import { ISpecialEventRoot } from '../interfaces/special-event.interface';
+import { AggiemapCustomMapConfiguration } from '../interfaces/special-event.interface';
 import { MensBasketball_Ts } from './mens-basketball.definitions';
 import { WomensBasketball_Ts } from './womens-basketball.definitions';
 import { MoveOut } from './move-out.definitions';
@@ -37,7 +37,7 @@ import { MaintenanceParkingTs } from './maintenance-parking.definitions';
 import { BaseballParkingTs } from './baseball-parking.definitions';
 import { SavannahBananasParkingTs } from './savannah-bananas.definitions';
 
-export const EventDefinitions: Array<ISpecialEventRoot> = [
+export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
   AggielandSaturdayEventTs,
   BigEventTs,

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum BASEBALL_PARKING_LAYERS {
   BASEBALL_SYMBOLS = 'baseball-symbols',
@@ -158,11 +162,12 @@ export const BaseballParkingConfiguration: EventConfiguration = {
 
 export const BaseballParkingOptions: SpecialEventOptions = [];
 
-export const BaseballParkingTs: ISpecialEventRoot = {
+export const BaseballParkingTs: AggiemapCustomMapConfiguration = {
   configuration: BaseballParkingConfiguration,
   options: BaseballParkingOptions,
   sources: BaseballParkingColdLayerSources,
   references: BASEBALL_PARKING_LAYERS,
+  type: 'special-event',
   discover: {
     id: BaseballParkingConfiguration.id,
     name: BaseballParkingConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -260,11 +264,12 @@ export const BigEventOptions: SpecialEventOptions = [
   }
 ];
 
-export const BigEventTs: ISpecialEventRoot = {
+export const BigEventTs: AggiemapCustomMapConfiguration = {
   configuration: BigEventConfiguration,
   options: BigEventOptions,
   sources: BigEventColdLayerSources,
   references: BIG_EVENT_LAYERS,
+  type: 'special-event',
   discover: {
     id: BigEventConfiguration.id,
     name: BigEventConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum BUSINESS_PARKING_LAYERS {
   LOT_SPECIFIC = 'Lot Specific Permit Required',
@@ -106,17 +110,18 @@ export const BusinessParkingConfiguration: EventConfiguration = {
 
 export const BusinessParkingOptions: SpecialEventOptions = [];
 
-export const BusinessParkingTs: ISpecialEventRoot = {
+export const BusinessParkingTs: AggiemapCustomMapConfiguration = {
   configuration: BusinessParkingConfiguration,
   options: BusinessParkingOptions,
   sources: BusinessParkingColdLayerSources,
   references: BUSINESS_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: BusinessParkingConfiguration.id,
     name: BusinessParkingConfiguration.name,
     description: 'Parking lot information for University Business permits.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['business', 'university business', 'ub', 'ub+', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
@@ -121,7 +121,7 @@ export const BusinessParkingTs: AggiemapCustomMapConfiguration = {
     name: BusinessParkingConfiguration.name,
     description: 'Parking lot information for University Business permits.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['business', 'university business', 'ub', 'ub+', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
@@ -77,7 +77,7 @@ export const ContractorParkingTs: AggiemapCustomMapConfiguration = {
     name: ContractorParkingConfiguration.name,
     description: 'Parking areas designated for contractors.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['contractor', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
@@ -1,7 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
-
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum CONTRACTOR_PARKING_LAYERS {
   CONSTRUCTION = 'construction',
@@ -46,7 +49,7 @@ export const ContractorParkingColdLayerSources: LayerSource[] = [
     visible: true,
     native: {
       listMode: 'show',
-      outFields: ['*'],
+      outFields: ['*']
     }
   }
 ];
@@ -63,17 +66,18 @@ export const ContractorParkingConfiguration: EventConfiguration = {
 
 export const ContractorParkingOptions: SpecialEventOptions = [];
 
-export const ContractorParkingTs: ISpecialEventRoot = {
+export const ContractorParkingTs: AggiemapCustomMapConfiguration = {
   configuration: ContractorParkingConfiguration,
   options: ContractorParkingOptions,
   sources: ContractorParkingColdLayerSources,
   references: CONTRACTOR_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: ContractorParkingConfiguration.id,
     name: ContractorParkingConfiguration.name,
     description: 'Parking areas designated for contractors.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['contractor', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum FAMILY_WEEKEND_LAYERS {
   PARKING_LOTS = 'family-weekend-parking-lots',
@@ -185,11 +189,12 @@ export const FamilyWeekendOptions: SpecialEventOptions = [
   }
 ];
 
-export const FamilyWeekendTs: ISpecialEventRoot = {
+export const FamilyWeekendTs: AggiemapCustomMapConfiguration = {
   configuration: FamilyWeekendConfiguration,
   options: FamilyWeekendOptions,
   sources: FamilyWeekendColdLayerSources,
   references: FAMILY_WEEKEND_LAYERS,
+  type: 'special-event',
   discover: {
     id: FamilyWeekendConfiguration.id,
     name: FamilyWeekendConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum FOOTBALL_PARKING_LAYERS {
   FP_POIS = 'football-pois',
@@ -364,7 +368,16 @@ export const FootballParkingConfiguration: EventConfiguration = {
   applicationName: 'Gameday Transportation Map',
   shortApplicationName: 'Gameday Map',
   introductionText: 'Get the best transportation and parking information for game days.',
-  eventDates: ['2025-08-30', '2025-09-06', '2025-09-27', '2025-10-04', '2025-10-11', '2025-11-15', '2025-11-22','2025-12-20'],
+  eventDates: [
+    '2025-08-30',
+    '2025-09-06',
+    '2025-09-27',
+    '2025-10-04',
+    '2025-10-11',
+    '2025-11-15',
+    '2025-11-22',
+    '2025-12-20'
+  ],
   mapCenter: [-96.34344, 30.61011],
   zoom: 16,
   defaultLayerOverrides: {
@@ -583,11 +596,12 @@ export const FootballParkingOptions: SpecialEventOptions = [
   }
 ];
 
-export const FootballParkingEvent: ISpecialEventRoot = {
+export const FootballParkingEvent: AggiemapCustomMapConfiguration = {
   configuration: FootballParkingConfiguration,
   options: FootballParkingOptions,
   sources: FootballParkingColdLayerSources,
   references: FOOTBALL_PARKING_LAYERS,
+  type: 'special-event',
   discover: {
     id: FootballParkingConfiguration.id,
     name: FootballParkingConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum FRESHMAN_SELECTABLE_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -97,17 +101,18 @@ export const FreshmanSelectableConfiguration: EventConfiguration = {
 
 export const FreshmanSelectableOptions: SpecialEventOptions = [];
 
-export const FreshmanSelectableTs: ISpecialEventRoot = {
+export const FreshmanSelectableTs: AggiemapCustomMapConfiguration = {
   configuration: FreshmanSelectableConfiguration,
   options: FreshmanSelectableOptions,
   sources: FreshmanSelectableColdLayerSources,
   references: FRESHMAN_SELECTABLE_LAYERS,
+  type: 'general-map',
   discover: {
     id: FreshmanSelectableConfiguration.id,
     name: FreshmanSelectableConfiguration.name,
     description: 'Selectable parking information for freshmen.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['permit select', 'freshman', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
@@ -112,7 +112,7 @@ export const FreshmanSelectableTs: AggiemapCustomMapConfiguration = {
     name: FreshmanSelectableConfiguration.name,
     description: 'Selectable parking information for freshmen.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['permit select', 'freshman', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
@@ -1,7 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
-import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum GIS_DAY_LAYERS {
   MSC_RUDDER = 'gis-day-msc-rudder',
@@ -43,7 +46,7 @@ export const GisDayLayerSources: LayerSource[] = [
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
       name: 'attributes.BldgName',
-      description: 'attributes.ParkingInfo',
+      description: 'attributes.ParkingInfo'
     },
     visible: true,
     listMode: 'show',
@@ -82,11 +85,12 @@ export const GisDayConfiguration: EventConfiguration = {
 
 export const GisDayOptions: SpecialEventOptions = [];
 
-export const GisDayTs: ISpecialEventRoot = {
+export const GisDayTs: AggiemapCustomMapConfiguration = {
   configuration: GisDayConfiguration,
   options: GisDayOptions,
   sources: GisDayLayerSources,
   references: GIS_DAY_LAYERS,
+  type: 'special-event',
   discover: {
     id: GisDayConfiguration.id,
     name: GisDayConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -274,9 +274,9 @@ export const GraduationColdLayerSources: LayerSource[] = [
 
 export const GraduationConfiguration: EventConfiguration = {
   id: 'graduation-fall',
-  name: 'Commencement Ceremony',
-  applicationName: 'Commencement Transportation Map',
-  shortApplicationName: 'Commencement Map',
+  name: 'Fall Commencement Ceremony',
+  applicationName: 'Fall Commencement Transportation Map',
+  shortApplicationName: 'Fall Commencement Map',
   introductionText: 'Get the best transportation and parking information for the fall commencement ceremonies.',
   eventDates: ['2025-12-17', '2025-12-18'],
   mapCenter: [-96.34458, 30.60629],
@@ -338,7 +338,7 @@ export const GraduationFallEventTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: GraduationConfiguration.id,
     name: GraduationConfiguration.name,
-    description: 'Transportation and parking information for graduation ceremonies.',
+    description: 'Transportation and parking information for fall graduation ceremonies.',
     source: 'internal',
     type: 'event',
     keywords: ['graduation', 'commencement', 'parking', 'transportation']

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -325,7 +329,8 @@ export const GraduationOptions: SpecialEventOptions = [
   }
 ];
 
-export const GraduationFallEventTs: ISpecialEventRoot = {
+export const GraduationFallEventTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: GraduationConfiguration,
   options: GraduationOptions,
   sources: GraduationColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -435,7 +439,8 @@ export const GraduationOptions: SpecialEventOptions = [
   }
 ];
 
-export const GraduationSpringEventTs: ISpecialEventRoot = {
+export const GraduationSpringEventTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: GraduationConfiguration,
   options: GraduationOptions,
   sources: GraduationColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -349,9 +349,9 @@ export const GraduationColdLayerSources: LayerSource[] = [
 
 export const GraduationConfiguration: EventConfiguration = {
   id: 'graduation-spring',
-  name: 'Commencement Ceremony',
-  applicationName: 'Commencement Transportation Map',
-  shortApplicationName: 'Commencement Map',
+  name: 'Spring Commencement Ceremony',
+  applicationName: 'Spring Commencement Transportation Map',
+  shortApplicationName: 'Spring Commencement Map',
   introductionText: 'Get the best transportation and parking information for the spring commencement ceremonies.',
   eventDates: ['2026-05-07', '2026-05-08', '2026-05-09'],
   mapCenter: [-96.34458, 30.60629],
@@ -448,7 +448,7 @@ export const GraduationSpringEventTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: GraduationConfiguration.id,
     name: GraduationConfiguration.name,
-    description: 'Transportation and parking information for graduation ceremonies.',
+    description: 'Transportation and parking information for spring graduation ceremonies.',
     source: 'internal',
     type: 'event',
     keywords: ['graduation', 'commencement', 'parking', 'transportation']

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -119,9 +119,9 @@ export const SummerCommencementColdLayerSources: LayerSource[] = [
 
 export const SummerCommencementConfiguration: EventConfiguration = {
   id: 'graduation-summer',
-  name: 'Commencement Ceremony',
-  applicationName: 'Commencement Transportation Map',
-  shortApplicationName: 'Commencement Map',
+  name: 'Summer Commencement Ceremony',
+  applicationName: 'Summer Commencement Transportation Map',
+  shortApplicationName: 'Summer Commencement Map',
   introductionText: 'Get the best transportation and parking information for the summer commencement ceremonies.',
   eventDates: ['2025-08-09'],
   mapCenter: [-96.34458, 30.60629],
@@ -143,7 +143,7 @@ export const SummerCommencementTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: SummerCommencementConfiguration.id,
     name: SummerCommencementConfiguration.name,
-    description: 'Transportation and parking information for summer commencement ceremony.',
+    description: 'Transportation and parking information for summer graduation ceremonies.',
     source: 'internal',
     type: 'event',
     keywords: ['summer', 'commencement', 'graduation', 'parking', 'transportation']

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -130,7 +134,8 @@ enum SummerCommencementAttendanceDateChoices {
 
 export const SummerCommencementOptions: SpecialEventOptions = [];
 
-export const SummerCommencementTs: ISpecialEventRoot = {
+export const SummerCommencementTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: SummerCommencementConfiguration,
   options: SummerCommencementOptions,
   sources: SummerCommencementColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 import { commonSymbols } from './common.definitions';
 
 export enum HS_GRADUATION_LAYERS {
@@ -191,7 +195,8 @@ export const HsGraduationOptions: SpecialEventOptions = [
   }
 ];
 
-export const HsGraduationTs: ISpecialEventRoot = {
+export const HsGraduationTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: HsGraduationConfiguration,
   sources: HsGraduationColdLayerSources,
   options: HsGraduationOptions,

--- a/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MAINTENANCE_PARKING_LAYERS {
   CONSTRUCTION = 'construction',
@@ -169,17 +173,18 @@ export const MaintenanceParkingConfiguration: EventConfiguration = {
 
 export const MaintenanceParkingOptions: SpecialEventOptions = [];
 
-export const MaintenanceParkingTs: ISpecialEventRoot = {
+export const MaintenanceParkingTs: AggiemapCustomMapConfiguration = {
   configuration: MaintenanceParkingConfiguration,
   options: MaintenanceParkingOptions,
   sources: MaintenanceParkingColdLayerSources,
   references: MAINTENANCE_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: MaintenanceParkingConfiguration.id,
     name: MaintenanceParkingConfiguration.name,
     description: 'Maintenance parking lots and spaces, including construction, service, contractor, and RNS overlays.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['maintenance', 'parking', 'service', 'contractor']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MAROON_WHITE_GAME_LAYERS {
   PARKING_LOTS = 'maroon-white-game-parking-lots'
@@ -50,7 +54,8 @@ export const MaroonWhiteGameConfiguration: EventConfiguration = {
 
 export const MaroonWhiteGameOptions: SpecialEventOptions = [];
 
-export const MaroonWhiteTs: ISpecialEventRoot = {
+export const MaroonWhiteTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: MaroonWhiteGameConfiguration,
   options: MaroonWhiteGameOptions,
   sources: MaroonWhiteGameColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MEDIA_PARKING_LAYERS {
   MEDIA_PARKING_LOTS = 'media-parking-lots',
@@ -62,17 +66,18 @@ export const MediaParkingConfiguration: EventConfiguration = {
 
 export const MediaParkingOptions: SpecialEventOptions = [];
 
-export const MediaParkingTs: ISpecialEventRoot = {
+export const MediaParkingTs: AggiemapCustomMapConfiguration = {
   configuration: MediaParkingConfiguration,
   options: MediaParkingOptions,
   sources: MediaParkingColdLayerSources,
   references: MEDIA_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: MediaParkingConfiguration.id,
     name: MediaParkingConfiguration.name,
     description: 'Parking lot information for media permits.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['media', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MENS_BASKETBALL_LAYERS {
   LINE_PAINT = 'mens-basketball-line-paint',
@@ -130,7 +134,8 @@ export const MensBasketball_Configuration: EventConfiguration = {
 
 export const MensBasketball_Options: SpecialEventOptions = [];
 
-export const MensBasketball_Ts: ISpecialEventRoot = {
+export const MensBasketball_Ts: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: MensBasketball_Configuration,
   options: MensBasketball_Options,
   sources: MensBasketball_ColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
@@ -58,7 +58,7 @@ export const MotoristAssistanceTs: AggiemapCustomMapConfiguration = {
     name: MotoristAssistanceConfiguration.name,
     description: 'Motorist assistance service area coverage.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['motorist', 'assistance', 'service area']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MOTORIST_ASSISTANCE_LAYERS {
   SERVICE_AREA = 'Service Area'
@@ -43,17 +47,18 @@ export const MotoristAssistanceConfiguration: EventConfiguration = {
 
 export const MotoristAssistanceOptions: SpecialEventOptions = [];
 
-export const MotoristAssistanceTs: ISpecialEventRoot = {
+export const MotoristAssistanceTs: AggiemapCustomMapConfiguration = {
   configuration: MotoristAssistanceConfiguration,
   options: MotoristAssistanceOptions,
   sources: MotoristAssistanceColdLayerSources,
   references: MOTORIST_ASSISTANCE_LAYERS,
+  type: 'general-map',
   discover: {
     id: MotoristAssistanceConfiguration.id,
     name: MotoristAssistanceConfiguration.name,
     description: 'Motorist assistance service area coverage.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['motorist', 'assistance', 'service area']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MOVE_IN_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -116,11 +120,12 @@ export const MoveInConfiguration: EventConfiguration = {
 
 export const MoveInOptions: SpecialEventOptions = [];
 
-export const MoveInTs: ISpecialEventRoot = {
+export const MoveInTs: AggiemapCustomMapConfiguration = {
   configuration: MoveInConfiguration,
   options: MoveInOptions,
   sources: MoveInColdLayerSources,
   references: MOVE_IN_LAYERS,
+  type: 'special-event',
   discover: {
     id: MoveInConfiguration.id,
     name: MoveInConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
@@ -1,14 +1,16 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
-
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MOVE_OUT_LAYERS {
   CONSTRUCTION = 'Construction',
   NO_PARKING = 'No Parking Areas',
-  STREET_PARKING = 'Move-Out Allowed Street Parking',
+  STREET_PARKING = 'Move-Out Allowed Street Parking'
 }
-
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MoveInMoveOut/MapServer';
 
@@ -66,7 +68,7 @@ export const MoveOutColdLayerSources: LayerSource[] = [
     native: {
       outFields: ['*']
     }
-  },
+  }
 ];
 
 export const MoveOutConfiguration: EventConfiguration = {
@@ -81,12 +83,12 @@ export const MoveOutConfiguration: EventConfiguration = {
 
 export const MoveOutOptions: SpecialEventOptions = [];
 
-
-export const MoveOut: ISpecialEventRoot = {
+export const MoveOut: AggiemapCustomMapConfiguration = {
   configuration: MoveOutConfiguration,
   options: MoveOutOptions,
   sources: MoveOutColdLayerSources,
   references: MOVE_OUT_LAYERS,
+  type: 'special-event',
   discover: {
     id: MoveOutConfiguration.id,
     name: MoveOutConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum MS150_LAYERS {
   PARKING_LOTS = 'ms150-parking-lots',
@@ -82,11 +86,12 @@ export const MS150Configuration: EventConfiguration = {
 
 export const MS150Options: SpecialEventOptions = [];
 
-export const MS150Ts: ISpecialEventRoot = {
+export const MS150Ts: AggiemapCustomMapConfiguration = {
   configuration: MS150Configuration,
   options: MS150Options,
   sources: MS150ColdLayerSources,
   references: MS150_LAYERS,
+  type: 'special-event',
   discover: {
     id: MS150Configuration.id,
     name: MS150Configuration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -103,7 +107,8 @@ export const MusterConfiguration: EventConfiguration = {
 
 export const MusterOptions: SpecialEventOptions = [];
 
-export const MusterTs: ISpecialEventRoot = {
+export const MusterTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: MusterConfiguration,
   options: MusterOptions,
   sources: MusterEventColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
@@ -58,7 +58,7 @@ export const NightWeekendTs: AggiemapCustomMapConfiguration = {
     name: NightWeekendConfiguration.name,
     description: 'Parking lot information for Night Privileges (5:00pm - 6:00am) and weekend parking.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['night', 'weekend', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum NIGHT_WEEKEND_LAYERS {
   NIGHT_PRIVILEGES = 'Night Privileges 5:00pm - 6:00am'
@@ -43,17 +47,18 @@ export const NightWeekendConfiguration: EventConfiguration = {
 
 export const NightWeekendOptions: SpecialEventOptions = [];
 
-export const NightWeekendTs: ISpecialEventRoot = {
+export const NightWeekendTs: AggiemapCustomMapConfiguration = {
   configuration: NightWeekendConfiguration,
   options: NightWeekendOptions,
   sources: NightWeekendColdLayerSources,
   references: NIGHT_WEEKEND_LAYERS,
+  type: 'general-map',
   discover: {
     id: NightWeekendConfiguration.id,
     name: NightWeekendConfiguration.name,
     description: 'Parking lot information for Night Privileges (5:00pm - 6:00am) and weekend parking.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['night', 'weekend', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS {
   FESTIVAL_AREAS = 'phys-eng-festival-areas',
@@ -83,7 +87,8 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
 
 export const PhysicsAndEngineeringFestivalOptions: SpecialEventOptions = [];
 
-export const PhysicsAndEngineeringFestivalTs: ISpecialEventRoot = {
+export const PhysicsAndEngineeringFestivalTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: PhysicsAndEngineeringFestivalConfiguration,
   options: PhysicsAndEngineeringFestivalOptions,
   sources: PhysEngFestivalColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum RETIREE_PARKING_LAYERS {
   LOT_SPECIFIC = 'Lot Specific Permit Required',
@@ -79,17 +83,18 @@ export const RetireeParkingConfiguration: EventConfiguration = {
 
 export const RetireeParkingOptions: SpecialEventOptions = [];
 
-export const RetireeParkingTs: ISpecialEventRoot = {
+export const RetireeParkingTs: AggiemapCustomMapConfiguration = {
   configuration: RetireeParkingConfiguration,
   options: RetireeParkingOptions,
   sources: RetireeParkingColdLayerSources,
   references: RETIREE_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: RetireeParkingConfiguration.id,
     name: RetireeParkingConfiguration.name,
     description: 'Parking lot information for Retiree permits.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['retiree', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum RING_DAY_LAYERS {
   RD_POIS = 'ring-day-pois',
@@ -222,7 +226,8 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
   // }
 ];
 
-export const RingDayEvent: ISpecialEventRoot = {
+export const RingDayEvent: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: RingDayConfiguration,
   options: RingDaySpecialEventOptions,
   sources: RingDayColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -179,11 +183,12 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
 
 export const SavannahBananasParkingOptions: SpecialEventOptions = [];
 
-export const SavannahBananasParkingTs: ISpecialEventRoot = {
+export const SavannahBananasParkingTs: AggiemapCustomMapConfiguration = {
   configuration: SavannahBananasParkingConfiguration,
   options: SavannahBananasParkingOptions,
   sources: SavannahBananasParkingColdLayerSources,
   references: SAVANNAH_BANANAS_PARKING_LAYERS,
+  type: 'special-event',
   discover: {
     id: SavannahBananasParkingConfiguration.id,
     name: SavannahBananasParkingConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum SERVICE_LOADING_LAYERS {
   CONSTRUCTION = 'construction',
@@ -169,17 +173,18 @@ export const ServiceLoadingConfiguration: EventConfiguration = {
 
 export const ServiceLoadingOptions: SpecialEventOptions = [];
 
-export const ServiceLoadingTs: ISpecialEventRoot = {
+export const ServiceLoadingTs: AggiemapCustomMapConfiguration = {
   configuration: ServiceLoadingConfiguration,
   options: ServiceLoadingOptions,
   sources: ServiceLoadingColdLayerSources,
   references: SERVICE_LOADING_LAYERS,
+  type: 'general-map',
   discover: {
     id: ServiceLoadingConfiguration.id,
     name: ServiceLoadingConfiguration.name,
     description: 'Service, maintenance, and contractor parking lots and spaces, including construction and RNS overlays.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['service', 'loading', 'maintenance', 'contractor', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -105,7 +109,8 @@ export const SoftballConfiguration: EventConfiguration = {
 
 export const SoftballOptions: SpecialEventOptions = [];
 
-export const SoftballRegionalsTs: ISpecialEventRoot = {
+export const SoftballRegionalsTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: SoftballConfiguration,
   sources: SoftballLayerSources,
   options: SoftballOptions,

--- a/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum STAFF_SELECTABLE_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -97,17 +101,18 @@ export const StaffSelectableConfiguration: EventConfiguration = {
 
 export const StaffSelectableOptions: SpecialEventOptions = [];
 
-export const StaffSelectableTs: ISpecialEventRoot = {
+export const StaffSelectableTs: AggiemapCustomMapConfiguration = {
   configuration: StaffSelectableConfiguration,
   options: StaffSelectableOptions,
   sources: StaffSelectableColdLayerSources,
   references: STAFF_SELECTABLE_LAYERS,
+  type: 'general-map',
   discover: {
     id: StaffSelectableConfiguration.id,
     name: StaffSelectableConfiguration.name,
     description: 'Selectable parking information for staff.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['permit select', 'staff', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
@@ -112,7 +112,7 @@ export const StaffSelectableTs: AggiemapCustomMapConfiguration = {
     name: StaffSelectableConfiguration.name,
     description: 'Selectable parking information for staff.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['permit select', 'staff', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
@@ -112,7 +112,7 @@ export const StudentSelectableTs: AggiemapCustomMapConfiguration = {
     name: StudentSelectableConfiguration.name,
     description: 'Selectable parking information for students.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['permit select', 'student', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum STUDENT_SELECTABLE_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -97,17 +101,18 @@ export const StudentSelectableConfiguration: EventConfiguration = {
 
 export const StudentSelectableOptions: SpecialEventOptions = [];
 
-export const StudentSelectableTs: ISpecialEventRoot = {
+export const StudentSelectableTs: AggiemapCustomMapConfiguration = {
   configuration: StudentSelectableConfiguration,
   options: StudentSelectableOptions,
   sources: StudentSelectableColdLayerSources,
   references: STUDENT_SELECTABLE_LAYERS,
+  type: 'general-map',
   discover: {
     id: StudentSelectableConfiguration.id,
     name: StudentSelectableConfiguration.name,
     description: 'Selectable parking information for students.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['permit select', 'student', 'selectable', 'parking', 'rns']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
@@ -1,7 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum TIMED_PARKING_LAYERS {
   TIMED_PARKING_AREA = 'Timed Parking in this area',
@@ -49,7 +52,7 @@ export const TimedParkingColdLayerSources: LayerSource[] = [
       listMode: 'show',
       outFields: ['*']
     }
-  },
+  }
 ];
 
 export const TimedParkingConfiguration: EventConfiguration = {
@@ -61,19 +64,20 @@ export const TimedParkingConfiguration: EventConfiguration = {
   mapCenter: [-96.33771, 30.62143]
 };
 
-export const TimedParkingOptions: SpecialEventOptions = []
+export const TimedParkingOptions: SpecialEventOptions = [];
 
-export const TimedParking_Ts: ISpecialEventRoot = {
+export const TimedParking_Ts: AggiemapCustomMapConfiguration = {
   configuration: TimedParkingConfiguration,
   options: TimedParkingOptions,
   sources: TimedParkingColdLayerSources,
   references: TIMED_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: TimedParkingConfiguration.id,
     name: TimedParkingConfiguration.name,
     description: 'Areas with timed parking on campus.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['timed', 'parking', 'transportation', '30 minute', '30 min']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
@@ -77,7 +77,7 @@ export const TimedParking_Ts: AggiemapCustomMapConfiguration = {
     name: TimedParkingConfiguration.name,
     description: 'Areas with timed parking on campus.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['timed', 'parking', 'transportation', '30 minute', '30 min']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
@@ -2,7 +2,11 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum TROUBADOUR_LAYERS {
   PARKING = 'troubadour-parking'
@@ -51,11 +55,12 @@ export const TroubadourConfiguration: EventConfiguration = {
 
 export const TroubadourOptions: SpecialEventOptions = [];
 
-export const TroubadourTs: ISpecialEventRoot = {
+export const TroubadourTs: AggiemapCustomMapConfiguration = {
   configuration: TroubadourConfiguration,
   options: TroubadourOptions,
   sources: TroubadourColdLayerSources,
   references: TROUBADOUR_LAYERS,
+  type: 'special-event',
   discover: {
     id: TroubadourConfiguration.id,
     name: TroubadourConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
@@ -132,7 +132,7 @@ export const VendorParking_Ts: AggiemapCustomMapConfiguration = {
     name: VendorParkingConfiguration.name,
     description: 'Parking information for vendors.',
     source: 'internal',
-    type: 'general',
+    type: 'parking',
     keywords: ['vendor', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
@@ -2,9 +2,13 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
-import esri = __esri
+import esri = __esri;
 
 export enum VENDOR_PARKING_LAYERS {
   CONSTRUCTION = 'Construction',
@@ -27,7 +31,7 @@ export const VendorParkingDefinitions = {
     name: 'Marked Business Spaces',
     url: `${eventUrl}/2`
   },
-    VENDOR_PARKING_LOTS: {
+  VENDOR_PARKING_LOTS: {
     id: VENDOR_PARKING_LAYERS.VENDOR_PARKING_LOTS,
     layerId: VENDOR_PARKING_LAYERS.VENDOR_PARKING_LOTS,
     name: 'Vendor Parking Lots',
@@ -56,7 +60,7 @@ export const VendorParkingColdLayerSources: LayerSource[] = [
     visible: true,
     native: {
       outFields: ['*']
-    },
+    }
   },
 
   {
@@ -74,33 +78,33 @@ export const VendorParkingColdLayerSources: LayerSource[] = [
         field2: 'GIS.TS.ParkingLots.LotType',
         fieldDelimiter: ',',
         uniqueValueInfos: [
-                  {
-                    value: '1,Surface',
-                    label: 'Surface Vender Permit and Vendor+ Permit Authorized',
-                    symbol: {
-                      type: 'simple-fill',
-                      color: 'rgb(90, 0, 0)'
-                    } as unknown as esri.SimpleFillSymbolProperties
-                  },
-                  {
-                    value: '1,Street',
-                    label: 'Street Vender Permit and Vendor+ Permit Authorized',
-                    symbol: {
-                      type: 'simple-fill',
-                      color: 'rgb(90, 0, 0)'
-                    } as unknown as esri.SimpleFillSymbolProperties
-                  },
-                  {
-                    value: '1,Garage Visitor',
-                    label: 'Garage Vender Permit and Vendor+ Permit Authorized',
-                    symbol: {
-                      type: 'simple-fill',
-                      color: 'rgb(90, 0, 0)'
-                    } as unknown as esri.SimpleFillSymbolProperties
-                  },
-                ]
+          {
+            value: '1,Surface',
+            label: 'Surface Vender Permit and Vendor+ Permit Authorized',
+            symbol: {
+              type: 'simple-fill',
+              color: 'rgb(90, 0, 0)'
+            } as unknown as esri.SimpleFillSymbolProperties
+          },
+          {
+            value: '1,Street',
+            label: 'Street Vender Permit and Vendor+ Permit Authorized',
+            symbol: {
+              type: 'simple-fill',
+              color: 'rgb(90, 0, 0)'
+            } as unknown as esri.SimpleFillSymbolProperties
+          },
+          {
+            value: '1,Garage Visitor',
+            label: 'Garage Vender Permit and Vendor+ Permit Authorized',
+            symbol: {
+              type: 'simple-fill',
+              color: 'rgb(90, 0, 0)'
+            } as unknown as esri.SimpleFillSymbolProperties
+          }
+        ]
       }
-    },
+    }
   }
 ];
 
@@ -117,17 +121,18 @@ export const VendorParkingConfiguration: EventConfiguration = {
 
 export const VendorParkingOptions: SpecialEventOptions = [];
 
-export const VendorParking_Ts: ISpecialEventRoot = {
+export const VendorParking_Ts: AggiemapCustomMapConfiguration = {
   configuration: VendorParkingConfiguration,
   options: VendorParkingOptions,
   sources: VendorParkingColdLayerSources,
   references: VENDOR_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: VendorParkingConfiguration.id,
     name: VendorParkingConfiguration.name,
     description: 'Parking information for vendors.',
     source: 'internal',
-    type: 'event',
+    type: 'general',
     keywords: ['vendor', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -1,7 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum WOMENS_BASKETBALL_LAYERS {
   VISITOR_KIOSK = 'womens-basketball-visitor-kiosk',
@@ -151,7 +155,8 @@ export const WomensBasketball_Configuration: EventConfiguration = {
 
 export const WomensBasketball_Options: SpecialEventOptions = [];
 
-export const WomensBasketball_Ts: ISpecialEventRoot = {
+export const WomensBasketball_Ts: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
   configuration: WomensBasketball_Configuration,
   options: WomensBasketball_Options,
   sources: WomensBasketball_ColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -236,24 +236,32 @@ export interface ResolvedEventSetting {
 
 export type ResolvedEventSettings = Array<ResolvedEventSetting>;
 
-export interface ISpecialEventRoot {
+export interface IMapConfigurationBase {
   configuration: EventConfiguration | null;
   options: SpecialEventOptions | null;
   references: Record<string, string> | null;
   sources: Array<LayerSource> | null;
 
   /**
-   * If the event should be discoverable in the Discover application, this property should be set to an object that conforms to the EventDiscoverMetadata interface.
+   * If the map should be discoverable in the Discover application, this property should be set to an object that conforms to the DiscoverMetadata interface.
    */
-  discover?: EventDiscoverMetadata | null;
+  discover?: DiscoverMetadata | null;
 }
 
+export interface ISpecialEventRoot extends IMapConfigurationBase {
+  type: 'special-event';
+}
+
+export interface IGeneralMapRoot extends IMapConfigurationBase {
+  type: 'general-map';
+}
+
+export type AggiemapCustomMapConfiguration = ISpecialEventRoot | IGeneralMapRoot;
+
 /**
- * Metadata used to represent an event in the Discover application.
- *
- * This has significant overlap with the EventConfiguration interface. This is sadly kept separate because of Nx library boundaries creates a circular dependency otherwise.
+ * Metadata used to represent a map in the Discover application.
  */
-export interface EventDiscoverMetadata {
+export interface DiscoverMetadata {
   id: string;
   name: string;
   description: string;
@@ -266,5 +274,5 @@ export interface EventDiscoverMetadata {
    */
   labels?: string[];
   source: 'internal';
-  type: 'event';
+  type: 'event' | 'general';
 }

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -274,5 +274,5 @@ export interface DiscoverMetadata {
    */
   labels?: string[];
   source: 'internal';
-  type: 'event' | 'general';
+  type: 'event' | 'parking';
 }

--- a/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
@@ -7,9 +7,9 @@ import { LocalStoreService } from '@tamu-gisc/common/ngx/local-store';
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import {
+  AggiemapCustomMapConfiguration,
   EventAccommodationOption,
   EventSettings,
-  ISpecialEventRoot,
   ResolvedEventSettings,
   SpecialEventOptions
 } from '../../interfaces/special-event.interface';
@@ -104,10 +104,12 @@ export class EventSettingsService {
     }
   }
 
-  public eventConfiguration(): ISpecialEventRoot;
-  public eventConfiguration(asObservable: true): Observable<ISpecialEventRoot>;
-  public eventConfiguration(asObservable: false): ISpecialEventRoot;
-  public eventConfiguration(asObservable?: boolean): ISpecialEventRoot | Observable<ISpecialEventRoot> {
+  public eventConfiguration(): AggiemapCustomMapConfiguration;
+  public eventConfiguration(asObservable: true): Observable<AggiemapCustomMapConfiguration>;
+  public eventConfiguration(asObservable: false): AggiemapCustomMapConfiguration;
+  public eventConfiguration(
+    asObservable?: boolean
+  ): AggiemapCustomMapConfiguration | Observable<AggiemapCustomMapConfiguration> {
     const config = this.getEventDefinitionById(this._settingsSecondaryKey);
 
     if (!config) {
@@ -330,7 +332,7 @@ export class EventSettingsService {
    * @param {string} eventId A string that represents the event configuration Id
    * @return {EventDefinition | null} Returns the EventDefinition object if found, otherwise null.
    */
-  public getEventDefinitionById(eventId: string): ISpecialEventRoot | null {
+  public getEventDefinitionById(eventId: string): AggiemapCustomMapConfiguration | null {
     if (!eventId || eventId.length === 0) {
       return null;
     }


### PR DESCRIPTION
This pull request introduces support for "parking" map applications alongside existing event maps in the AggieMap Discover module. The changes add a new "Parking Maps" section to the Discover UI, update the data model and interfaces to distinguish between event and parking applications, and refactor event definitions to support this new type. The routing is also updated to allow navigation to parking maps.

**Discover UI and Routing Enhancements:**

- Added a "Parking Maps" section to the Discover page, displaying an ordered list of parking map applications with links for navigation. [[1]](diffhunk://#diff-d1baec7fd0a7fe9eb1a0244aea2d618d42d4800f4b7803f4918ec2983cd523d9R58-R69) [[2]](diffhunk://#diff-cd173817ddb3e6cb190eb05f1d4a729cd5da080c595d256cf556611126ef5b5aR193-R228) [[3]](diffhunk://#diff-51dc4b91f359747a7e1c028a8b8230bb07140197c591bf6ebb851805f60e041eR28) [[4]](diffhunk://#diff-51dc4b91f359747a7e1c028a8b8230bb07140197c591bf6ebb851805f60e041eR62-R70)
- Updated application navigation logic to route to either `/events/:id` or `/parking/:id` depending on the application type.
- Added a new route for `parking` in the hybrid routes configuration.

**Data Model and Interface Updates:**

- Extended the `InternalDiscoverApplication` interface and related code to support both `event` and `parking` types, and included additional fields such as `labels`. [[1]](diffhunk://#diff-faef926f827f14b98006d8681e05d4437d4d86fbed4a4341c588b84390cde653L25-R25) [[2]](diffhunk://#diff-4f9f804700fedb67531c722de9fa277ceb8ffe7fe4356aed2f90483daf9254fdL23-R28)
- Discovery service now properly sets the application type and labels based on the event definition.

**Event Definitions Refactor:**

- Refactored all event definition files to use the new `AggiemapCustomMapConfiguration` type instead of `ISpecialEventRoot`. [[1]](diffhunk://#diff-11e10e0b337dff9f8146186a560e795606473169b4fd2e024b47d7da359e5749L6-R10) [[2]](diffhunk://#diff-44e5d0d9d876532ebf045f823b0199aa6b848a48626959dcd32fa02aae939816L3-R7) [[3]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5L17-R17) [[4]](diffhunk://#diff-d33032ca0b116bfee34044e8d324c62b498158d4317698a9165797daaff6f893L5-R9) [[5]](diffhunk://#diff-b8f020f5727ce137353e4c2cd77ae89c70719c98b96a51d2526f75d4ea442714L5-R9) [[6]](diffhunk://#diff-e6bc855c6be808e5ebcbc6e30215ba27261785f43134df45177e86a359f8d75dL3-R7) [[7]](diffhunk://#diff-cd459d8f41a46ae4aa043c7b46231765e3e414eee7e4ef1ee0c8e758bc5f6dcdL3-R7) [[8]](diffhunk://#diff-b5dc0b0a0f8d53f71e5fe0d4eaf8ca8988d54beb55cd8eccb09f143459be4033L4-R8) [[9]](diffhunk://#diff-bd9b00c1e2494acb9c49109b5cb0836631a4035671a3c5fa0de2f1966106eda6L4-R8)
- Updated event and parking map definitions to include a `type` field (`special-event` or `general-map`) and set the `discover.type` to either `event` or `parking` as appropriate. [[1]](diffhunk://#diff-11e10e0b337dff9f8146186a560e795606473169b4fd2e024b47d7da359e5749L78-R87) [[2]](diffhunk://#diff-44e5d0d9d876532ebf045f823b0199aa6b848a48626959dcd32fa02aae939816L96-R111) [[3]](diffhunk://#diff-5684a1a91dc22806aa74156eb1964d28c7f6f84ec3e1ace70b65fb7897951b0bR241) [[4]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5L40-R40) [[5]](diffhunk://#diff-d33032ca0b116bfee34044e8d324c62b498158d4317698a9165797daaff6f893L161-R170) [[6]](diffhunk://#diff-b8f020f5727ce137353e4c2cd77ae89c70719c98b96a51d2526f75d4ea442714L263-R272) [[7]](diffhunk://#diff-e6bc855c6be808e5ebcbc6e30215ba27261785f43134df45177e86a359f8d75dL109-R124) [[8]](diffhunk://#diff-cd459d8f41a46ae4aa043c7b46231765e3e414eee7e4ef1ee0c8e758bc5f6dcdL66-R80) [[9]](diffhunk://#diff-b5dc0b0a0f8d53f71e5fe0d4eaf8ca8988d54beb55cd8eccb09f143459be4033L188-R197)

**UI Display Improvements:**

- Updated the Discover page to display the application type as a chip label, using the value of `app.type`.

These changes collectively make it possible to discover and navigate to both event and parking maps within the AggieMap application, with clear UI separation and proper routing.