### PR TITLE
feat(aggiemap-angular): Add Main Parking map  + Allow for Multiple Attributes in Popups

### DIFF
--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -354,6 +354,16 @@ export type LayerSource = LayerSourceType & {
   >;
 
   /**
+   * Controls how popupData entries are resolved.
+   *
+   * `independent` resolves each entry only against the feature's original attributes.
+   * `cumulative` also allows later entries to reference popupData values resolved earlier in the same object.
+   *
+   * Defaults to `independent`.
+   */
+  popupDataResolutionStrategy?: 'independent' | 'cumulative';
+
+  /**
    * Legend items that are shown disabled in the legend as the layer visibility is on/off
    *
    * @deprecated Legend items are now rendered through the legend view model

--- a/libs/common/utils/string/src/lib/common-utils-string.spec.ts
+++ b/libs/common/utils/string/src/lib/common-utils-string.spec.ts
@@ -71,4 +71,38 @@ describe('TemplateRenderer', () => {
 
     expect(value).toBe('Mary had one white lamb and one green lamb.');
   });
+
+  it('should preserve unresolved template placeholders by default', () => {
+    options = {
+      lookup: {
+        value: 'lamb'
+      },
+      template: 'Mary had a little {value} named {name}.'
+    };
+
+    renderer = new TemplateRenderer(options);
+
+    const value = renderer.render();
+
+    expect(value).toBe('Mary had a little lamb named {name}.');
+  });
+
+  it('should apply nullishReplacement for unresolved placeholders', () => {
+    options = {
+      lookup: {
+        value: 'lamb'
+      },
+      template: 'Mary had a little {value} named {name}.',
+      options: {
+        nullishReplacement: '',
+        trim: true
+      }
+    };
+
+    renderer = new TemplateRenderer(options);
+
+    const value = renderer.render();
+
+    expect(value).toBe('Mary had a little lamb named .');
+  });
 });

--- a/libs/common/utils/string/src/lib/common-utils-string.spec.ts
+++ b/libs/common/utils/string/src/lib/common-utils-string.spec.ts
@@ -1,4 +1,4 @@
-import { TemplateRenderer, TemplateRendererOptions } from './common-utils-string';
+import { hasTemplateExpression, TemplateRenderer, TemplateRendererOptions } from './common-utils-string';
 
 describe('TemplateRenderer', () => {
   let options: TemplateRendererOptions;
@@ -104,5 +104,11 @@ describe('TemplateRenderer', () => {
     const value = renderer.render();
 
     expect(value).toBe('Mary had a little lamb named .');
+  });
+
+  it('should identify template expressions', () => {
+    expect(hasTemplateExpression('Mary had a little {value}.')).toBe(true);
+    expect(hasTemplateExpression('Mary had a little lamb.')).toBe(false);
+    expect(hasTemplateExpression(undefined)).toBe(false);
   });
 });

--- a/libs/common/utils/string/src/lib/common-utils-string.ts
+++ b/libs/common/utils/string/src/lib/common-utils-string.ts
@@ -38,18 +38,25 @@ export class TemplateRenderer {
       });
     } else if (this.template && this.lookup) {
       return this.template.replace(/\{.*?\}/g, (match: string) => {
-        const resolved = getPropertyValue<string>(this.lookup, match.replace('{', '').replace('}', '')).toString();
         // Remove template braces before setting value from lookup object.
+        const resolved = getPropertyValue<unknown>(this.lookup, match.replace('{', '').replace('}', ''));
 
-        if (this.options?.nullishReplacement !== undefined && (resolved === undefined || resolved === null)) {
+        if (resolved === undefined || resolved === null) {
+          // Keep placeholder when no nullish replacement is provided.
+          if (this.options?.nullishReplacement === undefined) {
+            return match;
+          }
+
           return this.options.nullishReplacement;
         }
 
+        const resolvedString = `${resolved}`;
+
         if (this.options?.trim) {
-          return resolved.trim();
+          return resolvedString.trim();
         }
 
-        return resolved;
+        return resolvedString;
       });
     }
   }

--- a/libs/common/utils/string/src/lib/common-utils-string.ts
+++ b/libs/common/utils/string/src/lib/common-utils-string.ts
@@ -1,5 +1,8 @@
 import { getPropertyValue } from '@tamu-gisc/common/utils/object';
 
+const TEMPLATE_EXPRESSION_PATTERN = /\{.*?\}/;
+const TEMPLATE_EXPRESSION_GLOBAL_PATTERN = /\{.*?\}/g;
+
 /**
  * Rendering class able to accept a single string and replace values between and including double curly
  * braces {{ }} with provided value.
@@ -32,12 +35,12 @@ export class TemplateRenderer {
    */
   public render(): string {
     if (this.template && this.replacement) {
-      return this.template.replace(/\{.*?\}/g, () => {
+      return this.template.replace(TEMPLATE_EXPRESSION_GLOBAL_PATTERN, () => {
         // Replace captured block with the provided replacement string.
         return this.replacement;
       });
     } else if (this.template && this.lookup) {
-      return this.template.replace(/\{.*?\}/g, (match: string) => {
+      return this.template.replace(TEMPLATE_EXPRESSION_GLOBAL_PATTERN, (match: string) => {
         // Remove template braces before setting value from lookup object.
         const resolved = getPropertyValue<unknown>(this.lookup, match.replace('{', '').replace('}', ''));
 
@@ -60,6 +63,14 @@ export class TemplateRenderer {
       });
     }
   }
+}
+
+export function hasTemplateExpression(template?: string): boolean {
+  if (!template) {
+    return false;
+  }
+
+  return TEMPLATE_EXPRESSION_PATTERN.test(template);
 }
 
 /**

--- a/libs/maps/feature/popup/src/lib/services/popup.service.spec.ts
+++ b/libs/maps/feature/popup/src/lib/services/popup.service.spec.ts
@@ -1,0 +1,103 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
+import { HitTestSnapshot } from '@tamu-gisc/maps/esri';
+
+import { PopupService } from './popup.service';
+
+describe('PopupService', () => {
+  let service: PopupService;
+
+  class TestPopupComponent {}
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PopupService,
+        {
+          provide: EnvironmentService,
+          useValue: {}
+        }
+      ]
+    });
+
+    service = TestBed.inject(PopupService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should resolve popup data independently by default', () => {
+    const snapshot = {
+      graphics: [
+        {
+          attributes: {
+            'GIS.TS.ParkingLots.Name': 'Lot 100',
+            'GIS.TS.SpacePnt_Count.Total': 200
+          },
+          layer: {
+            id: 'parking-lots',
+            title: 'Parking Lots',
+            popupComponent: TestPopupComponent,
+            popupData: {
+              name: {
+                field: 'GIS.TS.ParkingLots.Name',
+                collapsed: true
+              },
+              total: {
+                field: 'GIS.TS.SpacePnt_Count.Total',
+                collapsed: true
+              },
+              description: '{attributes.name}: {attributes.total}'
+            }
+          }
+        }
+      ]
+    } as unknown as HitTestSnapshot;
+
+    const result = service.getComponent(snapshot);
+
+    expect(result?.component).toBe(TestPopupComponent);
+    expect(result?.data.attributes.name).toBe('Lot 100');
+    expect(result?.data.attributes.total).toBe(200);
+    expect(result?.data.attributes.description).toBe('{attributes.name}: {attributes.total}');
+  });
+
+  it('should resolve popup data cumulatively when configured', () => {
+    const snapshot = {
+      graphics: [
+        {
+          attributes: {
+            'GIS.TS.ParkingLots.Name': 'Lot 100',
+            'GIS.TS.SpacePnt_Count.Total': 200
+          },
+          layer: {
+            id: 'parking-lots',
+            title: 'Parking Lots',
+            popupComponent: TestPopupComponent,
+            popupDataResolutionStrategy: 'cumulative',
+            popupData: {
+              name: {
+                field: 'GIS.TS.ParkingLots.Name',
+                collapsed: true
+              },
+              total: {
+                field: 'GIS.TS.SpacePnt_Count.Total',
+                collapsed: true
+              },
+              description: '{attributes.name}: {attributes.total}'
+            }
+          }
+        }
+      ]
+    } as unknown as HitTestSnapshot;
+
+    const result = service.getComponent(snapshot);
+
+    expect(result?.component).toBe(TestPopupComponent);
+    expect(result?.data.attributes.name).toBe('Lot 100');
+    expect(result?.data.attributes.total).toBe(200);
+    expect(result?.data.attributes.description).toBe('Lot 100: 200');
+  });
+});

--- a/libs/maps/feature/popup/src/lib/services/popup.service.ts
+++ b/libs/maps/feature/popup/src/lib/services/popup.service.ts
@@ -61,6 +61,14 @@ export class PopupService {
       if (graphicLayer.popupData) {
         resolved = Object.entries(graphicLayer.popupData).reduce((acc, [key, dotNotationPathOrDefinition]) => {
           if (acc[key] === undefined) {
+            const lookup = {
+              ...topGraphic,
+              attributes: {
+                ...topGraphic.attributes,
+                ...acc
+              }
+            };
+
             // If dotNotationPathOrDefinition is a string, resolve the value
             // If it is an object, assume it is a definition object, and the path to resolve is the `key` sub-path.
 
@@ -69,14 +77,14 @@ export class PopupService {
               if (dotNotationPathOrDefinition.includes('{') && dotNotationPathOrDefinition.includes('}')) {
                 acc[key] = new TemplateRenderer({
                   template: dotNotationPathOrDefinition,
-                  lookup: topGraphic,
+                  lookup,
                   options: {
                     nullishReplacement: '',
                     trim: true
                   }
                 }).render();
               } else {
-                acc[key] = getPropertyValue(topGraphic, dotNotationPathOrDefinition);
+                acc[key] = getPropertyValue(lookup, dotNotationPathOrDefinition);
               }
             } else {
               acc[key] = getPropertyValue(

--- a/libs/maps/feature/popup/src/lib/services/popup.service.ts
+++ b/libs/maps/feature/popup/src/lib/services/popup.service.ts
@@ -2,11 +2,16 @@ import { Component, Injectable, Type } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 import { HitTestSnapshot } from '@tamu-gisc/maps/esri';
+import { LayerSource } from '@tamu-gisc/common/types';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { getPropertyValue } from '@tamu-gisc/common/utils/object';
-import { TemplateRenderer } from '@tamu-gisc/common/utils/string';
+import { hasTemplateExpression, TemplateRenderer } from '@tamu-gisc/common/utils/string';
 
 import esri = __esri;
+
+type PopupDataDefinition = NonNullable<LayerSource['popupData']>;
+type PopupDataResolutionStrategy = NonNullable<LayerSource['popupDataResolutionStrategy']>;
+type PopupDataEntry = PopupDataDefinition[string];
 
 @Injectable({ providedIn: 'root' })
 export class PopupService {
@@ -59,44 +64,11 @@ export class PopupService {
       let resolved;
 
       if (graphicLayer.popupData) {
-        resolved = Object.entries(graphicLayer.popupData).reduce((acc, [key, dotNotationPathOrDefinition]) => {
-          if (acc[key] === undefined) {
-            const lookup = {
-              ...topGraphic,
-              attributes: {
-                ...topGraphic.attributes,
-                ...acc
-              }
-            };
-
-            // If dotNotationPathOrDefinition is a string, resolve the value
-            // If it is an object, assume it is a definition object, and the path to resolve is the `key` sub-path.
-
-            if (typeof dotNotationPathOrDefinition === 'string') {
-              // Handle the case where the content is a template vs just a notation path. Templates contain at least a single bracket pair.
-              if (dotNotationPathOrDefinition.includes('{') && dotNotationPathOrDefinition.includes('}')) {
-                acc[key] = new TemplateRenderer({
-                  template: dotNotationPathOrDefinition,
-                  lookup,
-                  options: {
-                    nullishReplacement: '',
-                    trim: true
-                  }
-                }).render();
-              } else {
-                acc[key] = getPropertyValue(lookup, dotNotationPathOrDefinition);
-              }
-            } else {
-              acc[key] = getPropertyValue(
-                topGraphic.attributes,
-                dotNotationPathOrDefinition['field'],
-                dotNotationPathOrDefinition['collapsed']
-              );
-            }
-          }
-
-          return acc;
-        }, {});
+        resolved = this.resolvePopupData(
+          topGraphic,
+          graphicLayer.popupData,
+          graphicLayer.popupDataResolutionStrategy ?? 'independent'
+        );
       }
 
       if (resolved) {
@@ -125,9 +97,73 @@ export class PopupService {
   public enablePopups() {
     this._suppressed.next(false);
   }
+
+  private resolvePopupData(
+    graphic: esri.Graphic,
+    popupData: PopupDataDefinition,
+    strategy: PopupDataResolutionStrategy
+  ): Record<string, unknown> {
+    return Object.entries(popupData).reduce<Record<string, unknown>>((acc, [key, definition]) => {
+      if (acc[key] !== undefined) {
+        return acc;
+      }
+
+      acc[key] = this.resolvePopupDataEntry(graphic, definition, acc, strategy);
+
+      return acc;
+    }, {});
+  }
+
+  private resolvePopupDataEntry(
+    graphic: esri.Graphic,
+    definition: PopupDataEntry,
+    resolvedEntries: Record<string, unknown>,
+    strategy: PopupDataResolutionStrategy
+  ): unknown {
+    if (typeof definition !== 'string') {
+      return getPropertyValue(graphic.attributes, definition.field, definition.collapsed);
+    }
+
+    const lookup = this.getPopupDataLookup(graphic, resolvedEntries, strategy);
+
+    if (hasTemplateExpression(definition)) {
+      return new TemplateRenderer({
+        template: definition,
+        lookup,
+        options:
+          strategy === 'cumulative'
+            ? {
+                nullishReplacement: '',
+                trim: true
+              }
+            : undefined
+      }).render();
+    }
+
+    return getPropertyValue(lookup, definition);
+  }
+
+  private getPopupDataLookup(
+    graphic: esri.Graphic,
+    resolvedEntries: Record<string, unknown>,
+    strategy: PopupDataResolutionStrategy
+  ) {
+    if (strategy === 'cumulative') {
+      return {
+        ...graphic,
+        attributes: {
+          ...(graphic.attributes || {}),
+          ...resolvedEntries
+        }
+      };
+    }
+
+    return graphic;
+  }
 }
 
 interface ILayerWithPopupComponent extends esri.Layer {
   popupComponent: Type<Component>;
-  popupData?: Record<string, unknown>;
+  popupData?: PopupDataDefinition;
+  popupDataResolutionStrategy?: PopupDataResolutionStrategy;
 }

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -36,6 +36,7 @@ import { RetireeParkingTs } from './retiree-parking.definitions';
 import { MaintenanceParkingTs } from './maintenance-parking.definitions';
 import { BaseballParkingTs } from './baseball-parking.definitions';
 import { SavannahBananasParkingTs } from './savannah-bananas.definitions';
+import { TsMainParkingTs } from './main-parking.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -74,5 +75,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   RetireeParkingTs,
   MaintenanceParkingTs,
   BaseballParkingTs,
-  SavannahBananasParkingTs
+  SavannahBananasParkingTs,
+  TsMainParkingTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -10,7 +10,6 @@ export enum TS_MAIN_PARKING_LAYERS {
   CAMPUS_STOPS = 'Campus Stops',
   CONSTRUCTION = 'Construction',
   VISITOR_KIOSKS = 'Visitor Kiosks',
-  LINE_PAINT = 'Line Paint',
   PARKING_LOTS = 'Parking Lots'
 }
 
@@ -40,12 +39,6 @@ export const TsMainParkingDefinitions = {
     layerId: TS_MAIN_PARKING_LAYERS.VISITOR_KIOSKS,
     name: 'Visitor Kiosks',
     url: `${eventUrl}/4`
-  },
-  LINE_PAINT: {
-    id: TS_MAIN_PARKING_LAYERS.LINE_PAINT,
-    layerId: TS_MAIN_PARKING_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/5`
   },
   PARKING_LOTS: {
     id: TS_MAIN_PARKING_LAYERS.PARKING_LOTS,
@@ -142,18 +135,6 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
 
   {
     type: 'feature',
-    id: TsMainParkingDefinitions.LINE_PAINT.id,
-    title: TsMainParkingDefinitions.LINE_PAINT.name,
-    url: TsMainParkingDefinitions.LINE_PAINT.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    } as unknown as FeatureNative
-  },
-
-  {
-    type: 'feature',
     id: TsMainParkingDefinitions.PARKING_LOTS.id,
     title: TsMainParkingDefinitions.PARKING_LOTS.name,
     url: TsMainParkingDefinitions.PARKING_LOTS.url,
@@ -161,6 +142,7 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
     listMode: 'show',
 
     popupComponent: MarkdownPopupComponent,
+    popupDataResolutionStrategy: 'cumulative',
     popupData: {
       lotName: { field: 'GIS.TS.ParkingLots.Name', collapsed: true },
 

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -182,22 +182,22 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
 
       name: '{attributes.lotName}',
       description:
-        `**Lot Name:** {attributes.lotName}\n` +
-        `**Total Number of Parking:** {attributes.total}\n\n` +
-        `**Number of Loading:** {attributes.loading}\n` +
-        `**Number of Regular:** {attributes.regular}\n` +
-        `**Number of Reserved:** {attributes.reserved}\n` +
-        `**Number of Others:** {attributes.other}\n` +
-        `**Number of Disabled:** {attributes.accessible}\n` +
-        `**Number of Motorcycle:** {attributes.motorcycle}\n` +
-        `**Number of Timed:** {attributes.timed}\n` +
-        `**Number of Service:** {attributes.service}\n` +
-        `**Number of U.B.:** {attributes.ub}\n` +
-        `**Number of Visitor:** {attributes.visitor}\n` +
-        `**Number of Visitor(H/C):** {attributes.visitorHc}\n` +
-        `**Number of RV:** {attributes.rv}\n\n` +
+        `Lot Name: {attributes.lotName}\n` +
+        `Total Number of Parking: {attributes.total}\n\n` +
+        `Number of Loading: {attributes.loading}\n` +
+        `Number of Reg (Regular): {attributes.regular}\n` +
+        `Number of RNS (Reserved): {attributes.reserved}\n` +
+        `Number of Other: {attributes.other}\n` +
+        `Number of H/C (Accessible): {attributes.accessible}\n` +
+        `Number of M/C (Motorcycle): {attributes.motorcycle}\n` +
+        `Number of Timed: {attributes.timed}\n` +
+        `Number of Serv (Service): {attributes.service}\n` +
+        `Number of UB: {attributes.ub}\n` +
+        `Number of Visitor: {attributes.visitor}\n` +
+        `Number of Visitor H/C: {attributes.visitorHc}\n` +
+        `Number of RV: {attributes.rv}\n\n` +
         `---\n\n` +
-        `**Notes:** {attributes.notes}`
+        `Lot Notes: {attributes.notes}`
     },
 
     native: {

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -1,0 +1,237 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+import { AggiemapCustomMapConfiguration, EventConfiguration, SpecialEventOptions } from '../interfaces/special-event.interface';
+
+import esri = __esri;
+
+export enum TS_MAIN_PARKING_LAYERS {
+  ROUTE_STOP_START_POINTS = 'Route Stop/Start Points',
+  CAMPUS_STOPS = 'Campus Stops',
+  CONSTRUCTION = 'Construction',
+  VISITOR_KIOSKS = 'Visitor Kiosks',
+  LINE_PAINT = 'Line Paint',
+  PARKING_LOTS = 'Parking Lots'
+}
+
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TS_Main/MapServer';
+
+export const TsMainParkingDefinitions = {
+  ROUTE_STOP_START_POINTS: {
+    id: TS_MAIN_PARKING_LAYERS.ROUTE_STOP_START_POINTS,
+    layerId: TS_MAIN_PARKING_LAYERS.ROUTE_STOP_START_POINTS,
+    name: 'Route Stop/Start Points',
+    url: `${eventUrl}/1`
+  },
+  CAMPUS_STOPS: {
+    id: TS_MAIN_PARKING_LAYERS.CAMPUS_STOPS,
+    layerId: TS_MAIN_PARKING_LAYERS.CAMPUS_STOPS,
+    name: 'Campus Stops',
+    url: `${eventUrl}/2`
+  },
+  CONSTRUCTION: {
+    id: TS_MAIN_PARKING_LAYERS.CONSTRUCTION,
+    layerId: TS_MAIN_PARKING_LAYERS.CONSTRUCTION,
+    name: 'Construction',
+    url: `${eventUrl}/3`
+  },
+  VISITOR_KIOSKS: {
+    id: TS_MAIN_PARKING_LAYERS.VISITOR_KIOSKS,
+    layerId: TS_MAIN_PARKING_LAYERS.VISITOR_KIOSKS,
+    name: 'Visitor Kiosks',
+    url: `${eventUrl}/4`
+  },
+  LINE_PAINT: {
+    id: TS_MAIN_PARKING_LAYERS.LINE_PAINT,
+    layerId: TS_MAIN_PARKING_LAYERS.LINE_PAINT,
+    name: 'Line Paint',
+    url: `${eventUrl}/5`
+  },
+  PARKING_LOTS: {
+    id: TS_MAIN_PARKING_LAYERS.PARKING_LOTS,
+    layerId: TS_MAIN_PARKING_LAYERS.PARKING_LOTS,
+    name: 'Parking Lots',
+    url: `${eventUrl}/6`
+  }
+};
+
+type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
+type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;
+const tsMainParkingLotsRenderer: FeatureRenderer = {
+  type: 'unique-value',
+  field: 'GIS.TS.ParkingLots.LotType',
+  defaultLabel: 'Valid Texas A&M Permit Required',
+  defaultSymbol: {
+    type: 'simple-fill',
+    color: [204, 204, 204, 255],
+    outline: {
+      type: 'simple-line',
+      color: [110, 110, 110, 255],
+      width: 1
+    }
+  } as unknown as esri.SymbolProperties,
+  uniqueValueInfos: [
+    {
+      value: 'Garage Visitor',
+      label: 'Visitor Parking',
+      symbol: {
+        type: 'simple-fill',
+        color: [0, 92, 230, 255],
+        outline: null
+      } as unknown as esri.SymbolProperties
+    },
+    {
+      value: 'Surface Visitor',
+      label: 'Visitor Parking',
+      symbol: {
+        type: 'simple-fill',
+        color: [0, 92, 230, 255],
+        outline: null
+      } as unknown as esri.SymbolProperties
+    }
+  ]
+};
+
+export const TsMainParkingColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.ROUTE_STOP_START_POINTS.id,
+    title: TsMainParkingDefinitions.ROUTE_STOP_START_POINTS.name,
+    url: TsMainParkingDefinitions.ROUTE_STOP_START_POINTS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    } as unknown as FeatureNative
+  },
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.CAMPUS_STOPS.id,
+    title: TsMainParkingDefinitions.CAMPUS_STOPS.name,
+    url: TsMainParkingDefinitions.CAMPUS_STOPS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    } as unknown as FeatureNative
+  },
+
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.CONSTRUCTION.id,
+    title: TsMainParkingDefinitions.CONSTRUCTION.name,
+    url: TsMainParkingDefinitions.CONSTRUCTION.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    } as unknown as FeatureNative
+  },
+
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.VISITOR_KIOSKS.id,
+    title: TsMainParkingDefinitions.VISITOR_KIOSKS.name,
+    url: TsMainParkingDefinitions.VISITOR_KIOSKS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    } as unknown as FeatureNative
+  },
+
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.LINE_PAINT.id,
+    title: TsMainParkingDefinitions.LINE_PAINT.name,
+    url: TsMainParkingDefinitions.LINE_PAINT.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    } as unknown as FeatureNative
+  },
+
+  {
+    type: 'feature',
+    id: TsMainParkingDefinitions.PARKING_LOTS.id,
+    title: TsMainParkingDefinitions.PARKING_LOTS.name,
+    url: TsMainParkingDefinitions.PARKING_LOTS.url,
+    visible: true,
+    listMode: 'show',
+
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      lotName: { field: 'GIS.TS.ParkingLots.Name', collapsed: true },
+
+      total: { field: 'GIS.TS.SpacePnt_Count.Total', collapsed: true },
+      loading: { field: 'GIS.TS.SpacePnt_Count.Loading', collapsed: true },
+      regular: { field: 'GIS.TS.SpacePnt_Count.Reg', collapsed: true },
+      reserved: { field: 'GIS.TS.SpacePnt_Count.RNS', collapsed: true },
+      other: { field: 'GIS.TS.SpacePnt_Count.Other', collapsed: true },
+      accessible: { field: 'GIS.TS.SpacePnt_Count.DVS', collapsed: true },
+      motorcycle: { field: 'GIS.TS.SpacePnt_Count.M_C', collapsed: true },
+      timed: { field: 'GIS.TS.SpacePnt_Count.Timed', collapsed: true },
+      service: { field: 'GIS.TS.SpacePnt_Count.Serv', collapsed: true },
+      ub: { field: 'GIS.TS.SpacePnt_Count.UB', collapsed: true },
+      visitor: { field: 'GIS.TS.SpacePnt_Count.Visitor', collapsed: true },
+      visitorHc: { field: 'GIS.TS.SpacePnt_Count.Visitor_H_C', collapsed: true },
+      rv: { field: 'GIS.TS.SpacePnt_Count.RV', collapsed: true },
+
+      notes: { field: 'GIS.TS.Lot_Data.Lot_Notes', collapsed: true },
+
+      name: '{attributes.lotName}',
+      description:
+        `**Lot Name:** {attributes.lotName}\n` +
+        `**Total Number of Parking:** {attributes.total}\n\n` +
+        `**Number of Loading:** {attributes.loading}\n` +
+        `**Number of Regular:** {attributes.regular}\n` +
+        `**Number of Reserved:** {attributes.reserved}\n` +
+        `**Number of Others:** {attributes.other}\n` +
+        `**Number of Disabled:** {attributes.accessible}\n` +
+        `**Number of Motorcycle:** {attributes.motorcycle}\n` +
+        `**Number of Timed:** {attributes.timed}\n` +
+        `**Number of Service:** {attributes.service}\n` +
+        `**Number of U.B.:** {attributes.ub}\n` +
+        `**Number of Visitor:** {attributes.visitor}\n` +
+        `**Number of Visitor(H/C):** {attributes.visitorHc}\n` +
+        `**Number of RV:** {attributes.rv}\n\n` +
+        `---\n\n` +
+        `**Notes:** {attributes.notes}`
+    },
+
+    native: {
+      outFields: ['*'],
+      renderer: tsMainParkingLotsRenderer,
+      popupEnabled: true
+    } as unknown as FeatureNative
+  }
+];
+
+export const TsMainParkingConfiguration: EventConfiguration = {
+  id: 'ts-main-parking',
+  name: 'Campus Main Parking',
+  applicationName: 'Campus Main Parking',
+  shortApplicationName: 'Main Parking',
+  mapCenter: [-96.34731, 30.60543],
+  eventDates: [],
+  zoom: 16
+};
+
+export const TsMainParkingOptions: SpecialEventOptions = [];
+
+export const TsMainParkingTs: AggiemapCustomMapConfiguration = {
+  type: 'general-map',
+  configuration: TsMainParkingConfiguration,
+  options: TsMainParkingOptions,
+  sources: TsMainParkingColdLayerSources,
+  references: TS_MAIN_PARKING_LAYERS,
+  discover: {
+    id: TsMainParkingConfiguration.id,
+    name: TsMainParkingConfiguration.name,
+    description: 'Main parking map with lot information.',
+    source: 'internal',
+    type: 'parking',
+    keywords: ['main', 'parking', 'map', 'lots', 'construction', 'bus', 'kiosk']
+  }
+};


### PR DESCRIPTION
This PR adds the TS Main Parking map and fixes an issue of popups not opening when multiple attributes are used in one popup template.

Single-field popups worked, but multi-field popups failed when templates referenced derived popupData keys (for example, `lotName`, `total`) and when unresolved placeholders caused runtime errors.

- Updated popup resolution to evaluate template strings against:
  - original ArcGIS feature attributes
  - already-resolved popupData values in the same popupData object
- Hardened template rendering to safely handle missing values instead of throwing.
- Added tests for unresolved template keys and nullish replacement behavior.
- Updated TS Main Parking popup text labels to match requested terminology:
  - Reg, RNS, H/C, M/C, Serv, Visitor H/C, RV
  - Lot Notes

New changes:
- Multi-attribute popups now render correctly for TS Main Parking.
- Existing single-attribute popup behavior remains unchanged.


<img width="2229" height="1164" alt="image" src="https://github.com/user-attachments/assets/eeaef921-b161-4011-9575-1ad25cf47cdf" />
<img width="2268" height="1145" alt="image" src="https://github.com/user-attachments/assets/7493f0cc-f24f-448f-8ff2-189ccb905f67" />

