### PR TITLE
feat(aggiemap-angular): Update TS Source for Existing Config Files

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
@@ -7,71 +7,21 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum ACCESSIBLE_PARKING_LAYERS {
-  CONSTRUCTION = 'Construction',
-  ACCESSIBLE_PARKING = 'Accessible Parking',
-  ACCESSIBLE_SPACES_IN_AREA = 'Accessible Spaces in this area',
   ACCESSIBLE_PARKING_SPACE = 'Accessible Parking Space'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/DisabledTimedMotorcycle/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AccessibleParking/MapServer';
 
 export const AccessibleParkingDefinitions = {
-  CONSTRUCTION: {
-    id: ACCESSIBLE_PARKING_LAYERS.CONSTRUCTION,
-    layerId: ACCESSIBLE_PARKING_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
-  ACCESSIBLE_PARKING: {
-    id: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_PARKING,
-    layerId: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_PARKING,
-    name: 'Accessible Parking',
-    url: `${eventUrl}/7`
-  },
-  ACCESSIBLE_SPACES_IN_AREA: {
-    id: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_SPACES_IN_AREA,
-    layerId: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_SPACES_IN_AREA,
-    name: 'Accessible Spaces in this area',
-    url: `${eventUrl}/8`
-  },
   ACCESSIBLE_PARKING_SPACE: {
     id: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_PARKING_SPACE,
     layerId: ACCESSIBLE_PARKING_LAYERS.ACCESSIBLE_PARKING_SPACE,
     name: 'Accessible Parking Space',
-    url: `${eventUrl}/9`
+    url: `${eventUrl}/0`
   }
 };
 
 export const AccessibleParkingColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: AccessibleParkingDefinitions.CONSTRUCTION.id,
-    title: AccessibleParkingDefinitions.CONSTRUCTION.name,
-    url: AccessibleParkingDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'group',
-    id: AccessibleParkingDefinitions.ACCESSIBLE_PARKING.id,
-    title: AccessibleParkingDefinitions.ACCESSIBLE_PARKING.name,
-    visible: true,
-    listMode: 'show'
-  },
-  {
-    type: 'feature',
-    id: AccessibleParkingDefinitions.ACCESSIBLE_SPACES_IN_AREA.id,
-    title: AccessibleParkingDefinitions.ACCESSIBLE_SPACES_IN_AREA.name,
-    url: AccessibleParkingDefinitions.ACCESSIBLE_SPACES_IN_AREA.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: AccessibleParkingDefinitions.ACCESSIBLE_PARKING_SPACE.id,
@@ -106,9 +56,9 @@ export const AccessibleParkingTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: AccessibleParkingConfiguration.id,
     name: AccessibleParkingConfiguration.name,
-    description: 'Accessible parking areas and spaces (including construction overlays).',
+    description: 'Accessible parking spaces.',
     source: 'internal',
     type: 'parking',
-    keywords: ['accessible', 'disability', 'parking', 'handicap']
+    keywords: ['accessible', 'parking', 'handicap', 'ada']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -2,6 +2,7 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -9,47 +10,71 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum BASEBALL_PARKING_LAYERS {
-  BASEBALL_SYMBOLS = 'baseball-symbols',
-  SHUTTLE_ROUTE = 'baseball-shuttle-route',
-  BASEBALL_GATES = 'baseball-gates',
-  BASEBALL_EVENT_PARKING_LOTS = 'baseball-event-parking-lots'
+  EVENT_SYMBOLS = 'baseball-event-symbols',
+  ACCESSIBLE_SYMBOLS = 'baseball-accessible-symbols',
+
+  ACCESSIBLE_LOTS = 'baseball-accessible-lots',
+  ACCESSIBLE_SHUTTLES = 'baseball-accessible-shuttles',
+
+  EVENT_LOTS = 'baseball-event-lots',
+  GATE_ROAD_CLOSURE = 'baseball-gate-road-closure'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BaseballParking/MapServer';
+enum BaseballMapMode {
+  EVENT = 'event',
+  ACCESSIBLE = 'accessible'
+}
 
-const BaseballParkingEventDefinitions = {
-  BASEBALL_SYMBOLS: {
-    id: BASEBALL_PARKING_LAYERS.BASEBALL_SYMBOLS,
-    layerId: BASEBALL_PARKING_LAYERS.BASEBALL_SYMBOLS,
-    name: 'Baseball Symbols',
-    url: `${eventUrl}/0`
-  },
-  SHUTTLE_ROUTE: {
-    id: BASEBALL_PARKING_LAYERS.SHUTTLE_ROUTE,
-    layerId: BASEBALL_PARKING_LAYERS.SHUTTLE_ROUTE,
-    name: 'Shuttle Route',
-    url: `${eventUrl}/1`
-  },
-  BASEBALL_GATES: {
-    id: BASEBALL_PARKING_LAYERS.BASEBALL_GATES,
-    layerId: BASEBALL_PARKING_LAYERS.BASEBALL_GATES,
-    name: 'Baseball Gates',
-    url: `${eventUrl}/2`
-  },
-  BASEBALL_EVENT_PARKING_LOTS: {
-    id: BASEBALL_PARKING_LAYERS.BASEBALL_EVENT_PARKING_LOTS,
-    layerId: BASEBALL_PARKING_LAYERS.BASEBALL_EVENT_PARKING_LOTS,
-    name: 'Baseball Event Parking Lots',
-    url: `${eventUrl}/3`
-  }
-};
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/BaseballParking/MapServer';
 
 export const BaseballParkingColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: BaseballParkingEventDefinitions.BASEBALL_EVENT_PARKING_LOTS.id,
-    title: BaseballParkingEventDefinitions.BASEBALL_EVENT_PARKING_LOTS.name,
-    url: BaseballParkingEventDefinitions.BASEBALL_EVENT_PARKING_LOTS.url,
+    id: BASEBALL_PARKING_LAYERS.EVENT_SYMBOLS,
+    title: 'Baseball Symbols',
+    url: `${eventUrl}/0`,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: '{attributes.Type}'
+    },
+    native: {
+      outFields: ['*'],
+      definitionExpression: `Event = 'Baseball' AND Type <> 'Accessible Shuttle Stop'`
+    }
+  },
+
+  {
+    type: 'feature',
+    id: BASEBALL_PARKING_LAYERS.ACCESSIBLE_SYMBOLS,
+    title: 'Baseball Symbols',
+    url: `${eventUrl}/0`,
+    visible: false,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: '{attributes.Type}'
+    },
+    native: {
+      outFields: ['*'],
+      definitionExpression: `Event = 'Baseball'`
+    }
+  },
+
+  {
+    type: 'feature',
+    id: BASEBALL_PARKING_LAYERS.GATE_ROAD_CLOSURE,
+    title: 'Gate/Road Closure',
+    url: `${eventUrl}/2`,
+    popupComponent: MarkdownPopupComponent,
+    native: {
+      outFields: ['*'],
+      definitionExpression: `Baseball = 1`
+    }
+  },
+  {
+    type: 'feature',
+    id: BASEBALL_PARKING_LAYERS.EVENT_LOTS,
+    title: 'Event Parking Lots',
+    url: `${eventUrl}/3`,
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
       name: {
@@ -62,39 +87,40 @@ export const BaseballParkingColdLayerSources: LayerSource[] = [
       }
     },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: `GIS.TS.SPEV_Lot_Use.Baseball IN ('AnyValid','SeasonPass')`
     }
   },
-  {
-    type: 'feature',
-    id: BaseballParkingEventDefinitions.BASEBALL_GATES.id,
-    title: BaseballParkingEventDefinitions.BASEBALL_GATES.name,
-    url: BaseballParkingEventDefinitions.BASEBALL_GATES.url,
-    popupComponent: MarkdownPopupComponent,
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: BaseballParkingEventDefinitions.SHUTTLE_ROUTE.id,
-    title: BaseballParkingEventDefinitions.SHUTTLE_ROUTE.name,
-    url: BaseballParkingEventDefinitions.SHUTTLE_ROUTE.url,
-    popupComponent: MarkdownPopupComponent,
 
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
-    id: BaseballParkingEventDefinitions.BASEBALL_SYMBOLS.id,
-    title: BaseballParkingEventDefinitions.BASEBALL_SYMBOLS.name,
-    url: BaseballParkingEventDefinitions.BASEBALL_SYMBOLS.url,
+    id: BASEBALL_PARKING_LAYERS.ACCESSIBLE_LOTS,
+    title: 'Accessible Parking Lots',
+    url: `${eventUrl}/3`,
+    visible: false,
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
-      name: '{attributes.Type}'
+      name: {
+        field: 'GIS.TS.ParkingLots.LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.SpEv_Lot_Notes.BaseballN',
+        collapsed: true
+      }
     },
+    native: {
+      outFields: ['*'],
+      definitionExpression: `GIS.TS.SPEV_Lot_Use.Baseball = 'Permit'`
+    }
+  },
+  {
+    type: 'feature',
+    id: BASEBALL_PARKING_LAYERS.ACCESSIBLE_SHUTTLES,
+    title: 'Accessible Shuttle',
+    url: `${eventUrl}/1`,
+    visible: false,
+    popupComponent: MarkdownPopupComponent,
     native: {
       outFields: ['*']
     }
@@ -145,35 +171,82 @@ export const BaseballParkingConfiguration: EventConfiguration = {
     '2026-05-16'
   ],
   mapCenter: [-96.34509, 30.60416],
-  zoom: 17,
-  toast: {
-    id: 'baseball-parking-notification',
-    title: 'Baseball Parking Map Available',
-    message: 'Headed to the game? Click to open the Baseball Parking Map for parking, gates, and shuttle information.',
-    imgUrl: './assets/images/icons/sports/Baseball.png',
-    imgAltText: 'Baseball Icon',
-    acknowledge: true,
-    action: {
-      type: 'internal',
-      value: '/events/baseball-parking'
-    }
-  }
+  zoom: 17
 };
 
-export const BaseballParkingOptions: SpecialEventOptions = [];
+export const BaseballParkingOptions: SpecialEventOptions = [
+  {
+    value: 'map-mode',
+    label: 'Choose Your Map',
+    shortDescription: 'Map Type',
+    description:
+      'The Event Map shows event parking lots, symbols, and road closures (no accessibility layers). The Accessibility Map shows accessible parking lots, the accessible shuttle route, and all symbols.',
+    choices: [
+      { value: BaseballMapMode.EVENT, label: 'Baseball Event Map' },
+      { value: BaseballMapMode.ACCESSIBLE, label: 'Accessible Baseball Map' }
+    ],
+    effects: {
+      layers: [
+        {
+          layerId: BASEBALL_PARKING_LAYERS.EVENT_SYMBOLS,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: true } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: false } }
+          ]
+        },
+        {
+          layerId: BASEBALL_PARKING_LAYERS.ACCESSIBLE_SYMBOLS,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: false } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: true } }
+          ]
+        },
+
+        {
+          layerId: BASEBALL_PARKING_LAYERS.GATE_ROAD_CLOSURE,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: true } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: true } }
+          ]
+        },
+        {
+          layerId: BASEBALL_PARKING_LAYERS.EVENT_LOTS,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: true } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: true } }
+          ]
+        },
+        {
+          layerId: BASEBALL_PARKING_LAYERS.ACCESSIBLE_LOTS,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: false } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: true } }
+          ]
+        },
+        {
+          layerId: BASEBALL_PARKING_LAYERS.ACCESSIBLE_SHUTTLES,
+          conversions: [
+            { input: BaseballMapMode.EVENT, propOverrides: { visible: false } },
+            { input: BaseballMapMode.ACCESSIBLE, propOverrides: { visible: true } }
+          ]
+        }
+      ]
+    }
+  }
+];
 
 export const BaseballParkingTs: AggiemapCustomMapConfiguration = {
   configuration: BaseballParkingConfiguration,
   options: BaseballParkingOptions,
   sources: BaseballParkingColdLayerSources,
   references: BASEBALL_PARKING_LAYERS,
-  type: 'special-event',
+  type: 'general-map',
   discover: {
-    id: BaseballParkingConfiguration.id,
-    name: BaseballParkingConfiguration.name,
-    description: 'Parking and access information for Texas A&M baseball home games.',
+    id: 'baseball-parking',
+    name: 'Baseball Parking',
+    description: 'Baseball event parking with optional accessibility-focused view.',
     source: 'internal',
-    type: 'event',
-    keywords: ['baseball', 'parking', 'transportation', 'shuttle', 'gates']
+    type: 'parking',
+    keywords: ['baseball', 'parking', 'accessible', 'shuttle', 'closure']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,35 +9,83 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum BUSINESS_PARKING_LAYERS {
-  LOT_SPECIFIC = 'Lot Specific Permit Required',
+  UB_2_HOUR_SPACES = 'University Business Spaces 2 Hour Time Limit',
   UB_AND_UB_PLUS = 'UB Permit and UB+ Permit Authorized',
   UB_PLUS_ONLY = 'Only UB+ Permit Authorized'
 }
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/BusinessParking/MapServer';
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
+type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
+type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;
+
+const ubAndUbPlusRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [90, 0, 0, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
+
+const ubPlusOnlyRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [232, 190, 255, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
 
 export const BusinessParkingDefinitions = {
-  LOT_SPECIFIC: {
-    id: BUSINESS_PARKING_LAYERS.LOT_SPECIFIC,
-    layerId: BUSINESS_PARKING_LAYERS.LOT_SPECIFIC,
-    name: 'Lot Specific Permit Required',
-    url: `${eventUrl}/8`
+  UB_2_HOUR_SPACES: {
+    id: BUSINESS_PARKING_LAYERS.UB_2_HOUR_SPACES,
+    layerId: BUSINESS_PARKING_LAYERS.UB_2_HOUR_SPACES,
+    name: 'University Business Spaces 2 Hour Time Limit',
+    url: `${eventUrl}/0`
   },
   UB_AND_UB_PLUS: {
     id: BUSINESS_PARKING_LAYERS.UB_AND_UB_PLUS,
     layerId: BUSINESS_PARKING_LAYERS.UB_AND_UB_PLUS,
     name: 'UB Permit and UB+ Permit Authorized',
-    url: `${eventUrl}/8`
+    url: `${eventUrl}/1`
   },
   UB_PLUS_ONLY: {
     id: BUSINESS_PARKING_LAYERS.UB_PLUS_ONLY,
     layerId: BUSINESS_PARKING_LAYERS.UB_PLUS_ONLY,
     name: 'Only UB+ Permit Authorized',
-    url: `${eventUrl}/8`
+    url: `${eventUrl}/1`
   }
 };
 
 export const BusinessParkingColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: BusinessParkingDefinitions.UB_2_HOUR_SPACES.id,
+    title: BusinessParkingDefinitions.UB_2_HOUR_SPACES.name,
+    url: BusinessParkingDefinitions.UB_2_HOUR_SPACES.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: '{attributes.LotName}',
+      description: {
+        field: 'Spc_ID_Num',
+        collapsed: true
+      }
+    },
+    native: {
+      outFields: ['*'],
+      definitionExpression: `Spc_Type = 'UB'`
+    }
+  },
   {
     type: 'feature',
     id: BusinessParkingDefinitions.UB_AND_UB_PLUS.id,
@@ -43,18 +93,22 @@ export const BusinessParkingColdLayerSources: LayerSource[] = [
     url: BusinessParkingDefinitions.UB_AND_UB_PLUS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: '*',
-      definitionExpression: `"GIS.TS.Lot_Use.UB_Lot" = 1 AND "GIS.TS.ParkingLots.LotType" IN ('Street', 'Surface', 'Surface Visitor')`,
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-fill',
-          color: [90, 0, 0, 255],
-          outline: null
-        }
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.UBN',
+        collapsed: true
       }
-    } as any
+    },
+    native: {
+      outFields: ['*'],
+      definitionExpression: `"GIS.TS.Lot_Use.UB_Lot" = 1 AND "GIS.TS.ParkingLots.LotType" IN ('Street', 'Surface', 'Surface Visitor')`,
+      renderer: ubAndUbPlusRenderer
+    }
   },
   {
     type: 'feature',
@@ -63,38 +117,22 @@ export const BusinessParkingColdLayerSources: LayerSource[] = [
     url: BusinessParkingDefinitions.UB_PLUS_ONLY.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.UBN',
+        collapsed: true
+      }
+    },
     native: {
-      outFields: '*',
+      outFields: ['*'],
       definitionExpression: `"GIS.TS.Lot_Use.UB_Lot" = 1 AND "GIS.TS.ParkingLots.LotType" IN ('Garage', 'Garage Visitor')`,
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-fill',
-          color: [232, 190, 255, 255],
-          outline: null
-        }
-      }
-    } as any
-  },
-  {
-    type: 'feature',
-    id: BusinessParkingDefinitions.LOT_SPECIFIC.id,
-    title: BusinessParkingDefinitions.LOT_SPECIFIC.name,
-    url: BusinessParkingDefinitions.LOT_SPECIFIC.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: '*',
-      definitionExpression: `"GIS.TS.Lot_Use.UB_Lot" <> 1 OR "GIS.TS.Lot_Use.UB_Lot" IS NULL OR "GIS.TS.ParkingLots.LotType" NOT IN ('Street', 'Surface', 'Surface Visitor', 'Garage', 'Garage Visitor') OR "GIS.TS.ParkingLots.LotType" IS NULL`,
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-fill',
-          color: [204, 204, 204, 255],
-          outline: null
-        }
-      }
-    } as any
+      renderer: ubPlusOnlyRenderer
+    }
   }
 ];
 
@@ -122,6 +160,6 @@ export const BusinessParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking lot information for University Business permits.',
     source: 'internal',
     type: 'parking',
-    keywords: ['business', 'university business', 'ub', 'ub+', 'parking', 'permit']
+    keywords: ['business', 'university business', 'ub', 'ub+', 'parking', 'permit', '2 hour']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
@@ -1,29 +1,57 @@
 import { LayerSource } from '@tamu-gisc/common/types';
-
+import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
-  AggiemapCustomMapConfiguration,
   EventConfiguration,
+  AggiemapCustomMapConfiguration,
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
 
 export enum CONTRACTOR_PARKING_LAYERS {
-  CONSTRUCTION = 'construction',
-  CONTRACTOR_PARKING = 'contractor-parking'
+  CONTRACTOR_AND_CONTRACTOR_PLUS = 'Contractor Permit and Contractor+ Permit Authorized',
+  CONTRACTOR_PLUS_ONLY = 'Only Contractor+ Permit Authorized'
 }
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/ContractorParking/MapServer';
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/ServiceMaintenanceContractor/MapServer';
+type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
+type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;
 
-export const ContractorParkingEventDefinitions = {
-  CONTRACTOR_PARKING: {
-    id: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_PARKING,
-    layerId: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_PARKING,
-    name: 'Contractor Parking Lots',
-    url: `${eventUrl}/7`
+const contractorAndContractorPlusRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [90, 0, 0, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
+
+const contractorPlusOnlyRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [232, 190, 255, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
+
+export const ContractorParkingDefinitions = {
+  CONTRACTOR_AND_CONTRACTOR_PLUS: {
+    id: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_AND_CONTRACTOR_PLUS,
+    layerId: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_AND_CONTRACTOR_PLUS,
+    name: 'Contractor Permit and Contractor+ Permit Authorized',
+    url: `${eventUrl}/0`
   },
-  CONSTRUCTION: {
-    id: CONTRACTOR_PARKING_LAYERS.CONSTRUCTION,
-    layerId: CONTRACTOR_PARKING_LAYERS.CONSTRUCTION,
-    name: 'Construction',
+  CONTRACTOR_PLUS_ONLY: {
+    id: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_PLUS_ONLY,
+    layerId: CONTRACTOR_PARKING_LAYERS.CONTRACTOR_PLUS_ONLY,
+    name: 'Only Contractor+ Permit Authorized',
     url: `${eventUrl}/0`
   }
 };
@@ -31,25 +59,50 @@ export const ContractorParkingEventDefinitions = {
 export const ContractorParkingColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: ContractorParkingEventDefinitions.CONTRACTOR_PARKING.id,
-    title: ContractorParkingEventDefinitions.CONTRACTOR_PARKING.name,
-    url: ContractorParkingEventDefinitions.CONTRACTOR_PARKING.url,
+    id: ContractorParkingDefinitions.CONTRACTOR_AND_CONTRACTOR_PLUS.id,
+    title: ContractorParkingDefinitions.CONTRACTOR_AND_CONTRACTOR_PLUS.name,
+    url: ContractorParkingDefinitions.CONTRACTOR_AND_CONTRACTOR_PLUS.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.ContractorN',
+        collapsed: true
+      }
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: `"GIS.TS.Lot_Use.Construct_Lot" = 1 AND "GIS.TS.ParkingLots.LotType" IN ('Street', 'Surface')`,
+      renderer: contractorAndContractorPlusRenderer
     }
   },
-
   {
     type: 'feature',
-    id: ContractorParkingEventDefinitions.CONSTRUCTION.id,
-    title: ContractorParkingEventDefinitions.CONSTRUCTION.name,
-    url: ContractorParkingEventDefinitions.CONSTRUCTION.url,
+    id: ContractorParkingDefinitions.CONTRACTOR_PLUS_ONLY.id,
+    title: ContractorParkingDefinitions.CONTRACTOR_PLUS_ONLY.name,
+    url: ContractorParkingDefinitions.CONTRACTOR_PLUS_ONLY.url,
     visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.ContractorN',
+        collapsed: true
+      }
+    },
     native: {
-      listMode: 'show',
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: `"GIS.TS.Lot_Use.Construct_Lot" = 1 AND "GIS.TS.ParkingLots.LotType" IN ('Garage Visitor')`,
+      renderer: contractorPlusOnlyRenderer
     }
   }
 ];
@@ -58,9 +111,9 @@ export const ContractorParkingConfiguration: EventConfiguration = {
   id: 'contractor-parking',
   name: 'Contractor Parking',
   applicationName: 'Contractor Parking Map',
-  shortApplicationName: 'Contractor Parking Map',
+  shortApplicationName: 'Contractor Parking',
+  mapCenter: [-96.34731, 30.60543],
   eventDates: [],
-  mapCenter: [-96.34467, 30.60585],
   zoom: 16
 };
 
@@ -75,9 +128,9 @@ export const ContractorParkingTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: ContractorParkingConfiguration.id,
     name: ContractorParkingConfiguration.name,
-    description: 'Parking areas designated for contractors.',
+    description: 'Parking lot information for Contractor and Contractor+ permits.',
     source: 'internal',
     type: 'parking',
-    keywords: ['contractor', 'parking', 'transportation']
+    keywords: ['contractor', 'contractor+', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,84 +9,102 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum FRESHMAN_SELECTABLE_LAYERS {
-  CONSTRUCTION = 'Construction',
-  LINE_PAINT = 'Line Paint',
-  FRESHMAN_SELECTABLE = 'Freshman Selectable Parking Lots',
-  RNS_SPACES = 'RNS Spaces'
+  RESIDENT_STUDENT_PRIORITY = 'Resident Student Priority',
+  FRESHMAN_STUDENT_SELECTABLE = 'Freshman Student Selectable'
 }
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/FreshmanSelectableParking/MapServer';
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/PermitSelect/MapServer';
+type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
+type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;
+
+const residentStudentPriorityRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [255, 0, 0, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
+
+const freshmanSelectableRenderer: FeatureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    color: [0, 92, 230, 255],
+    outline: {
+      type: 'simple-line',
+      color: [0, 0, 0, 0],
+      width: 0
+    }
+  }
+};
 
 export const FreshmanSelectableDefinitions = {
-  CONSTRUCTION: {
-    id: FRESHMAN_SELECTABLE_LAYERS.CONSTRUCTION,
-    layerId: FRESHMAN_SELECTABLE_LAYERS.CONSTRUCTION,
-    name: 'Construction',
+  RESIDENT_STUDENT_PRIORITY: {
+    id: FRESHMAN_SELECTABLE_LAYERS.RESIDENT_STUDENT_PRIORITY,
+    layerId: FRESHMAN_SELECTABLE_LAYERS.RESIDENT_STUDENT_PRIORITY,
+    name: 'Resident Student Priority',
     url: `${eventUrl}/0`
   },
-  LINE_PAINT: {
-    id: FRESHMAN_SELECTABLE_LAYERS.LINE_PAINT,
-    layerId: FRESHMAN_SELECTABLE_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/1`
-  },
-  FRESHMAN_SELECTABLE: {
-    id: FRESHMAN_SELECTABLE_LAYERS.FRESHMAN_SELECTABLE,
-    layerId: FRESHMAN_SELECTABLE_LAYERS.FRESHMAN_SELECTABLE,
-    name: 'Freshman Selectable Parking Lots',
-    url: `${eventUrl}/3`
-  },
-  RNS_SPACES: {
-    id: FRESHMAN_SELECTABLE_LAYERS.RNS_SPACES,
-    layerId: FRESHMAN_SELECTABLE_LAYERS.RNS_SPACES,
-    name: 'RNS Spaces',
-    url: `${eventUrl}/5`
+  FRESHMAN_STUDENT_SELECTABLE: {
+    id: FRESHMAN_SELECTABLE_LAYERS.FRESHMAN_STUDENT_SELECTABLE,
+    layerId: FRESHMAN_SELECTABLE_LAYERS.FRESHMAN_STUDENT_SELECTABLE,
+    name: 'Freshman Student Selectable',
+    url: `${eventUrl}/0`
   }
 };
 
 export const FreshmanSelectableColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: FreshmanSelectableDefinitions.CONSTRUCTION.id,
-    title: FreshmanSelectableDefinitions.CONSTRUCTION.name,
-    url: FreshmanSelectableDefinitions.CONSTRUCTION.url,
+    id: FreshmanSelectableDefinitions.RESIDENT_STUDENT_PRIORITY.id,
+    title: FreshmanSelectableDefinitions.RESIDENT_STUDENT_PRIORITY.name,
+    url: FreshmanSelectableDefinitions.RESIDENT_STUDENT_PRIORITY.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.StuSeleN',
+        collapsed: true
+      }
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: `"GIS.TS.Lot_Use.Resident_Lot" = 1 AND "GIS.TS.Lot_Use.FreshmanSele_Lot" = 1`,
+      renderer: residentStudentPriorityRenderer
     }
   },
   {
     type: 'feature',
-    id: FreshmanSelectableDefinitions.LINE_PAINT.id,
-    title: FreshmanSelectableDefinitions.LINE_PAINT.name,
-    url: FreshmanSelectableDefinitions.LINE_PAINT.url,
+    id: FreshmanSelectableDefinitions.FRESHMAN_STUDENT_SELECTABLE.id,
+    title: FreshmanSelectableDefinitions.FRESHMAN_STUDENT_SELECTABLE.name,
+    url: FreshmanSelectableDefinitions.FRESHMAN_STUDENT_SELECTABLE.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.StuSeleN',
+        collapsed: true
+      }
+    },
     native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: FreshmanSelectableDefinitions.FRESHMAN_SELECTABLE.id,
-    title: FreshmanSelectableDefinitions.FRESHMAN_SELECTABLE.name,
-    url: FreshmanSelectableDefinitions.FRESHMAN_SELECTABLE.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: FreshmanSelectableDefinitions.RNS_SPACES.id,
-    title: FreshmanSelectableDefinitions.RNS_SPACES.name,
-    url: FreshmanSelectableDefinitions.RNS_SPACES.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: `"GIS.TS.Lot_Use.Resident_Lot" = 0 AND "GIS.TS.Lot_Use.FreshmanSele_Lot" = 1`,
+      renderer: freshmanSelectableRenderer
     }
   }
 ];
@@ -113,6 +133,6 @@ export const FreshmanSelectableTs: AggiemapCustomMapConfiguration = {
     description: 'Selectable parking information for freshmen.',
     source: 'internal',
     type: 'parking',
-    keywords: ['permit select', 'freshman', 'selectable', 'parking', 'rns']
+    keywords: ['permit select', 'freshman', 'selectable', 'parking', 'resident', 'priority']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,81 +9,28 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum MAINTENANCE_PARKING_LAYERS {
-  CONSTRUCTION = 'construction',
   MAINTENANCE_SPACES = 'maintenance-parking-spaces',
-  SERVICE_SPACES = 'service-parking-spaces',
-  LINE_PAINT = 'line-paint',
-  MAINTENANCE_LOTS = 'maintenance-parking-lots',
-  SERVICE_LOTS = 'service-parking-lots',
-  RNS_SPACES = 'rns-spaces',
-  CONTRACTOR_LOTS = 'contractor-parking-lots'
+  MAINTENANCE_LOTS = 'maintenance-parking-lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/ServiceMaintenanceContractor/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MaintenanceParking/MapServer';
 
 export const MaintenanceParkingDefinitions = {
-  CONSTRUCTION: {
-    id: MAINTENANCE_PARKING_LAYERS.CONSTRUCTION,
-    layerId: MAINTENANCE_PARKING_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
   MAINTENANCE_SPACES: {
     id: MAINTENANCE_PARKING_LAYERS.MAINTENANCE_SPACES,
     layerId: MAINTENANCE_PARKING_LAYERS.MAINTENANCE_SPACES,
     name: 'Maintenance Parking Spaces',
-    url: `${eventUrl}/1`
-  },
-  SERVICE_SPACES: {
-    id: MAINTENANCE_PARKING_LAYERS.SERVICE_SPACES,
-    layerId: MAINTENANCE_PARKING_LAYERS.SERVICE_SPACES,
-    name: 'Service Parking Spaces',
-    url: `${eventUrl}/2`
-  },
-  LINE_PAINT: {
-    id: MAINTENANCE_PARKING_LAYERS.LINE_PAINT,
-    layerId: MAINTENANCE_PARKING_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/3`
+    url: `${eventUrl}/0`
   },
   MAINTENANCE_LOTS: {
     id: MAINTENANCE_PARKING_LAYERS.MAINTENANCE_LOTS,
     layerId: MAINTENANCE_PARKING_LAYERS.MAINTENANCE_LOTS,
     name: 'Maintenance Parking Lots',
-    url: `${eventUrl}/4`
-  },
-  SERVICE_LOTS: {
-    id: MAINTENANCE_PARKING_LAYERS.SERVICE_LOTS,
-    layerId: MAINTENANCE_PARKING_LAYERS.SERVICE_LOTS,
-    name: 'Service Parking Lots',
-    url: `${eventUrl}/5`
-  },
-  RNS_SPACES: {
-    id: MAINTENANCE_PARKING_LAYERS.RNS_SPACES,
-    layerId: MAINTENANCE_PARKING_LAYERS.RNS_SPACES,
-    name: 'RNS Spaces',
-    url: `${eventUrl}/6`
-  },
-  CONTRACTOR_LOTS: {
-    id: MAINTENANCE_PARKING_LAYERS.CONTRACTOR_LOTS,
-    layerId: MAINTENANCE_PARKING_LAYERS.CONTRACTOR_LOTS,
-    name: 'Contractor Parking Lots',
-    url: `${eventUrl}/7`
+    url: `${eventUrl}/1`
   }
 };
 
 export const MaintenanceParkingColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.CONSTRUCTION.id,
-    title: MaintenanceParkingDefinitions.CONSTRUCTION.name,
-    url: MaintenanceParkingDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: MaintenanceParkingDefinitions.MAINTENANCE_SPACES.id,
@@ -89,28 +38,30 @@ export const MaintenanceParkingColdLayerSources: LayerSource[] = [
     url: MaintenanceParkingDefinitions.MAINTENANCE_SPACES.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.SERVICE_SPACES.id,
-    title: MaintenanceParkingDefinitions.SERVICE_SPACES.name,
-    url: MaintenanceParkingDefinitions.SERVICE_SPACES.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.LINE_PAINT.id,
-    title: MaintenanceParkingDefinitions.LINE_PAINT.name,
-    url: MaintenanceParkingDefinitions.LINE_PAINT.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.LotName}',
+      description: {
+        field: 'Spc_Type',
+        collapsed: true
+      },
+      spaceId: {
+        field: 'Spc_ID_Num',
+        collapsed: true
+      },
+      rns: {
+        field: 'RNS_Num',
+        collapsed: true
+      },
+      garageLevel: {
+        field: 'Garage_Lvl',
+        collapsed: true
+      },
+      note: {
+        field: 'Anno_Type',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -122,39 +73,21 @@ export const MaintenanceParkingColdLayerSources: LayerSource[] = [
     url: MaintenanceParkingDefinitions.MAINTENANCE_LOTS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.SERVICE_LOTS.id,
-    title: MaintenanceParkingDefinitions.SERVICE_LOTS.name,
-    url: MaintenanceParkingDefinitions.SERVICE_LOTS.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.RNS_SPACES.id,
-    title: MaintenanceParkingDefinitions.RNS_SPACES.name,
-    url: MaintenanceParkingDefinitions.RNS_SPACES.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MaintenanceParkingDefinitions.CONTRACTOR_LOTS.id,
-    title: MaintenanceParkingDefinitions.CONTRACTOR_LOTS.name,
-    url: MaintenanceParkingDefinitions.CONTRACTOR_LOTS.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.MainteN',
+        collapsed: true
+      },
+      lotType: {
+        field: 'GIS.TS.ParkingLots.LotType',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -182,9 +115,9 @@ export const MaintenanceParkingTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: MaintenanceParkingConfiguration.id,
     name: MaintenanceParkingConfiguration.name,
-    description: 'Maintenance parking lots and spaces, including construction, service, contractor, and RNS overlays.',
+    description: 'Maintenance parking lots and spaces.',
     source: 'internal',
     type: 'parking',
-    keywords: ['maintenance', 'parking', 'service', 'contractor']
+    keywords: ['maintenance', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,23 +9,15 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum MEDIA_PARKING_LAYERS {
-  MEDIA_PARKING_LOTS = 'media-parking-lots',
-  CONSTRUCTION = 'construction'
+  MEDIA_PARKING_LOTS = 'media-parking-lots'
 }
-
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MediaParking/MapServer';
 
 export const MediaParkingDefinitions = {
   MEDIA_PARKING_LOTS: {
     id: MEDIA_PARKING_LAYERS.MEDIA_PARKING_LOTS,
     layerId: MEDIA_PARKING_LAYERS.MEDIA_PARKING_LOTS,
     name: 'Media Parking Lots',
-    url: `${eventUrl}/12`
-  },
-  CONSTRUCTION: {
-    id: MEDIA_PARKING_LAYERS.CONSTRUCTION,
-    layerId: MEDIA_PARKING_LAYERS.CONSTRUCTION,
-    name: 'Construction',
     url: `${eventUrl}/0`
   }
 };
@@ -36,17 +30,21 @@ export const MediaParkingColdLayerSources: LayerSource[] = [
     url: MediaParkingDefinitions.MEDIA_PARKING_LOTS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MediaParkingDefinitions.CONSTRUCTION.id,
-    title: MediaParkingDefinitions.CONSTRUCTION.name,
-    url: MediaParkingDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.AVPN',
+        collapsed: true
+      },
+      lotType: {
+        field: 'GIS.TS.ParkingLots.LotType',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -57,8 +55,8 @@ export const MediaParkingConfiguration: EventConfiguration = {
   id: 'media-parking',
   name: 'Media Parking',
   applicationName: 'Media Parking Map',
-  shortApplicationName: 'Media Parking Map',
-  introductionText: 'Parking map for media permits.',
+  shortApplicationName: 'Media Parking',
+  introductionText: 'Parking lot information for media permits.',
   eventDates: [],
   mapCenter: [-96.34731, 30.60543],
   zoom: 16

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,44 +9,30 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum MOVE_IN_LAYERS {
-  CONSTRUCTION = 'Construction',
-  NO_PARKING = 'No Parking Areas',
-  STREET_PARKING = 'Move-In Allowed Street Parking',
-  MOVE_IN_LOTS = 'Move-In Lots',
-  MOVE_IN_POI = 'Move-In Points of Interest'
+  MOVE_IN_POI = 'Move-In Points of Interest',
+  MOVE_IN_STREETS = 'Move-In Streets',
+  MOVE_IN_LOTS = 'Move-In Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MoveInMoveOut/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/FallMoveInParking/MapServer';
 
 export const MoveInDefinitions = {
-  CONSTRUCTION: {
-    id: MOVE_IN_LAYERS.CONSTRUCTION,
-    layerId: MOVE_IN_LAYERS.CONSTRUCTION,
-    name: 'Construction',
+  MOVE_IN_POI: {
+    id: MOVE_IN_LAYERS.MOVE_IN_POI,
+    layerId: MOVE_IN_LAYERS.MOVE_IN_POI,
+    name: 'Move-In Points of Interest',
     url: `${eventUrl}/0`
   },
-  NO_PARKING: {
-    id: MOVE_IN_LAYERS.NO_PARKING,
-    layerId: MOVE_IN_LAYERS.NO_PARKING,
-    name: 'No Parking Areas',
+  MOVE_IN_STREETS: {
+    id: MOVE_IN_LAYERS.MOVE_IN_STREETS,
+    layerId: MOVE_IN_LAYERS.MOVE_IN_STREETS,
+    name: 'Move-In Streets',
     url: `${eventUrl}/1`
-  },
-  STREET_PARKING: {
-    id: MOVE_IN_LAYERS.STREET_PARKING,
-    layerId: MOVE_IN_LAYERS.STREET_PARKING,
-    name: 'Street Parking',
-    url: `${eventUrl}/5`
   },
   MOVE_IN_LOTS: {
     id: MOVE_IN_LAYERS.MOVE_IN_LOTS,
     layerId: MOVE_IN_LAYERS.MOVE_IN_LOTS,
     name: 'Move-In Lots',
-    url: `${eventUrl}/6`
-  },
-  MOVE_IN_POI: {
-    id: MOVE_IN_LAYERS.MOVE_IN_POI,
-    layerId: MOVE_IN_LAYERS.MOVE_IN_POI,
-    name: 'Move-In Points of Interest',
     url: `${eventUrl}/2`
   }
 };
@@ -52,31 +40,9 @@ export const MoveInDefinitions = {
 export const MoveInColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: MoveInDefinitions.CONSTRUCTION.id,
-    title: MoveInDefinitions.CONSTRUCTION.name,
-    url: MoveInDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MoveInDefinitions.NO_PARKING.id,
-    title: MoveInDefinitions.NO_PARKING.name,
-    url: MoveInDefinitions.NO_PARKING.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: MoveInDefinitions.STREET_PARKING.id,
-    title: MoveInDefinitions.STREET_PARKING.name,
-    url: MoveInDefinitions.STREET_PARKING.url,
+    id: MoveInDefinitions.MOVE_IN_STREETS.id,
+    title: MoveInDefinitions.MOVE_IN_STREETS.name,
+    url: MoveInDefinitions.MOVE_IN_STREETS.url,
     visible: true,
     listMode: 'show',
     native: {
@@ -90,6 +56,20 @@ export const MoveInColdLayerSources: LayerSource[] = [
     url: MoveInDefinitions.MOVE_IN_LOTS.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      /**
+       * Notes requested from column: MoveInN
+       */
+      description: {
+        field: 'GIS.TS.SpEv_Lot_Notes.MoveInN',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -101,6 +81,14 @@ export const MoveInColdLayerSources: LayerSource[] = [
     url: MoveInDefinitions.MOVE_IN_POI.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description: {
+        field: 'Note',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -125,13 +113,13 @@ export const MoveInTs: AggiemapCustomMapConfiguration = {
   options: MoveInOptions,
   sources: MoveInColdLayerSources,
   references: MOVE_IN_LAYERS,
-  type: 'special-event',
+  type: 'general-map',
   discover: {
     id: MoveInConfiguration.id,
     name: MoveInConfiguration.name,
-    description: 'Transportation and parking information for Move In Day.',
+    description: 'Transportation and parking information for Fall Move In.',
     source: 'internal',
-    type: 'event',
-    keywords: ['move in', 'parking', 'transportation']
+    type: 'parking',
+    keywords: ['move in', 'fall move in', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
@@ -1,5 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,46 +8,35 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum MOVE_OUT_LAYERS {
-  CONSTRUCTION = 'Construction',
   NO_PARKING = 'No Parking Areas',
-  STREET_PARKING = 'Move-Out Allowed Street Parking'
+  STREET_PARKING = 'Move-Out Allowed Street Parking',
+  MOVE_OUT_LOTS = 'Move-Out Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MoveInMoveOut/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MoveOutParking/MapServer';
 
 export const MoveOutDefinitions = {
-  CONSTRUCTION: {
-    id: MOVE_OUT_LAYERS.CONSTRUCTION,
-    layerId: MOVE_OUT_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
   NO_PARKING: {
     id: MOVE_OUT_LAYERS.NO_PARKING,
     layerId: MOVE_OUT_LAYERS.NO_PARKING,
     name: 'No Parking Areas',
-    url: `${eventUrl}/1`
+    url: `${eventUrl}/0`
   },
   STREET_PARKING: {
     id: MOVE_OUT_LAYERS.STREET_PARKING,
     layerId: MOVE_OUT_LAYERS.STREET_PARKING,
-    name: 'Street Parking',
-    url: `${eventUrl}/4`
+    name: 'Move-Out Allowed Street Parking',
+    url: `${eventUrl}/1`
+  },
+  MOVE_OUT_LOTS: {
+    id: MOVE_OUT_LAYERS.MOVE_OUT_LOTS,
+    layerId: MOVE_OUT_LAYERS.MOVE_OUT_LOTS,
+    name: 'Move-Out Lots',
+    url: `${eventUrl}/2`
   }
 };
 
 export const MoveOutColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: MoveOutDefinitions.CONSTRUCTION.id,
-    title: MoveOutDefinitions.CONSTRUCTION.name,
-    url: MoveOutDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: MoveOutDefinitions.NO_PARKING.id,
@@ -54,6 +44,17 @@ export const MoveOutColdLayerSources: LayerSource[] = [
     url: MoveOutDefinitions.NO_PARKING.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'Type',
+        collapsed: true
+      },
+      description: {
+        field: 'Note',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -65,6 +66,39 @@ export const MoveOutColdLayerSources: LayerSource[] = [
     url: MoveOutDefinitions.STREET_PARKING.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'A_Name',
+        collapsed: true
+      },
+      description: {
+        field: 'SP_SH_Notes',
+        collapsed: true
+      }
+    },
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: MoveOutDefinitions.MOVE_OUT_LOTS.id,
+    title: MoveOutDefinitions.MOVE_OUT_LOTS.name,
+    url: MoveOutDefinitions.MOVE_OUT_LOTS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.SpEv_Lot_Notes.MoveOutN',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -84,11 +118,11 @@ export const MoveOutConfiguration: EventConfiguration = {
 export const MoveOutOptions: SpecialEventOptions = [];
 
 export const MoveOut: AggiemapCustomMapConfiguration = {
+  type: 'general-map',
   configuration: MoveOutConfiguration,
   options: MoveOutOptions,
   sources: MoveOutColdLayerSources,
   references: MOVE_OUT_LAYERS,
-  type: 'special-event',
   discover: {
     id: MoveOutConfiguration.id,
     name: MoveOutConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
@@ -5,19 +5,20 @@ import {
   EventConfiguration,
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
 export enum NIGHT_WEEKEND_LAYERS {
   NIGHT_PRIVILEGES = 'Night Privileges 5:00pm - 6:00am'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/NightWeekendParking/MapServer';
 
 export const NightWeekendDefinitions = {
   NIGHT_PRIVILEGES: {
     id: NIGHT_WEEKEND_LAYERS.NIGHT_PRIVILEGES,
     layerId: NIGHT_WEEKEND_LAYERS.NIGHT_PRIVILEGES,
     name: 'Night Privileges 5:00pm - 6:00am',
-    url: `${eventUrl}/6`
+    url: `${eventUrl}/0`
   }
 };
 
@@ -29,8 +30,42 @@ export const NightWeekendColdLayerSources: LayerSource[] = [
     url: NightWeekendDefinitions.NIGHT_PRIVILEGES.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.NandWN',
+        collapsed: true
+      }
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      // labels are being buried under features so they are being manually drawn
+      labelsVisible: true,
+      labelingInfo: [
+        {
+          labelPlacement: 'always-horizontal',
+          labelExpressionInfo: {
+            expression: `$feature["GIS.TS.ParkingLots.Name"]`
+          },
+          minScale: 15000,
+          maxScale: 0,
+          symbol: {
+            type: 'text',
+            color: [0, 0, 0, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1,
+            font: {
+              family: 'Open Sans',
+              size: 12,
+              weight: 'bold'
+            }
+          }
+        }
+      ]
     }
   }
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
@@ -1,73 +1,49 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import {
-  AggiemapCustomMapConfiguration,
   EventConfiguration,
+  AggiemapCustomMapConfiguration,
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
 export enum RETIREE_PARKING_LAYERS {
-  LOT_SPECIFIC = 'Lot Specific Permit Required',
-  RETIREE_AUTHORIZED = 'Retiree Permit Authorized'
+  RETIREE_PARKING_LOTS = 'Retiree Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/RetireeParking/MapServer';
 
 export const RetireeParkingDefinitions = {
-  LOT_SPECIFIC: {
-    id: RETIREE_PARKING_LAYERS.LOT_SPECIFIC,
-    layerId: RETIREE_PARKING_LAYERS.LOT_SPECIFIC,
-    name: 'Lot Specific Permit Required',
-    url: `${eventUrl}/7`
-  },
-  RETIREE_AUTHORIZED: {
-    id: RETIREE_PARKING_LAYERS.RETIREE_AUTHORIZED,
-    layerId: RETIREE_PARKING_LAYERS.RETIREE_AUTHORIZED,
-    name: 'Retiree Permit Authorized',
-    url: `${eventUrl}/7`
+  RETIREE_PARKING_LOTS: {
+    id: RETIREE_PARKING_LAYERS.RETIREE_PARKING_LOTS,
+    layerId: RETIREE_PARKING_LAYERS.RETIREE_PARKING_LOTS,
+    name: 'Retiree Parking Lots',
+    url: `${eventUrl}/0`
   }
 };
 
 export const RetireeParkingColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: RetireeParkingDefinitions.RETIREE_AUTHORIZED.id,
-    title: RetireeParkingDefinitions.RETIREE_AUTHORIZED.name,
-    url: RetireeParkingDefinitions.RETIREE_AUTHORIZED.url,
+    id: RetireeParkingDefinitions.RETIREE_PARKING_LOTS.id,
+    title: RetireeParkingDefinitions.RETIREE_PARKING_LOTS.name,
+    url: RetireeParkingDefinitions.RETIREE_PARKING_LOTS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*'],
-      definitionExpression: `"GIS.TS.Lot_Use.Retired_Lot" = 1`,
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-fill',
-          color: [90, 0, 0, 255],
-          outline: null
-        }
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.RetireeN',
+        collapsed: true
       }
-    } as any
-  },
-  {
-    type: 'feature',
-    id: RetireeParkingDefinitions.LOT_SPECIFIC.id,
-    title: RetireeParkingDefinitions.LOT_SPECIFIC.name,
-    url: RetireeParkingDefinitions.LOT_SPECIFIC.url,
-    visible: true,
-    listMode: 'show',
+    },
     native: {
-      outFields: ['*'],
-      definitionExpression: `"GIS.TS.Lot_Use.Retired_Lot" <> 1 OR "GIS.TS.Lot_Use.Retired_Lot" IS NULL`,
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-fill',
-          color: [204, 204, 204, 255],
-          outline: null
-        }
-      }
-    } as any
+      outFields: ['*']
+    }
   }
 ];
 

--- a/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,92 +9,27 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum SERVICE_LOADING_LAYERS {
-  CONSTRUCTION = 'construction',
-  MAINTENANCE_SPACES = 'maintenance-parking-spaces',
   SERVICE_SPACES = 'service-parking-spaces',
-  LINE_PAINT = 'line-paint',
-  MAINTENANCE_LOTS = 'maintenance-parking-lots',
-  SERVICE_LOTS = 'service-parking-lots',
-  RNS_SPACES = 'rns-spaces',
-  CONTRACTOR_LOTS = 'contractor-parking-lots'
+  SERVICE_LOTS = 'service-parking-lots'
 }
-
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/ServiceMaintenanceContractor/MapServer';
+const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Loading_Zones/MapServer';
 
 export const ServiceLoadingDefinitions = {
-  CONSTRUCTION: {
-    id: SERVICE_LOADING_LAYERS.CONSTRUCTION,
-    layerId: SERVICE_LOADING_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
-  MAINTENANCE_SPACES: {
-    id: SERVICE_LOADING_LAYERS.MAINTENANCE_SPACES,
-    layerId: SERVICE_LOADING_LAYERS.MAINTENANCE_SPACES,
-    name: 'Maintenance Parking Spaces',
-    url: `${eventUrl}/1`
-  },
   SERVICE_SPACES: {
     id: SERVICE_LOADING_LAYERS.SERVICE_SPACES,
     layerId: SERVICE_LOADING_LAYERS.SERVICE_SPACES,
     name: 'Service Parking Spaces',
-    url: `${eventUrl}/2`
-  },
-  LINE_PAINT: {
-    id: SERVICE_LOADING_LAYERS.LINE_PAINT,
-    layerId: SERVICE_LOADING_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/3`
-  },
-  MAINTENANCE_LOTS: {
-    id: SERVICE_LOADING_LAYERS.MAINTENANCE_LOTS,
-    layerId: SERVICE_LOADING_LAYERS.MAINTENANCE_LOTS,
-    name: 'Maintenance Parking Lots',
-    url: `${eventUrl}/4`
+    url: `${eventUrl}/0`
   },
   SERVICE_LOTS: {
     id: SERVICE_LOADING_LAYERS.SERVICE_LOTS,
     layerId: SERVICE_LOADING_LAYERS.SERVICE_LOTS,
     name: 'Service Parking Lots',
-    url: `${eventUrl}/5`
-  },
-  RNS_SPACES: {
-    id: SERVICE_LOADING_LAYERS.RNS_SPACES,
-    layerId: SERVICE_LOADING_LAYERS.RNS_SPACES,
-    name: 'RNS Spaces',
-    url: `${eventUrl}/6`
-  },
-  CONTRACTOR_LOTS: {
-    id: SERVICE_LOADING_LAYERS.CONTRACTOR_LOTS,
-    layerId: SERVICE_LOADING_LAYERS.CONTRACTOR_LOTS,
-    name: 'Contractor Parking Lots',
-    url: `${eventUrl}/7`
+    url: `${eventUrl}/1`
   }
 };
 
 export const ServiceLoadingColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.CONSTRUCTION.id,
-    title: ServiceLoadingDefinitions.CONSTRUCTION.name,
-    url: ServiceLoadingDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.MAINTENANCE_SPACES.id,
-    title: ServiceLoadingDefinitions.MAINTENANCE_SPACES.name,
-    url: ServiceLoadingDefinitions.MAINTENANCE_SPACES.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: ServiceLoadingDefinitions.SERVICE_SPACES.id,
@@ -100,28 +37,26 @@ export const ServiceLoadingColdLayerSources: LayerSource[] = [
     url: ServiceLoadingDefinitions.SERVICE_SPACES.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.LINE_PAINT.id,
-    title: ServiceLoadingDefinitions.LINE_PAINT.name,
-    url: ServiceLoadingDefinitions.LINE_PAINT.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.MAINTENANCE_LOTS.id,
-    title: ServiceLoadingDefinitions.MAINTENANCE_LOTS.name,
-    url: ServiceLoadingDefinitions.MAINTENANCE_LOTS.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.LotName}',
+      description: {
+        field: 'Spc_Type',
+        collapsed: true
+      },
+      spaceId: {
+        field: 'Spc_ID_Num',
+        collapsed: true
+      },
+      rns: {
+        field: 'RNS_Num',
+        collapsed: true
+      },
+      garageLevel: {
+        field: 'Garage_Lvl',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -133,28 +68,17 @@ export const ServiceLoadingColdLayerSources: LayerSource[] = [
     url: ServiceLoadingDefinitions.SERVICE_LOTS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.RNS_SPACES.id,
-    title: ServiceLoadingDefinitions.RNS_SPACES.name,
-    url: ServiceLoadingDefinitions.RNS_SPACES.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: ServiceLoadingDefinitions.CONTRACTOR_LOTS.id,
-    title: ServiceLoadingDefinitions.CONTRACTOR_LOTS.name,
-    url: ServiceLoadingDefinitions.CONTRACTOR_LOTS.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.ServiceN',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -182,9 +106,9 @@ export const ServiceLoadingTs: AggiemapCustomMapConfiguration = {
   discover: {
     id: ServiceLoadingConfiguration.id,
     name: ServiceLoadingConfiguration.name,
-    description: 'Service, maintenance, and contractor parking lots and spaces, including construction and RNS overlays.',
+    description: 'Service and loading zone parking layers.',
     source: 'internal',
     type: 'parking',
-    keywords: ['service', 'loading', 'maintenance', 'contractor', 'parking']
+    keywords: ['service', 'loading', 'loading zone', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
@@ -1,5 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,64 +8,21 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum STAFF_SELECTABLE_LAYERS {
-  CONSTRUCTION = 'Construction',
-  LINE_PAINT = 'Line Paint',
-  STAFF_SELECTABLE = 'Staff Selectable Parking Lots',
-  RNS_SPACES = 'RNS Spaces'
+  STAFF_SELECTABLE = 'Staff Selectable Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/PermitSelect/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/StaffSelectableParking/MapServer';
 
 export const StaffSelectableDefinitions = {
-  CONSTRUCTION: {
-    id: STAFF_SELECTABLE_LAYERS.CONSTRUCTION,
-    layerId: STAFF_SELECTABLE_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
-  LINE_PAINT: {
-    id: STAFF_SELECTABLE_LAYERS.LINE_PAINT,
-    layerId: STAFF_SELECTABLE_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/1`
-  },
   STAFF_SELECTABLE: {
     id: STAFF_SELECTABLE_LAYERS.STAFF_SELECTABLE,
     layerId: STAFF_SELECTABLE_LAYERS.STAFF_SELECTABLE,
     name: 'Staff Selectable Parking Lots',
-    url: `${eventUrl}/4`
-  },
-  RNS_SPACES: {
-    id: STAFF_SELECTABLE_LAYERS.RNS_SPACES,
-    layerId: STAFF_SELECTABLE_LAYERS.RNS_SPACES,
-    name: 'RNS Spaces',
-    url: `${eventUrl}/5`
+    url: `${eventUrl}/0`
   }
 };
 
 export const StaffSelectableColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: StaffSelectableDefinitions.CONSTRUCTION.id,
-    title: StaffSelectableDefinitions.CONSTRUCTION.name,
-    url: StaffSelectableDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: StaffSelectableDefinitions.LINE_PAINT.id,
-    title: StaffSelectableDefinitions.LINE_PAINT.name,
-    url: StaffSelectableDefinitions.LINE_PAINT.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: StaffSelectableDefinitions.STAFF_SELECTABLE.id,
@@ -72,17 +30,17 @@ export const StaffSelectableColdLayerSources: LayerSource[] = [
     url: StaffSelectableDefinitions.STAFF_SELECTABLE.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: StaffSelectableDefinitions.RNS_SPACES.id,
-    title: StaffSelectableDefinitions.RNS_SPACES.name,
-    url: StaffSelectableDefinitions.RNS_SPACES.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.StuSeleN',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -113,6 +71,6 @@ export const StaffSelectableTs: AggiemapCustomMapConfiguration = {
     description: 'Selectable parking information for staff.',
     source: 'internal',
     type: 'parking',
-    keywords: ['permit select', 'staff', 'selectable', 'parking', 'rns']
+    keywords: ['permit select', 'staff', 'selectable', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
@@ -1,5 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,64 +8,20 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum STUDENT_SELECTABLE_LAYERS {
-  CONSTRUCTION = 'Construction',
-  LINE_PAINT = 'Line Paint',
-  STUDENT_SELECTABLE = 'Student Selectable Parking Lots',
-  RNS_SPACES = 'RNS Spaces'
+  STUDENT_SELECTABLE = 'Student Selectable Parking Lots'
 }
-
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/PermitSelect/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/StudentSelectableParking/MapServer';
 
 export const StudentSelectableDefinitions = {
-  CONSTRUCTION: {
-    id: STUDENT_SELECTABLE_LAYERS.CONSTRUCTION,
-    layerId: STUDENT_SELECTABLE_LAYERS.CONSTRUCTION,
-    name: 'Construction',
-    url: `${eventUrl}/0`
-  },
-  LINE_PAINT: {
-    id: STUDENT_SELECTABLE_LAYERS.LINE_PAINT,
-    layerId: STUDENT_SELECTABLE_LAYERS.LINE_PAINT,
-    name: 'Line Paint',
-    url: `${eventUrl}/1`
-  },
   STUDENT_SELECTABLE: {
     id: STUDENT_SELECTABLE_LAYERS.STUDENT_SELECTABLE,
     layerId: STUDENT_SELECTABLE_LAYERS.STUDENT_SELECTABLE,
     name: 'Student Selectable Parking Lots',
-    url: `${eventUrl}/2`
-  },
-  RNS_SPACES: {
-    id: STUDENT_SELECTABLE_LAYERS.RNS_SPACES,
-    layerId: STUDENT_SELECTABLE_LAYERS.RNS_SPACES,
-    name: 'RNS Spaces',
-    url: `${eventUrl}/5`
+    url: `${eventUrl}/0`
   }
 };
 
 export const StudentSelectableColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: StudentSelectableDefinitions.CONSTRUCTION.id,
-    title: StudentSelectableDefinitions.CONSTRUCTION.name,
-    url: StudentSelectableDefinitions.CONSTRUCTION.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: StudentSelectableDefinitions.LINE_PAINT.id,
-    title: StudentSelectableDefinitions.LINE_PAINT.name,
-    url: StudentSelectableDefinitions.LINE_PAINT.url,
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
   {
     type: 'feature',
     id: StudentSelectableDefinitions.STUDENT_SELECTABLE.id,
@@ -72,17 +29,17 @@ export const StudentSelectableColdLayerSources: LayerSource[] = [
     url: StudentSelectableDefinitions.STUDENT_SELECTABLE.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: StudentSelectableDefinitions.RNS_SPACES.id,
-    title: StudentSelectableDefinitions.RNS_SPACES.name,
-    url: StudentSelectableDefinitions.RNS_SPACES.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'GIS.TS.ParkingLots.Name',
+        collapsed: true
+      },
+      description: {
+        field: 'GIS.TS.Lot_Notes.StuSeleN',
+        collapsed: true
+      }
+    },
     native: {
       outFields: ['*']
     }
@@ -113,6 +70,6 @@ export const StudentSelectableTs: AggiemapCustomMapConfiguration = {
     description: 'Selectable parking information for students.',
     source: 'internal',
     type: 'parking',
-    keywords: ['permit select', 'student', 'selectable', 'parking', 'rns']
+    keywords: ['permit select', 'student', 'selectable', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
@@ -1,5 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,49 +8,40 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum TIMED_PARKING_LAYERS {
-  TIMED_PARKING_AREA = 'Timed Parking in this area',
   TIMED_PARKING_SPACE = 'Timed Parking Space'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/DisabledTimedMotorcycle/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TimedParking/MapServer';
 
 export const TimedParkingDefinitions = {
-  TIMED_PARKING_AREA: {
-    id: TIMED_PARKING_LAYERS.TIMED_PARKING_AREA,
-    layerId: TIMED_PARKING_LAYERS.TIMED_PARKING_AREA,
-    name: 'Timed Spaces in this area',
-    url: `${eventUrl}/5`
-  },
   TIMED_PARKING_SPACE: {
     id: TIMED_PARKING_LAYERS.TIMED_PARKING_SPACE,
     layerId: TIMED_PARKING_LAYERS.TIMED_PARKING_SPACE,
     name: 'Timed Parking Space',
-    url: `${eventUrl}/6`
+    url: `${eventUrl}/0`
   }
 };
 
 export const TimedParkingColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: TimedParkingDefinitions.TIMED_PARKING_AREA.id,
-    title: TimedParkingDefinitions.TIMED_PARKING_AREA.name,
-    url: TimedParkingDefinitions.TIMED_PARKING_AREA.url,
-    // popupComponent: MarkdownPopupComponent,
-    visible: true,
-    native: {
-      listMode: 'show',
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
     id: TimedParkingDefinitions.TIMED_PARKING_SPACE.id,
     title: TimedParkingDefinitions.TIMED_PARKING_SPACE.name,
     url: TimedParkingDefinitions.TIMED_PARKING_SPACE.url,
-    // popupComponent: MarkdownPopupComponent,
     visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: {
+        field: 'LotName',
+        collapsed: true
+      },
+      description: {
+        field: 'Anno_Type',
+        collapsed: true
+      }
+    },
     native: {
-      listMode: 'show',
       outFields: ['*']
     }
   }
@@ -58,10 +50,11 @@ export const TimedParkingColdLayerSources: LayerSource[] = [
 export const TimedParkingConfiguration: EventConfiguration = {
   id: 'timed-parking',
   name: 'Timed Parking',
-  applicationName: 'Areas with Timed Parking',
-  shortApplicationName: 'Timed Parking Map',
+  applicationName: 'Timed Parking Map',
+  shortApplicationName: 'Timed Parking',
   eventDates: [],
-  mapCenter: [-96.33771, 30.62143]
+  mapCenter: [-96.34409, 30.6073],
+  zoom: 18
 };
 
 export const TimedParkingOptions: SpecialEventOptions = [];
@@ -75,9 +68,9 @@ export const TimedParking_Ts: AggiemapCustomMapConfiguration = {
   discover: {
     id: TimedParkingConfiguration.id,
     name: TimedParkingConfiguration.name,
-    description: 'Areas with timed parking on campus.',
+    description: 'Timed parking spaces on campus.',
     source: 'internal',
     type: 'parking',
-    keywords: ['timed', 'parking', 'transportation', '30 minute', '30 min']
+    keywords: ['timed', 'parking', 'transportation']
   }
 };


### PR DESCRIPTION
This PR updates the Transportation Services map source for the following files/maps:

accessible-parking.definitions.ts
baseball-parking.definitions.ts
business-parking.definitions.ts
contractor-parking.definitions.ts
freshman-parking.definitions.ts
maintenance-parking.definitions.ts
media-parking.definitions.ts
move-in.definitions.ts
move-out.definitions.ts
night-weekend.definitions.ts
retiree-parking.definitions.ts
service-and-loading-zones.definitions.ts
staff-selectable.definitions.ts
student-selectable.definitions.ts
timed-parking.definitions.ts

This also updates the event modules from ISpecialEventRoot to AggiemapCustomMapConfiguration.

All maps are verified to work in AggieMap.

Supersedes #608, #606, #609, #623, #625, #605, #621, #624, #620, #616, #628, #626, #604, #607, #618, #627

Previous PRs (listed above) were incorrectly built on pre-existing branches and commits were made to PRs that were already closed. 