### PR TITLE
fix(aggiemap-angular): Rearrange Layers for Aggieland Saturday

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -7,10 +7,10 @@ import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-
 import esri = __esri;
 
 export enum AGGIELAND_SATURDAY_LAYERS {
-  PARKING = 'aggieland-saturday-parking',
-  BUS_ROUTES = 'aggieland-saturday-bus-routes',
   BUS_STOPS = 'aggieland-saturday-bus-stops',
-  SPECIAL_POIS = 'aggieland-saturday-special-pois'
+  BUS_ROUTES = 'aggieland-saturday-bus-routes',
+  SPECIAL_POIS = 'aggieland-saturday-special-pois',
+  PARKING = 'aggieland-saturday-parking'
 }
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AggielandSaturday/MapServer';


### PR DESCRIPTION
Rearranges the layers for the Aggieland Saturday map.

Previous arrangement:

Parking
POIs
Routes
Bus Stops
<img width="654" height="674" alt="image" src="https://github.com/user-attachments/assets/ca10dde4-1201-472d-9c03-565bc8904225" />


New arrangement:

Bus Stops
Routes
POIs
Parking

<img width="874" height="1558" alt="image" src="https://github.com/user-attachments/assets/be2a168d-29e0-4ca8-adbc-c39de5fd812e" />

Part of #629 