### PR TITLE
fix(aggiemap-angular): Use top-bottom ordering discover maps section

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -56,15 +56,22 @@
       </div>
 
       <!-- Parking Maps Section -->
-      <div class="parking-maps-section trailer-3" *ngIf="parkingApplications.length > 0">
+      <div class="parking-maps-section trailer-3" *ngIf="parkingColumns[0].length + parkingColumns[1].length > 0">
         <h2>Parking Maps</h2>
-        <p class="section-description">Ordered list of parking maps.</p>
+        <p class="section-description">Browse available parking maps for Texas A&M University campus.</p>
 
-        <ol class="parking-links">
-          <li class="parking-link-item" *ngFor="let app of parkingApplications">
-            <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
-          </li>
-        </ol>
+        <div class="parking-columns">
+          <ol class="parking-links">
+            <li class="parking-link-item" *ngFor="let app of parkingColumns[0]">
+              <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
+            </li>
+          </ol>
+          <ol class="parking-links" *ngIf="parkingColumns[1].length > 0" [attr.start]="parkingColumnStart">
+            <li class="parking-link-item" *ngFor="let app of parkingColumns[1]">
+              <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
+            </li>
+          </ol>
+        </div>
       </div>
 
       <!-- Experimental Applications Section -->

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -202,6 +202,12 @@
 .parking-links {
   margin: 0;
   padding-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.parking-columns {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.5rem 2rem;

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -25,7 +25,8 @@ export class DiscoverComponent implements OnInit {
   public allApplications: DiscoverApplication[];
   private allEvents: EventConfiguration[];
   public upcomingEvents: EventConfiguration[];
-  public parkingApplications: InternalDiscoverApplication[];
+  public parkingColumns: InternalDiscoverApplication[][] = [[], []];
+  public parkingColumnStart = 1;
 
   public searchControl = new FormControl();
   public filteredApplications: Observable<DiscoverApplication[]>;
@@ -60,14 +61,21 @@ export class DiscoverComponent implements OnInit {
     // Calculate upcoming events
     this.upcomingEvents = this.getUpcomingEvents();
 
-    // Build ordered parking list
-    this.parkingApplications = this.getParkingApplications();
+    // Build ordered parking list and split into two columns
+    const parkingApplications = this.getParkingApplications();
+    this.parkingColumns = this.buildParkingColumns(parkingApplications);
+    this.parkingColumnStart = this.parkingColumns[0].length + 1;
   }
 
   private getParkingApplications(): InternalDiscoverApplication[] {
     return this.eventDiscoverApplications
       .filter((app) => app.type === 'parking')
       .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private buildParkingColumns(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[][] {
+    const midpoint = Math.ceil(apps.length / 2);
+    return [apps.slice(0, midpoint), apps.slice(midpoint)];
   }
 
   private _filterApplications(value: string, isDev: boolean): DiscoverApplication[] {


### PR DESCRIPTION
This pull request updates the "Parking Maps" section in the `DiscoverComponent` to display parking map links in two columns for improved readability and user experience. The logic for rendering and organizing parking applications has been refactored, and related styles have been updated to support the new layout.

**Parking Maps section improvements:**

* The "Parking Maps" section now displays links in two columns by splitting the list of parking applications into two arrays, `parkingColumns[0]` and `parkingColumns[1]`, and rendering each as a separate ordered list. The section description has also been updated for clarity. (`discover.component.html`)
* The component logic has been refactored to compute `parkingColumns` (an array of two arrays) and `parkingColumnStart` (used to correctly number the second column), replacing the previous single `parkingApplications` array. (`discover.component.ts`) [[1]](diffhunk://#diff-51dc4b91f359747a7e1c028a8b8230bb07140197c591bf6ebb851805f60e041eL28-R29) [[2]](diffhunk://#diff-51dc4b91f359747a7e1c028a8b8230bb07140197c591bf6ebb851805f60e041eL63-R67) [[3]](diffhunk://#diff-51dc4b91f359747a7e1c028a8b8230bb07140197c591bf6ebb851805f60e041eR76-R80)

**Styling updates:**

* Added `.parking-columns` CSS class to lay out the columns using CSS grid, and updated `.parking-links` to use flex layout with spacing between items for better visual separation. (`discover.component.scss`)