### PR TITLE
fix(aggiemap-angular): Display Correct Dates on Discover Page Under Upcoming Events

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -122,6 +122,12 @@ export class DiscoverComponent implements OnInit {
     if (date instanceof Date) {
       return date.getTime();
     }
+    // Treat date-only strings as local dates to avoid UTC day-shift issues.
+    const dateOnlyMatch = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      const [, year, month, day] = dateOnlyMatch;
+      return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
+    }
     return new Date(date).getTime();
   }
 


### PR DESCRIPTION
This PR fixes a bug on the discover homepage that caused dates under "Upcoming Events" to appear one day earlier than they actually are.

Previously, date strings were parsed with `new Date(date)`. For date-only strings in `YYYY-MM-DD` format, JavaScript interprets them as UTC. In US time zones, that can render as the previous calendar day when displayed locally.

This PR updates `parseEventDate()` in discover.components.ts to detect date-only strings (`YYYY-MM-DD`), parse them as a local calendar date with `new Date(year, month - 1, day)`, and keeps the same behavior for timestamps, `Date` objects and other date string formats

Before:
<img width="450" height="418" alt="image" src="https://github.com/user-attachments/assets/30af16d7-8923-4c75-893a-27c84790593e" />

After:
<img width="2990" height="1590" alt="image" src="https://github.com/user-attachments/assets/ad8c2ed9-1cd1-4510-b506-3da89bb31aa3" />

Part of #629
