### PR TITLE
fix(aggiemap-angular): Update Ring Day Dates + Fix Issue with Ring Day Map Visibility

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -140,11 +140,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
     choices: [
       {
         value: EventDay.DAY1,
-        label: 'November 6, 2025'
+        label: 'April 9, 2026'
       },
       {
         value: EventDay.DAY2,
-        label: 'November 7, 2025'
+        label: 'April 10, 2026'
       }
     ],
     effects: {

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -154,11 +154,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: `StartDate <= date'${RingDayDates.DAY1}' AND EndDate >= date'${RingDayDates.DAY1}'`
+              expression: '1=1'
             },
             {
               input: EventDay.DAY2,
-              expression: `StartDate <= date'${RingDayDates.DAY2}' AND EndDate >= date'${RingDayDates.DAY2}'`
+              expression: '1=1'
             }
           ]
         },
@@ -167,11 +167,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: `Start_Date <= date'${RingDayDates.DAY1}' AND End_Date >= date'${RingDayDates.DAY1}'`
+              expression: '1=1'
             },
             {
               input: EventDay.DAY2,
-              expression: `Start_Date <= date'${RingDayDates.DAY2}' AND End_Date >= date'${RingDayDates.DAY2}'`
+              expression: '1=1'
             }
           ]
         },
@@ -180,11 +180,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: `Start_Date <= date'${RingDayDates.DAY1}' AND End_Date >= date'${RingDayDates.DAY1}'`
+              expression: '1=1'
             },
             {
               input: EventDay.DAY2,
-              expression: `Start_Date <= date'${RingDayDates.DAY2}' AND End_Date >= date'${RingDayDates.DAY2}'`
+              expression: '1=1'
             }
           ]
         }

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -14,8 +14,9 @@ export enum RING_DAY_LAYERS {
 }
 
 enum RingDayDates {
-  DAY1 = '2026-04-09',
-  DAY2 = '2026-04-10'
+  DAY1 = '2026-04-08',
+  DAY2 = '2026-04-09',
+  DAY3 = '2026-04-10'
 }
 
 const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Ring_Day/MapServer';
@@ -98,7 +99,7 @@ export const RingDayConfiguration: EventConfiguration = {
   applicationName: 'Ring Day Transportation Map',
   shortApplicationName: 'Ring Day Map',
   introductionText: 'Get the best transportation and logistics information for Ring Day.',
-  eventDates: [RingDayDates.DAY1, RingDayDates.DAY2],
+  eventDates: [RingDayDates.DAY1, RingDayDates.DAY2, RingDayDates.DAY3],
   mapCenter: [-96.33616, 30.60958],
   zoom: 16,
   defaultLayerOverrides: {
@@ -135,16 +136,17 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
   {
     value: RingDayOptions.EVENT_DAY,
     label: 'Event Day',
-    description: 'Select which day you plan to attend Ring Day to see the most relevant information for that specific day.',
+    description:
+      'Select which Ring Day period you plan to attend to see the most relevant transportation and logistics information.',
     shortDescription: 'Event Day',
     choices: [
       {
         value: EventDay.DAY1,
-        label: 'April 9, 2026'
+        label: 'Aggie Ring Pickup (April 8, 2026)'
       },
       {
         value: EventDay.DAY2,
-        label: 'April 10, 2026'
+        label: 'Aggie Ring Day (April 9-10, 2026)'
       }
     ],
     effects: {
@@ -154,11 +156,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: '1=1'
+              expression: `StartDate <= date'${RingDayDates.DAY1}' AND EndDate >= date'${RingDayDates.DAY1}'`
             },
             {
               input: EventDay.DAY2,
-              expression: '1=1'
+              expression: `StartDate <= date'${RingDayDates.DAY3}' AND EndDate >= date'${RingDayDates.DAY2}'`
             }
           ]
         },
@@ -167,11 +169,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: '1=1'
+              expression: `Start_Date <= date'${RingDayDates.DAY1}' AND End_Date >= date'${RingDayDates.DAY1}'`
             },
             {
               input: EventDay.DAY2,
-              expression: '1=1'
+              expression: `Start_Date <= date'${RingDayDates.DAY3}' AND End_Date >= date'${RingDayDates.DAY2}'`
             }
           ]
         },
@@ -180,11 +182,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
           conversions: [
             {
               input: EventDay.DAY1,
-              expression: '1=1'
+              expression: `Start_Date <= date'${RingDayDates.DAY1}' AND End_Date >= date'${RingDayDates.DAY1}'`
             },
             {
               input: EventDay.DAY2,
-              expression: '1=1'
+              expression: `Start_Date <= date'${RingDayDates.DAY3}' AND End_Date >= date'${RingDayDates.DAY2}'`
             }
           ]
         }


### PR DESCRIPTION
This PR fixes two labels that were missed when initially updating the maps to 2026. 

The service data dates don’t seem to match 2026 yet, which caused date filters to return zero results and show an empty map. This PR replaces date-based layer expressions with 1=1 for Areas, Routes, and POIs to ensure everything shows.