### PR TITLE
fix(aggiemap-angular): Manually set map center and zoom for Big Event

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -202,7 +202,9 @@ export const BigEventConfiguration: EventConfiguration = {
   name: 'Big Event',
   applicationName: 'Big Event Transportation Map',
   shortApplicationName: 'Big Event Map',
-  eventDates: ['2026-03-21']
+  eventDates: ['2026-03-21'],
+  mapCenter: [-96.3463, 30.6059],
+  zoom: 17
 };
 
 export const BigEventOptions: SpecialEventOptions = [


### PR DESCRIPTION
This PR resolves an issue where the Big Event map was centered in an incorrect location in the ocean:
<img width="1731" height="1001" alt="image" src="https://github.com/user-attachments/assets/a52b0b14-9fba-4fd8-a5a9-253971790dbc" />


This PR now centers it around Reed Arena with a default zoom level of 17.

<img width="2534" height="1219" alt="image" src="https://github.com/user-attachments/assets/91d8bc02-6fb9-41d3-a8a9-e21416547703" />
