### PR TITLE
fix(aggiemap-angular) Make Discover + Other Options Clickable on Mobile Sidebar

### DIFF
--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
@@ -40,7 +40,7 @@ export class MainMobileSidebarComponent {
     {
       name: 'Building Directory',
       type: 'router-path',
-      path: '../../../../../directory'
+      path: '/directory'
     },
     {
       name: 'Feedback',
@@ -51,12 +51,12 @@ export class MainMobileSidebarComponent {
     {
       name: 'Discover',
       type: 'router-path',
-      path: '../../../../../discover'
+      path: '/discover'
     },
     {
       name: 'About',
       type: 'router-path',
-      path: '../../../../../about'
+      path: '/about'
     },
     {
       name: 'Site Policies',
@@ -73,7 +73,7 @@ export class MainMobileSidebarComponent {
     {
       name: 'Privacy & Security',
       type: 'router-path',
-      path: '../../../../../privacy'
+      path: '/privacy'
     },
     {
       name: 'Changelog',


### PR DESCRIPTION
This PR fixes an issue with the mobile sidebar components that caused Discover, About, Privacy & Security, and Building Directory to be inaccessible on mobile.

Before:
![m](https://github.com/user-attachments/assets/8d26360a-a15f-4273-a3a9-daeaff634136)

After:
![ezgif-15ff6c6a3c693ed6](https://github.com/user-attachments/assets/a93bb575-4ebf-46f9-a4b2-86a8e0ad2677)



Resolves #634 
