### PR TITLE
fix(aggiemap-angular): Remove Paid Parking from Aggieland Saturday Legend

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -165,16 +165,6 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
         field: 'Type',
         uniqueValueInfos: [
           {
-            value: 'Pay Parking',
-            label: 'Paid Parking',
-            symbol: {
-              type: 'picture-marker',
-              url: '/assets/images/icons/transportation/Paid-Parking.png',
-              width: '24px',
-              height: '32px'
-            } as unknown as esri.PictureMarkerSymbolProperties
-          },
-          {
             value: 'Dining',
             label: 'Dining',
             symbol: {


### PR DESCRIPTION
Removes the unnecessary "Paid Parking" icon from the list of Points of Interest on the Aggieland Saturday map.

Part of #629