### PR TITLE
fix(aggiemap-angular): Missing parking map links on Discover

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
@@ -223,7 +227,7 @@ export const AggielandSaturdayConfiguration: EventConfiguration = {
 
 export const AggielandSaturdayOptions: SpecialEventOptions = [];
 
-export const AggielandSaturdayEventTs: ISpecialEventRoot = {
+export const AggielandSaturdayEventTs: AggiemapCustomMapConfiguration = {
   configuration: AggielandSaturdayConfiguration,
   options: AggielandSaturdayOptions,
   sources: AggielandSaturdayEventColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -19,6 +19,26 @@ import { MensBasketball_Ts } from './mens-basketball.definitions';
 import { WomensBasketball_Ts } from './womens-basketball.definitions';
 import { MoveOut } from './move-out.definitions';
 import { GisDayTs } from './gis-day-map.definitions';
+import { ContractorParkingTs } from './contractor-parking.definitions';
+import { TimedParking_Ts } from './timed-parking.definitions';
+import { VendorParking_Ts } from './vendor-parking.definitions';
+import { MoveInTs } from './move-in.definitions';
+import { NightWeekendTs } from './night-weekend.definitions';
+import { StudentSelectableTs } from './student-selectable.definitions';
+import { FreshmanSelectableTs } from './freshman-parking.definitions';
+import { StaffSelectableTs } from './staff-selectable.definitions';
+import { BusinessParkingTs } from './business-parking.definitions';
+import { MotoristAssistanceTs } from './motorist-assistance.definitions';
+import { MediaParkingTs } from './media-parking.definitions';
+import { AccessibleParkingTs } from './accessible-parking.definitions';
+import { ServiceLoadingTs } from './service-and-loading-zones.definitions';
+import { RetireeParkingTs } from './retiree-parking.definitions';
+import { MaintenanceParkingTs } from './maintenance-parking.definitions';
+import { BaseballParkingTs } from './baseball-parking.definitions';
+import { SavannahBananasParkingTs } from './savannah-bananas.definitions';
+import { VisitorParkingTs } from './visitor-parking.definitions';
+import { MotorcycleParkingTs } from './motorcycle-parking.definitions';
+import { AVPParkingTs } from './avp-parking.definitions';
 import { NscParkingTs } from './nsc-parking.definitions';
 import { BreakSummerParkingTs } from './break-summer.definitions';
 
@@ -42,6 +62,27 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   RingDayEvent,
   WomensBasketball_Ts,
   GisDayTs,
+  MoveOut,
+  ContractorParkingTs,
+  TimedParking_Ts,
+  VendorParking_Ts,
+  MoveInTs,
+  NightWeekendTs,
+  StudentSelectableTs,
+  FreshmanSelectableTs,
+  StaffSelectableTs,
+  BusinessParkingTs,
+  MotoristAssistanceTs,
+  MediaParkingTs,
+  AccessibleParkingTs,
+  ServiceLoadingTs,
+  RetireeParkingTs,
+  MaintenanceParkingTs,
+  BaseballParkingTs,
+  SavannahBananasParkingTs,
+  VisitorParkingTs,
+  MotorcycleParkingTs,
+  AVPParkingTs,
   NscParkingTs,
   BreakSummerParkingTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
 import esri = __esri;
@@ -117,13 +121,13 @@ export const BreakSummerConfiguration: EventConfiguration = {
 
 export const BreakSummerOptions: SpecialEventOptions = [];
 
-export const BreakSummerParkingTs: ISpecialEventRoot = {
+export const BreakSummerParkingTs: AggiemapCustomMapConfiguration = {
   configuration: BreakSummerConfiguration,
   options: BreakSummerOptions,
   sources: BreakSummerColdLayerSources,
   type: 'special-event',
   references: BREAK_SUMMER_LAYERS,
-  
+
   discover: {
     id: BreakSummerConfiguration.id,
     name: BreakSummerConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/break_summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break_summer.definitions.ts
@@ -1,9 +1,13 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum BREAK_SUMMER_LAYERS {
-  BREAK_SUMMER_PARKING = 'Break-Summer Parking Lots',
+  BREAK_SUMMER_PARKING = 'Break-Summer Parking Lots'
 }
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
@@ -43,17 +47,18 @@ export const BreakSummerConfiguration: EventConfiguration = {
 
 export const BreakSummerOptions: SpecialEventOptions = [];
 
-export const BreakSummerTs: ISpecialEventRoot = {
+export const BreakSummerTs: AggiemapCustomMapConfiguration = {
   configuration: BreakSummerConfiguration,
   options: BreakSummerOptions,
   sources: BreakSummerColdLayerSources,
   references: BREAK_SUMMER_LAYERS,
+  type: 'general-map',
   discover: {
     id: BreakSummerConfiguration.id,
     name: BreakSummerConfiguration.name,
     description: 'Parking lot authorization information for Break and Summer.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['break', 'summer', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/break_summer.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break_summer.ts
@@ -1,9 +1,13 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum BREAK_SUMMER_LAYERS {
-  BREAK_SUMMER_PARKING = 'Break-Summer Parking Lots',
+  BREAK_SUMMER_PARKING = 'Break-Summer Parking Lots'
 }
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
@@ -43,17 +47,18 @@ export const BreakSummerConfiguration: EventConfiguration = {
 
 export const BreakSummerOptions: SpecialEventOptions = [];
 
-export const BreakSummerTs: ISpecialEventRoot = {
+export const BreakSummerTs: AggiemapCustomMapConfiguration = {
   configuration: BreakSummerConfiguration,
   options: BreakSummerOptions,
   sources: BreakSummerColdLayerSources,
   references: BREAK_SUMMER_LAYERS,
+  type: 'general-map',
   discover: {
     id: BreakSummerConfiguration.id,
     name: BreakSummerConfiguration.name,
     description: 'Parking lot authorization information for Break and Summer.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['break', 'summer', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
@@ -1,8 +1,11 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions, AggiemapCustomMapConfiguration } from '../interfaces/special-event.interface';
-
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 import esri = __esri;
 
@@ -184,12 +187,11 @@ export const MusterConfiguration: EventConfiguration = {
   applicationName: 'Muster Parking Map',
   shortApplicationName: 'Muster Map',
   eventDates: ['2026-04-21'],
-  mapCenter: [-96.34724, 30.60550],
+  mapCenter: [-96.34724, 30.6055],
   zoom: 16
 };
 
 export const MusterOptions: SpecialEventOptions = [];
-
 
 export const MusterTs: AggiemapCustomMapConfiguration = {
   type: 'special-event',
@@ -206,4 +208,3 @@ export const MusterTs: AggiemapCustomMapConfiguration = {
     keywords: ['muster', 'parking', 'transportation']
   }
 };
-

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking-definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking-definitions.ts
@@ -1,10 +1,14 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 
 export enum NSC_PARKING_LAYERS {
   LOT_SPECIFIC = 'Lot Specific Permit Required',
-  NSC_AUTHORIZED = 'NSC Permit Authorized',
+  NSC_AUTHORIZED = 'NSC Permit Authorized'
 }
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AVPVisBSUBVenNWRetNSCMed/MapServer';
@@ -79,17 +83,18 @@ export const NscParkingConfiguration: EventConfiguration = {
 
 export const NscParkingOptions: SpecialEventOptions = [];
 
-export const NscParkingTs: ISpecialEventRoot = {
+export const NscParkingTs: AggiemapCustomMapConfiguration = {
   configuration: NscParkingConfiguration,
   options: NscParkingOptions,
   sources: NscParkingColdLayerSources,
   references: NSC_PARKING_LAYERS,
+  type: 'general-map',
   discover: {
     id: NscParkingConfiguration.id,
     name: NscParkingConfiguration.name,
     description: 'Parking lot information for New Student Conference (NSC) permits.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     keywords: ['new student conference', 'nsc', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -1,6 +1,10 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
-import { EventConfiguration, ISpecialEventRoot, SpecialEventOptions } from '../interfaces/special-event.interface';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
 import { MarkdownPopupComponent } from '@tamu-gisc/aggiemap/ngx/popups';
 
 import esri = __esri;
@@ -77,7 +81,7 @@ export const NscParkingConfiguration: EventConfiguration = {
 
 export const NscParkingOptions: SpecialEventOptions = [];
 
-export const NscParkingTs: ISpecialEventRoot = {
+export const NscParkingTs: AggiemapCustomMapConfiguration = {
   configuration: NscParkingConfiguration,
   options: NscParkingOptions,
   sources: NscParkingColdLayerSources,

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -248,11 +248,11 @@ export interface IMapConfigurationBase {
   discover?: DiscoverMetadata | null;
 }
 
-export interface ISpecialEventRoot extends IMapConfigurationBase {
+interface ISpecialEventRoot extends IMapConfigurationBase {
   type: 'special-event';
 }
 
-export interface IGeneralMapRoot extends IMapConfigurationBase {
+interface IGeneralMapRoot extends IMapConfigurationBase {
   type: 'general-map';
 }
 


### PR DESCRIPTION
This pull request updates the event and parking map definitions to use a unified `AggiemapCustomMapConfiguration` type instead of the older `ISpecialEventRoot` and `IGeneralMapRoot` interfaces. It also standardizes and expands the event definitions to include additional parking-related configurations.

Key changes include:

**Type and Interface Refactoring:**
- Replaced usage of `ISpecialEventRoot` and `IGeneralMapRoot` with the consolidated `AggiemapCustomMapConfiguration` type across all event and parking map definition files, streamlining how event configurations are defined and referenced. [[1]](diffhunk://#diff-5684a1a91dc22806aa74156eb1964d28c7f6f84ec3e1ace70b65fb7897951b0bL226-R230) [[2]](diffhunk://#diff-86949053b24929a42735667813aaf7f20054d8a37985b5895c998ec94d977ae5L120-R124) [[3]](diffhunk://#diff-5e00769998b2534325962b3532ebcea7446f4c028c8eb2649da8700aa6a183f3L46-R61) [[4]](diffhunk://#diff-9dcd38be423fcb93fabb98f1d071a3a23d408ba66996489bffdd3d169a97bdc7L82-R97) [[5]](diffhunk://#diff-9262dbb40a69bb0e2e549cd533a2f6556509715b10c8382f009a70d20cfddc3dL80-R84) [[6]](diffhunk://#diff-81db11ca4a985ea58a741897aa8b2e50c846f84fd9a6387aeb1ece4c9a8cfb0dL251-R255)

**Import and Export Updates:**
- Updated import statements in all relevant files to import `AggiemapCustomMapConfiguration` instead of the removed interfaces. [[1]](diffhunk://#diff-5684a1a91dc22806aa74156eb1964d28c7f6f84ec3e1ace70b65fb7897951b0bL3-R7) [[2]](diffhunk://#diff-86949053b24929a42735667813aaf7f20054d8a37985b5895c998ec94d977ae5L3-R7) [[3]](diffhunk://#diff-5e00769998b2534325962b3532ebcea7446f4c028c8eb2649da8700aa6a183f3L3-R10) [[4]](diffhunk://#diff-33865c7c8d88aa49036c064b3e9358adaa69d966e02733e8c2129cb5c741e755L4-R8) [[5]](diffhunk://#diff-9dcd38be423fcb93fabb98f1d071a3a23d408ba66996489bffdd3d169a97bdc7L3-R11) [[6]](diffhunk://#diff-9262dbb40a69bb0e2e549cd533a2f6556509715b10c8382f009a70d20cfddc3dL3-R7)

**Event Definitions Expansion:**
- Added a large number of new parking configuration definitions (e.g., `ContractorParkingTs`, `TimedParking_Ts`, `VendorParking_Ts`, etc.) to the `all.definitions.ts` file and included them in the exported `EventDefinitions` array, broadening the supported event and parking scenarios. [[1]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5R22-R41) [[2]](diffhunk://#diff-c3334ae7a194f007cae1224ae2289f243ed1a1af6651b726d92a8b88ac5696d5R65-R85)

**Metadata and Configuration Adjustments:**
- Updated metadata for several configurations, such as changing the `type` and `discover.type` fields from `'event'` to `'parking'` or `'general-map'` where appropriate, and made minor corrections (e.g., fixing number formatting in coordinates). [[1]](diffhunk://#diff-5e00769998b2534325962b3532ebcea7446f4c028c8eb2649da8700aa6a183f3L46-R61) [[2]](diffhunk://#diff-33865c7c8d88aa49036c064b3e9358adaa69d966e02733e8c2129cb5c741e755L187-L193) [[3]](diffhunk://#diff-33865c7c8d88aa49036c064b3e9358adaa69d966e02733e8c2129cb5c741e755L209) [[4]](diffhunk://#diff-9dcd38be423fcb93fabb98f1d071a3a23d408ba66996489bffdd3d169a97bdc7L82-R97)

**Minor Cleanups:**
- Removed unnecessary blank lines and made minor formatting adjustments for consistency.

These changes modernize and standardize how event and parking map configurations are handled, making the codebase easier to maintain and extend.