### PR TITLE
fix(aggiemap-angular) Add Notes to Aggieland Saturday Popups

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -51,7 +51,7 @@ export const AggielandSaturdayEventColdLayerSources: LayerSource[] = [
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Event} Parking',
-      description: 'Type: {attributes.Type}\nLot Name: {attributes.name}'
+      description: 'Type: {attributes.Type}\nLot Name: {attributes.name}\nNotes: {attributes.Notes}'
     },
     visible: true,
     listMode: 'show',


### PR DESCRIPTION
This PR adds a notes section to the Aggieland Saturday popups, indicating what type of parking the feature is.

<img width="1691" height="948" alt="image" src="https://github.com/user-attachments/assets/4938706d-9a4a-4480-b5dc-80f8c1b53492" />
