### PR TITLE
feat(aggiemap-angular) Update Physics Fest map

### DIFF
--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -1,13 +1,34 @@
 <div class="legend-collection">
-  <div [ngSwitch]="group.children">
-    <!-- If there are no children in the current group, then iterate through them and list them out -->
-    <div *ngSwitchCase="0">
-      <tamu-gisc-legend-element *ngFor="let element of group.legendElements; trackBy: trackByLegendElement" [element]="element" [layer]="group.layer" [groupTitle]="group.title" [deduplicateChildren]="deduplicate" [respectDefinitionExpression]="respectDefinitionExpression"></tamu-gisc-legend-element>
-    </div>
+  <div
+    class="collection-group-title"
+    *ngIf="hasChildren"
+    tabindex="0"
+    role="button"
+    (click)="toggleExpanded()"
+    (keydown.enter)="toggleExpanded()"
+    (keydown.space)="toggleExpanded(); $event.preventDefault()"
+  >
+    <span class="material-icons">{{ isExpanded ? 'expand_more' : 'chevron_right' }}</span>
+    <span class="collection-group-title-text">{{ group.title }}</span>
+  </div>
 
-    <!-- If the current group has more children, render another collection group. This represents nested layers/groups. -->
-    <div *ngSwitchDefault>
-      <tamu-gisc-legend-collection *ngFor="let group of group.children" [group]="group" [layer]="group.layer" [deduplicate]="deduplicate" [respectDefinitionExpression]="respectDefinitionExpression"></tamu-gisc-legend-collection>
-    </div>
+  <div class="collection-group-content" *ngIf="!hasChildren || isExpanded">
+    <tamu-gisc-legend-element
+      *ngFor="let element of legendElements; trackBy: trackByLegendElement"
+      [element]="element"
+      [layer]="group.layer"
+      [groupTitle]="group.title"
+      [deduplicateChildren]="deduplicate"
+      [respectDefinitionExpression]="respectDefinitionExpression"
+    ></tamu-gisc-legend-element>
+
+    <tamu-gisc-legend-collection
+      *ngFor="let childGroup of childGroups; trackBy: trackByLegendGroup"
+      [group]="childGroup"
+      [layer]="childGroup.layer"
+      [deduplicate]="deduplicate"
+      [respectDefinitionExpression]="respectDefinitionExpression"
+      [allowVisibilityToggle]="allowVisibilityToggle"
+    ></tamu-gisc-legend-collection>
   </div>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -20,6 +20,7 @@
       [groupTitle]="group.title"
       [deduplicateChildren]="deduplicate"
       [respectDefinitionExpression]="respectDefinitionExpression"
+      [hideGroupHeader]="hideElementGroupHeaders"
     ></tamu-gisc-legend-element>
 
     <tamu-gisc-legend-collection
@@ -29,6 +30,8 @@
       [deduplicate]="deduplicate"
       [respectDefinitionExpression]="respectDefinitionExpression"
       [allowVisibilityToggle]="allowVisibilityToggle"
+      [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
+      [hideElementGroupHeaders]="childHideElementGroupHeaders"
     ></tamu-gisc-legend-collection>
   </div>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.scss
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.scss
@@ -5,3 +5,26 @@
   @include flex-direction(column);
   font-size: 0.875rem;
 }
+
+.collection-group-title {
+  @include flexbox();
+  @include flex-direction(row);
+  @include align-items(center);
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  user-select: none;
+
+  .material-icons {
+    font-size: 1.1rem;
+    margin-right: 0.25rem;
+  }
+}
+
+.collection-group-title-text {
+  flex: 1;
+}
+
+.collection-group-content {
+  margin-left: 0.5rem;
+}

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.spec.ts
@@ -21,4 +21,36 @@ describe('LegendCollectionComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('toggles expanded state for groups with children', () => {
+    component.group = {
+      title: 'Parent Group',
+      children: [{ title: 'Child Group' }]
+    } as unknown as __esri.ActiveLayerInfo;
+
+    expect(component.hasChildren).toBe(true);
+    expect(component.expanded).toBe(true);
+
+    component.toggleExpanded();
+    expect(component.expanded).toBe(false);
+
+    component.toggleExpanded();
+    expect(component.expanded).toBe(true);
+  });
+
+  it('toggles layer visibility', () => {
+    component.group = {
+      title: 'Parent Group',
+      children: [{ title: 'Child Group' }],
+      layer: { visible: true }
+    } as unknown as __esri.ActiveLayerInfo;
+    component.allowVisibilityToggle = true;
+
+    expect(component.isLayerVisible).toBe(true);
+    expect(component.isExpanded).toBe(true);
+
+    component.toggleExpanded();
+    expect(component.isLayerVisible).toBe(false);
+    expect(component.isExpanded).toBe(false);
+  });
 });

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -28,10 +28,35 @@ export class LegendCollectionComponent {
   @Input()
   public allowVisibilityToggle = false;
 
+  @Input()
+  public combineChildrenUnderPrimary = false;
+
+  @Input()
+  public hideElementGroupHeaders = false;
+
   public expanded = true;
 
   public get childGroups(): IActiveLayerInfo[] {
-    return this._toArray<IActiveLayerInfo>(this.group?.children);
+    const children = this._toArray<IActiveLayerInfo>(this.group?.children);
+
+    if (!this.combineChildrenUnderPrimary || !this._isPhysicsFestivalGroup(this.group?.layer?.id)) {
+      return children;
+    }
+
+    return children
+      .map((child, index) => ({
+        child,
+        index,
+        priority: this._getPhysicsFestivalChildPriority(child?.title)
+      }))
+      .sort((a, b) => {
+        if (a.priority !== b.priority) {
+          return a.priority - b.priority;
+        }
+
+        return a.index - b.index;
+      })
+      .map(({ child }) => child);
   }
 
   public get legendElements(): esri.LegendElement[] {
@@ -40,6 +65,18 @@ export class LegendCollectionComponent {
 
   public get hasChildren(): boolean {
     return this.childGroups.length > 0;
+  }
+
+  public get childHideElementGroupHeaders(): boolean {
+    if (
+      this.combineChildrenUnderPrimary &&
+      this.hasChildren &&
+      this._isPhysicsFestivalGroup(this.group?.layer?.id)
+    ) {
+      return true;
+    }
+
+    return this.hideElementGroupHeaders;
   }
 
   public toggleExpanded(): void {
@@ -102,6 +139,24 @@ export class LegendCollectionComponent {
     }
 
     return [];
+  }
+
+  private _isPhysicsFestivalGroup(layerId?: string): boolean {
+    return layerId?.startsWith('phys-eng-festival-') ?? false;
+  }
+
+  private _getPhysicsFestivalChildPriority(title?: string): number {
+    const normalizedTitle = title?.toLowerCase() ?? '';
+
+    if (normalizedTitle.includes('drop off') || normalizedTitle.includes('dropoff') || normalizedTitle.includes('pick up')) {
+      return 1;
+    }
+
+    if (normalizedTitle.includes('route') || normalizedTitle.includes('path')) {
+      return 2;
+    }
+
+    return 0;
   }
 }
 

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -25,6 +25,47 @@ export class LegendCollectionComponent {
   @Input()
   public respectDefinitionExpression = false;
 
+  @Input()
+  public allowVisibilityToggle = false;
+
+  public expanded = true;
+
+  public get childGroups(): IActiveLayerInfo[] {
+    return this._toArray<IActiveLayerInfo>(this.group?.children);
+  }
+
+  public get legendElements(): esri.LegendElement[] {
+    return this._toArray<esri.LegendElement>(this.group?.legendElements);
+  }
+
+  public get hasChildren(): boolean {
+    return this.childGroups.length > 0;
+  }
+
+  public toggleExpanded(): void {
+    if (!this.hasChildren) {
+      return;
+    }
+
+    if (this.allowVisibilityToggle && this.group?.layer) {
+      this.group.layer.visible = !this.isLayerVisible;
+    } else {
+      this.expanded = !this.expanded;
+    }
+  }
+
+  public get isLayerVisible(): boolean {
+    return this.group?.layer?.visible ?? true;
+  }
+
+  public get isExpanded(): boolean {
+    if (this.allowVisibilityToggle && this.hasChildren) {
+      return this.isLayerVisible;
+    }
+
+    return this.expanded;
+  }
+
   /**
    * Function used to track legend elements in the ngFor loop to prevent unnecessary re-renders.
    *
@@ -35,6 +76,32 @@ export class LegendCollectionComponent {
     const identifier = el?.infos ? el.infos?.map((i) => `${i.label}-${i.value}`).join(',') : null;
 
     return identifier;
+  }
+
+  public trackByLegendGroup(index: number, group: IActiveLayerInfo): string {
+    return `${group?.layer?.id || 'layer'}-${group?.title || index}`;
+  }
+
+  private _toArray<T>(collection: unknown): T[] {
+    if (!collection) {
+      return [];
+    }
+
+    if (Array.isArray(collection)) {
+      return collection as T[];
+    }
+
+    const collectionAsObject = collection as { toArray?: () => T[]; length?: number; getItemAt?: (index: number) => T };
+
+    if (typeof collectionAsObject.toArray === 'function') {
+      return collectionAsObject.toArray();
+    }
+
+    if (typeof collectionAsObject.length === 'number' && typeof collectionAsObject.getItemAt === 'function') {
+      return Array.from({ length: collectionAsObject.length }, (_, index) => collectionAsObject.getItemAt(index));
+    }
+
+    return [];
   }
 }
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -29,6 +29,7 @@ of the table -->
               [groupTitle]="info.title"
               [deduplicateChildren]="deduplicateChildren"
               [respectDefinitionExpression]="respectDefinitionExpression"
+              [hideGroupHeader]="hideGroupHeader"
             ></tamu-gisc-legend-element>
           </div>
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -2,17 +2,34 @@
   <!-- If there is only one legend element, don't apply a group title. Will apply the parent label on the
 single child so that there aren't groups with a single child, because it will break the cleanliness
 of the table -->
-  <div class="element-parent-name" *ngIf="element.infos && element.infos.length > 1"><span class="material-icons">expand_more</span> {{ groupTitle }}</div>
+  <div
+    class="element-parent-name"
+    *ngIf="showGroupHeader"
+    tabindex="0"
+    role="button"
+    (click)="toggleExpanded()"
+    (keydown.enter)="toggleExpanded()"
+    (keydown.space)="toggleExpanded(); $event.preventDefault()"
+  >
+    <span class="material-icons">{{ expanded ? 'expand_more' : 'chevron_right' }}</span> {{ groupTitle }}
+  </div>
 
   <!-- Switch through the different element types. The default is a "not supported" message printout. -->
-  <ng-container [ngSwitch]="element.type">
+  <ng-container [ngSwitch]="element?.type">
     <!-- For SymbolTable element type -->
     <div *ngSwitchCase="'symbol-table'" class="element-group">
-      <div class="legend-info" *ngFor="let info of infos | async">
+      <div class="legend-info" *ngFor="let info of infos | async" [hidden]="showGroupHeader && !expanded">
         <div [ngSwitch]="info.type">
           <!-- Support for infos with nested infos. This case will continue to recursively iterate through n-nested infos until reaching the last node. -->
           <div *ngSwitchCase="'symbol-table'">
-            <tamu-gisc-legend-element *ngFor="let subInfo of info?.infos" [element]="subInfo" [groupTitle]="info.title"></tamu-gisc-legend-element>
+            <tamu-gisc-legend-element
+              *ngFor="let subInfo of info?.infos"
+              [element]="subInfo"
+              [layer]="layer"
+              [groupTitle]="info.title"
+              [deduplicateChildren]="deduplicateChildren"
+              [respectDefinitionExpression]="respectDefinitionExpression"
+            ></tamu-gisc-legend-element>
           </div>
 
           <!-- This case will be reached of every info node and will terminate either with an info.preview or info.src -->
@@ -26,13 +43,13 @@ of the table -->
 
         <!-- Apply the legend item from the parent group or child -->
         <div [ngSwitch]="element.infos?.length">
-          <div *ngSwitchCase="1" class="group-title">{{groupTitle}}</div>
-          <div *ngSwitchDefault class="label">{{info?.label}}</div>
+          <div *ngSwitchCase="1" class="group-title">{{ groupTitle }}</div>
+          <div *ngSwitchDefault class="label">{{ info?.label }}</div>
         </div>
       </div>
     </div>
 
     <!-- Default printout -->
-    <div *ngSwitchDefault>Unsupported legend element type: {{element.type}}</div>
+    <div *ngSwitchDefault>Unsupported legend element type: {{ element?.type }}</div>
   </ng-container>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.scss
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.scss
@@ -4,8 +4,10 @@
   @include flexbox();
   @include flex-direction(row);
   @include align-items(center);
+  cursor: pointer;
   font-weight: 600;
   margin-bottom: 0.9rem;
+  user-select: none;
 
   // Add a left margin to any subsequent info group
   & ~ div {

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -28,4 +28,16 @@ describe('LegendElementComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('toggles expanded state when legend element is grouped', () => {
+    component.element = {
+      infos: [{ label: 'A', value: 'A' }, { label: 'B', value: 'B' }]
+    } as unknown as __esri.LegendElement;
+
+    expect(component.showGroupHeader).toBe(true);
+    expect(component.expanded).toBe(true);
+
+    component.toggleExpanded();
+    expect(component.expanded).toBe(false);
+  });
 });

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -62,8 +62,26 @@ export class LegendElementComponent implements OnInit {
   public respectDefinitionExpression = false;
 
   public infos: Observable<Array<LegendInfo>>;
+  public expanded = true;
+
+  public get showGroupHeader(): boolean {
+    const infos = this.element?.infos as { length?: number } | undefined;
+
+    return typeof infos?.length === 'number' && infos.length > 1;
+  }
+
+  public toggleExpanded(): void {
+    if (this.showGroupHeader) {
+      this.expanded = !this.expanded;
+    }
+  }
 
   public async ngOnInit(): Promise<void> {
+    if (!this.element?.infos) {
+      this.infos = of([]);
+      return;
+    }
+
     this.infos = iif(
       () => {
         return this.deduplicateChildren;
@@ -231,7 +249,7 @@ export class LegendElementComponent implements OnInit {
 
     // If there are no operable fields, return early
     if (operableFields.length === 0) {
-      return;
+      return of(info);
     }
 
     // Unique value expressions can at most be a concatenation of 3 fields, with exact value matches. This means

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -61,10 +61,17 @@ export class LegendElementComponent implements OnInit {
   @Input()
   public respectDefinitionExpression = false;
 
+  @Input()
+  public hideGroupHeader = false;
+
   public infos: Observable<Array<LegendInfo>>;
   public expanded = true;
 
   public get showGroupHeader(): boolean {
+    if (this.hideGroupHeader) {
+      return false;
+    }
+
     const infos = this.element?.infos as { length?: number } | undefined;
 
     return typeof infos?.length === 'number' && infos.length > 1;

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
@@ -12,5 +12,6 @@
     [deduplicate]="deduplicate"
     [respectDefinitionExpression]="respectDefinitionExpression"
     [allowVisibilityToggle]="allowVisibilityToggle"
+    [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
   ></tamu-gisc-legend-collection>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
@@ -5,5 +5,12 @@
 
 <div class="sidebar-component-content-container">
   <!-- Followed by dynamic legend items -->
-  <tamu-gisc-legend-collection *ngFor="let group of legend | async" [group]="group" [layer]="group.layer" [deduplicate]="deduplicate" [respectDefinitionExpression]="respectDefinitionExpression"></tamu-gisc-legend-collection>
+  <tamu-gisc-legend-collection
+    *ngFor="let group of legend | async"
+    [group]="group"
+    [layer]="group.layer"
+    [deduplicate]="deduplicate"
+    [respectDefinitionExpression]="respectDefinitionExpression"
+    [allowVisibilityToggle]="allowVisibilityToggle"
+  ></tamu-gisc-legend-collection>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -33,6 +33,9 @@ export class LegendComponent implements OnInit, OnDestroy {
   @Input()
   public excludedLayerIds: string[] = [];
 
+  @Input()
+  public combineChildrenUnderPrimary = false;
+
   public legend: Observable<Array<esri.ActiveLayerInfo>>;
 
   public responsive: ResponsiveSnapshot;
@@ -55,6 +58,8 @@ export class LegendComponent implements OnInit, OnDestroy {
       this.respectDefinitionExpression = routeData['respectDefinitionExpression'] ?? this.respectDefinitionExpression;
       this.allowVisibilityToggle = routeData['allowVisibilityToggle'] ?? this.allowVisibilityToggle;
       this.excludedLayerIds = routeData['excludedLayerIds'] ?? this.excludedLayerIds;
+      this.combineChildrenUnderPrimary =
+        routeData['combineChildrenUnderPrimary'] ?? this.combineChildrenUnderPrimary;
     }
 
     this.legend = this.legendService.legend({

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -27,6 +27,12 @@ export class LegendComponent implements OnInit, OnDestroy {
   @Input()
   public respectDefinitionExpression = false;
 
+  @Input()
+  public allowVisibilityToggle = false;
+
+  @Input()
+  public excludedLayerIds: string[] = [];
+
   public legend: Observable<Array<esri.ActiveLayerInfo>>;
 
   public responsive: ResponsiveSnapshot;
@@ -47,9 +53,14 @@ export class LegendComponent implements OnInit, OnDestroy {
     if (routeData) {
       this.deduplicate = routeData['deduplicate'] ?? this.deduplicate;
       this.respectDefinitionExpression = routeData['respectDefinitionExpression'] ?? this.respectDefinitionExpression;
+      this.allowVisibilityToggle = routeData['allowVisibilityToggle'] ?? this.allowVisibilityToggle;
+      this.excludedLayerIds = routeData['excludedLayerIds'] ?? this.excludedLayerIds;
     }
 
-    this.legend = this.legendService.legend();
+    this.legend = this.legendService.legend({
+      respectLayerVisibility: !this.allowVisibilityToggle,
+      excludedLayerIds: this.excludedLayerIds
+    });
 
     this.responsive = this.responsiveService.snapshot;
   }

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -18,11 +18,15 @@ export class LegendService {
     private env: EnvironmentService
   ) {}
 
-  public legend() {
+  public legend(options?: LegendOptions) {
+    const respectLayerVisibility = options?.respectLayerVisibility ?? true;
+    const excludedLayerIds = new Set(options?.excludedLayerIds ?? []);
+
     return combineLatest([this.moduleProvider.require(['LegendViewModel']), this.mapService.store]).pipe(
       switchMap(([[LegendViewModel], instances]: [[esri.LegendViewModelConstructor], MapServiceInstance]) => {
         const model = new LegendViewModel({
-          view: instances.view
+          view: instances.view,
+          respectLayerVisibility
         });
 
         // Create add/remove watch handlers for the activeLayerInfos property of the view model.
@@ -41,12 +45,20 @@ export class LegendService {
         return fromEventPattern(add, remove).pipe(
           startWith({ target: model.activeLayerInfos }),
           map((event: IActiveLayerInfosChangeEvent) => {
-            return event.target.filter((l) => l.layer.listMode !== 'hide').toArray();
+            return event.target
+              .filter((l) => l.layer.listMode !== 'hide')
+              .filter((l) => !excludedLayerIds.has(l.layer.id))
+              .toArray();
           })
         );
       })
     );
   }
+}
+
+interface LegendOptions {
+  respectLayerVisibility?: boolean;
+  excludedLayerIds?: string[];
 }
 
 export interface IActiveLayerInfosChangeEvent {

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -1,4 +1,4 @@
-import { LayerSource } from '@tamu-gisc/common/types';
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -8,68 +8,317 @@ import {
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
 
+import esri = __esri;
+
 export enum PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS {
-  FESTIVAL_AREAS = 'phys-eng-festival-areas',
-  PEDESTRIAN_PATH = 'phys-eng-festival-pedestrian-path'
+  GENERAL_PARKING_GROUP = 'phys-eng-festival-general-parking-group',
+  GENERAL_PARKING = 'phys-eng-festival-general-parking',
+  GENERAL_PARKING_PEDESTRIAN_PATH = 'phys-eng-festival-general-parking-pedestrian-path',
+  EASTBOUND_UNIVERSITY_GROUP = 'phys-eng-festival-eastbound-university-group',
+  EASTBOUND_BUS_PARKING = 'phys-eng-festival-eastbound-bus-parking',
+  EASTBOUND_BUS_DROPOFF = 'phys-eng-festival-eastbound-bus-dropoff',
+  EASTBOUND_BUS_ROUTE = 'phys-eng-festival-eastbound-bus-route',
+  EASTBOUND_PEDESTRIAN_PATH = 'phys-eng-festival-eastbound-pedestrian-path',
+  WESTBOUND_UNIVERSITY_GROUP = 'phys-eng-festival-westbound-university-group',
+  WESTBOUND_BUS_PARKING = 'phys-eng-festival-westbound-bus-parking',
+  WESTBOUND_BUS_DROPOFF = 'phys-eng-festival-westbound-bus-dropoff',
+  WESTBOUND_BUS_ROUTE = 'phys-eng-festival-westbound-bus-route',
+  WESTBOUND_PEDESTRIAN_PATH = 'phys-eng-festival-westbound-pedestrian-path'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Physics_Fest/MapServer';
+const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Physics_Fest/MapServer';
+
+type AutoCastSimpleLineSymbol = { type: 'simple-line' } & esri.SimpleLineSymbolProperties;
+
+const GREEN_PATH_ARROW_SYMBOL: AutoCastSimpleLineSymbol = {
+  type: 'simple-line',
+  color: 'rgb(56, 168, 0)',
+  width: 2,
+  marker: {
+    style: 'arrow',
+    color: 'rgb(56, 168, 0)',
+    placement: 'end'
+  }
+};
+
+const EASTBOUND_BUS_ROUTE_ARROW_SYMBOL: AutoCastSimpleLineSymbol = {
+  type: 'simple-line',
+  color: 'blue',
+  width: 3.5,
+  marker: {
+    style: 'arrow',
+    color: 'blue',
+    placement: 'end'
+  }
+};
+
+const WESTBOUND_BUS_ROUTE_ARROW_SYMBOL: AutoCastSimpleLineSymbol = {
+  type: 'simple-line',
+  color: 'red',
+  width: 3.5,
+  marker: {
+    style: 'arrow',
+    color: 'red',
+    placement: 'end'
+  }
+};
+
+const GREEN_ARROW_LINE_NATIVE: NonNullable<FeatureLayerSourceProperties['native']> = {
+  outFields: ['*'],
+  renderer: {
+    type: 'simple',
+    symbol: GREEN_PATH_ARROW_SYMBOL
+  }
+};
+
+const EASTBOUND_BUS_ROUTE_LINE_NATIVE: NonNullable<FeatureLayerSourceProperties['native']> = {
+  outFields: ['*'],
+  renderer: {
+    type: 'simple',
+    symbol: EASTBOUND_BUS_ROUTE_ARROW_SYMBOL
+  }
+};
+
+const WESTBOUND_BUS_ROUTE_LINE_NATIVE: NonNullable<FeatureLayerSourceProperties['native']> = {
+  outFields: ['*'],
+  renderer: {
+    type: 'simple',
+    symbol: WESTBOUND_BUS_ROUTE_ARROW_SYMBOL
+  }
+};
 
 export const PhysEngFestDefinitions = {
-  FESTIVAL_AREAS: {
-    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.FESTIVAL_AREAS,
-    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.FESTIVAL_AREAS,
-    name: 'Physics & Engineering Festival Areas',
+  GENERAL_PARKING_GROUP: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING_GROUP,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING_GROUP,
+    name: 'General Parking',
     url: `${eventUrl}/0`
   },
-  PEDESTRIAN_PATHS: {
-    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.PEDESTRIAN_PATH,
-    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.PEDESTRIAN_PATH,
-    name: 'Pedestrian Path',
+  GENERAL_PARKING: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING,
+    name: 'Physics/Engineering Festival - General Parking',
     url: `${eventUrl}/1`
+  },
+  GENERAL_PARKING_PEDESTRIAN_PATH: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING_PEDESTRIAN_PATH,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING_PEDESTRIAN_PATH,
+    name: 'Pedestrian Path - General Parking',
+    url: `${eventUrl}/2`
+  },
+  EASTBOUND_UNIVERSITY_GROUP: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_UNIVERSITY_GROUP,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_UNIVERSITY_GROUP,
+    name: 'Buses Entering from Eastbound University Dr',
+    url: `${eventUrl}/3`
+  },
+  EASTBOUND_BUS_PARKING: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_PARKING,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_PARKING,
+    name: 'Physics/Engineering Festival - Bus Parking',
+    url: `${eventUrl}/4`
+  },
+  EASTBOUND_BUS_DROPOFF: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_DROPOFF,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_DROPOFF,
+    name: 'Eastbound Bus Drop Off/Pick Up Location',
+    url: `${eventUrl}/5`
+  },
+  EASTBOUND_BUS_ROUTE: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_ROUTE,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_BUS_ROUTE,
+    name: 'Bus Route - Buses Entering from Eastbound University Dr',
+    url: `${eventUrl}/6`
+  },
+  EASTBOUND_PEDESTRIAN_PATH: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_PEDESTRIAN_PATH,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_PEDESTRIAN_PATH,
+    name: 'Pedestrian Path - Buses Entering from Eastbound University Dr',
+    url: `${eventUrl}/7`
+  },
+  WESTBOUND_UNIVERSITY_GROUP: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_UNIVERSITY_GROUP,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_UNIVERSITY_GROUP,
+    name: 'Buses Entering from Westbound University Dr',
+    url: `${eventUrl}/8`
+  },
+  WESTBOUND_BUS_PARKING: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_PARKING,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_PARKING,
+    name: 'Physics/Engineering Festival - Bus Parking',
+    url: `${eventUrl}/9`
+  },
+  WESTBOUND_BUS_DROPOFF: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_DROPOFF,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_DROPOFF,
+    name: 'Westbound Bus Drop Off/Pick Up Location',
+    url: `${eventUrl}/10`
+  },
+  WESTBOUND_BUS_ROUTE: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_ROUTE,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_BUS_ROUTE,
+    name: 'Bus Route - Buses Entering from Westbound University',
+    url: `${eventUrl}/11`
+  },
+  WESTBOUND_PEDESTRIAN_PATH: {
+    id: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_PEDESTRIAN_PATH,
+    layerId: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_PEDESTRIAN_PATH,
+    name: 'Pedestrian Path - Buses Entering from Westbound University',
+    url: `${eventUrl}/12`
   }
+};
+
+const PhysicsAndEngineeringFestivalLayerReferences: Record<string, string> = {
+  GENERAL_PARKING_GROUP: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.GENERAL_PARKING_GROUP,
+  EASTBOUND_UNIVERSITY_GROUP: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.EASTBOUND_UNIVERSITY_GROUP,
+  WESTBOUND_UNIVERSITY_GROUP: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS.WESTBOUND_UNIVERSITY_GROUP
 };
 
 export const PhysEngFestivalColdLayerSources: LayerSource[] = [
   {
-    type: 'feature',
-    id: PhysEngFestDefinitions.FESTIVAL_AREAS.id,
-    title: PhysEngFestDefinitions.FESTIVAL_AREAS.name,
-    url: PhysEngFestDefinitions.FESTIVAL_AREAS.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
+    type: 'group',
+    id: PhysEngFestDefinitions.GENERAL_PARKING_GROUP.id,
+    title: PhysEngFestDefinitions.GENERAL_PARKING_GROUP.name,
     visible: true,
     listMode: 'show',
-    popupData: {
-      name: 'attributes.Type',
-      description: 'attributes.name'
-    },
+    sources: [
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.GENERAL_PARKING.id,
+        title: PhysEngFestDefinitions.GENERAL_PARKING.name,
+        url: PhysEngFestDefinitions.GENERAL_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.GENERAL_PARKING_PEDESTRIAN_PATH.id,
+        title: PhysEngFestDefinitions.GENERAL_PARKING_PEDESTRIAN_PATH.name,
+        url: PhysEngFestDefinitions.GENERAL_PARKING_PEDESTRIAN_PATH.url,
+        popupComponent: MarkdownPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: GREEN_ARROW_LINE_NATIVE
+      }
+    ],
     native: {
-      outFields: ['*']
+      listMode: 'hide-children'
     }
   },
   {
-    type: 'feature',
-    id: PhysEngFestDefinitions.PEDESTRIAN_PATHS.id,
-    title: PhysEngFestDefinitions.PEDESTRIAN_PATHS.name,
-    url: PhysEngFestDefinitions.PEDESTRIAN_PATHS.url,
-    popupComponent: MarkdownPopupComponent,
+    type: 'group',
+    id: PhysEngFestDefinitions.EASTBOUND_UNIVERSITY_GROUP.id,
+    title: PhysEngFestDefinitions.EASTBOUND_UNIVERSITY_GROUP.name,
     visible: true,
-    native: {
-      listMode: 'show',
-      outFields: ['*'],
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'simple-line',
-          color: 'rgb(56, 168, 0)',
-          width: 2.5,
-          marker: {
-            style: 'arrow',
-            color: 'rgb(56, 168, 0)',
-            placement: 'end'
-          }
+    listMode: 'show',
+    sources: [
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.EASTBOUND_BUS_PARKING.id,
+        title: PhysEngFestDefinitions.EASTBOUND_BUS_PARKING.name,
+        url: PhysEngFestDefinitions.EASTBOUND_BUS_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
         }
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.id,
+        title: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.name,
+        url: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.id,
+        title: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.name,
+        url: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.url,
+        popupComponent: MarkdownPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: EASTBOUND_BUS_ROUTE_LINE_NATIVE
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.EASTBOUND_PEDESTRIAN_PATH.id,
+        title: PhysEngFestDefinitions.EASTBOUND_PEDESTRIAN_PATH.name,
+        url: PhysEngFestDefinitions.EASTBOUND_PEDESTRIAN_PATH.url,
+        popupComponent: MarkdownPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: GREEN_ARROW_LINE_NATIVE
       }
+    ],
+    native: {
+      listMode: 'hide-children'
+    }
+  },
+  {
+    type: 'group',
+    id: PhysEngFestDefinitions.WESTBOUND_UNIVERSITY_GROUP.id,
+    title: PhysEngFestDefinitions.WESTBOUND_UNIVERSITY_GROUP.name,
+    visible: true,
+    listMode: 'show',
+    sources: [
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.WESTBOUND_BUS_PARKING.id,
+        title: PhysEngFestDefinitions.WESTBOUND_BUS_PARKING.name,
+        url: PhysEngFestDefinitions.WESTBOUND_BUS_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.id,
+        title: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.name,
+        url: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.id,
+        title: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.name,
+        url: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.url,
+        popupComponent: MarkdownPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: WESTBOUND_BUS_ROUTE_LINE_NATIVE
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.WESTBOUND_PEDESTRIAN_PATH.id,
+        title: PhysEngFestDefinitions.WESTBOUND_PEDESTRIAN_PATH.name,
+        url: PhysEngFestDefinitions.WESTBOUND_PEDESTRIAN_PATH.url,
+        popupComponent: MarkdownPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: GREEN_ARROW_LINE_NATIVE
+      }
+    ],
+    native: {
+      listMode: 'hide-children'
     }
   }
 ];
@@ -79,7 +328,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   name: 'Physics and Engineering Festival',
   applicationName: 'Physics and Engineering Festival Transportation Map',
   shortApplicationName: 'Physics and Engineering Festival Map',
-  introductionText: 'Get the best parking information for the',
+  introductionText: 'Get the best parking information for the Physics and Engineering Festival.',
   eventDates: ['2026-03-28'],
   mapCenter: [-96.33771, 30.62143],
   zoom: 17
@@ -92,7 +341,7 @@ export const PhysicsAndEngineeringFestivalTs: AggiemapCustomMapConfiguration = {
   configuration: PhysicsAndEngineeringFestivalConfiguration,
   options: PhysicsAndEngineeringFestivalOptions,
   sources: PhysEngFestivalColdLayerSources,
-  references: PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS,
+  references: PhysicsAndEngineeringFestivalLayerReferences,
   discover: {
     id: PhysicsAndEngineeringFestivalConfiguration.id,
     name: PhysicsAndEngineeringFestivalConfiguration.name,

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -230,18 +230,6 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
       },
       {
         type: 'feature',
-        id: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.id,
-        title: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.name,
-        url: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      },
-      {
-        type: 'feature',
         id: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.id,
         title: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.name,
         url: PhysEngFestDefinitions.EASTBOUND_BUS_ROUTE.url,
@@ -259,6 +247,18 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
         visible: true,
         listMode: 'show',
         native: GREEN_ARROW_LINE_NATIVE
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.id,
+        title: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.name,
+        url: PhysEngFestDefinitions.EASTBOUND_BUS_DROPOFF.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       }
     ],
     native: {
@@ -286,18 +286,6 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
       },
       {
         type: 'feature',
-        id: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.id,
-        title: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.name,
-        url: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      },
-      {
-        type: 'feature',
         id: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.id,
         title: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.name,
         url: PhysEngFestDefinitions.WESTBOUND_BUS_ROUTE.url,
@@ -315,6 +303,18 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
         visible: true,
         listMode: 'show',
         native: GREEN_ARROW_LINE_NATIVE
+      },
+      {
+        type: 'feature',
+        id: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.id,
+        title: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.name,
+        url: PhysEngFestDefinitions.WESTBOUND_BUS_DROPOFF.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       }
     ],
     native: {

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
@@ -1,0 +1,7 @@
+<tamu-gisc-legend
+  [deduplicate]="deduplicate"
+  [respectDefinitionExpression]="respectDefinitionExpression"
+  [allowVisibilityToggle]="allowVisibilityToggle"
+  [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
+  [excludedLayerIds]="excludedLayerIds"
+></tamu-gisc-legend>

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+
+import { EventSettingsService } from '../../../../services/settings/event-settings.service';
+
+@Component({
+  selector: 'tamu-gisc-event-legend',
+  templateUrl: './event-legend.component.html'
+})
+export class EventLegendComponent implements OnInit {
+  private readonly _physicsEventId = 'phys-eng-fest';
+
+  private readonly _physicsExcludedLayerIds = [
+    'aggieprint-locations-layer',
+    'accessible-entrances-layer',
+    'visitor-parking-layer',
+    'lactation-rooms-layer',
+    'poi-layer',
+    'construction_zone-layer',
+    'dining-locations-layer',
+    'family-friendly-bathrooms-locations-layer',
+    'emergency-phones-layer'
+  ];
+
+  public deduplicate = true;
+  public respectDefinitionExpression = true;
+  public allowVisibilityToggle = false;
+  public combineChildrenUnderPrimary = false;
+  public excludedLayerIds: string[] = [];
+
+  constructor(private readonly eventSettingsService: EventSettingsService) {}
+
+  public ngOnInit(): void {
+    const eventId = this.eventSettingsService.eventConfiguration()?.configuration?.id;
+    const isPhysicsMap = eventId === this._physicsEventId;
+
+    this.allowVisibilityToggle = isPhysicsMap;
+    this.combineChildrenUnderPrimary = isPhysicsMap;
+    this.excludedLayerIds = isPhysicsMap ? this._physicsExcludedLayerIds : [];
+  }
+}

--- a/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
@@ -37,7 +37,7 @@ import { SettingsModule } from '@tamu-gisc/common/ngx/settings';
 import { SidebarModule } from '@tamu-gisc/common/ngx/ui/sidebar';
 import { LayerListModule, LayerListComponent } from '@tamu-gisc/maps/feature/layer-list';
 import { PipesModule } from '@tamu-gisc/common/ngx/pipes';
-import { LegendModule, LegendComponent } from '@tamu-gisc/maps/feature/legend';
+import { LegendModule } from '@tamu-gisc/maps/feature/legend';
 import { MapsFeatureTripPlannerModule, TripPlannerOptionsComponent } from '@tamu-gisc/maps/feature/trip-planner';
 import { MapPopupModule, PopupMobileComponent } from '@tamu-gisc/maps/feature/popup';
 import { UIClipboardModule } from '@tamu-gisc/ui-kits/ngx/interactions/clipboard';
@@ -49,6 +49,7 @@ import { MoveInOutSidebarModule } from '../sidebar/sidebar.module';
 import { MapComponent } from './map.component';
 import { MoveInOutSidebarComponent } from '../sidebar/sidebar.component';
 import { SidebarReferenceComponent } from '../sidebar/components/sidebar-reference/sidebar-reference.component';
+import { EventLegendComponent } from './components/event-legend/event-legend.component';
 
 const routes: Routes = [
   {
@@ -101,20 +102,7 @@ const routes: Routes = [
               { path: '', component: MainMobileSidebarComponent },
               {
                 path: 'legend',
-                component: LegendComponent,
-                data: {
-                  deduplicate: true,
-                  respectDefinitionExpression: true,
-                  allowVisibilityToggle: true,
-                  excludedLayerIds: [
-                    'aggieprint-locations-layer',
-                    'accessible-entrances-layer',
-                    'visitor-parking-layer',
-                    'lactation-rooms-layer',
-                    'poi-layer',
-                    'construction_zone-layer'
-                  ]
-                }
+                component: EventLegendComponent
               },
               { path: 'layers', component: LayerListComponent },
               { path: 'basemap', component: BasemapGalleryComponent }
@@ -159,6 +147,6 @@ const routes: Routes = [
     UIClipboardModule,
     MoveInOutSidebarModule
   ],
-  declarations: [MapComponent]
+  declarations: [MapComponent, EventLegendComponent]
 })
 export class MapModule {}

--- a/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
@@ -99,7 +99,23 @@ const routes: Routes = [
             component: MobileSidebarComponent,
             children: [
               { path: '', component: MainMobileSidebarComponent },
-              { path: 'legend', component: LegendComponent, data: { deduplicate: true, respectDefinitionExpression: true } },
+              {
+                path: 'legend',
+                component: LegendComponent,
+                data: {
+                  deduplicate: true,
+                  respectDefinitionExpression: true,
+                  allowVisibilityToggle: true,
+                  excludedLayerIds: [
+                    'aggieprint-locations-layer',
+                    'accessible-entrances-layer',
+                    'visitor-parking-layer',
+                    'lactation-rooms-layer',
+                    'poi-layer',
+                    'construction_zone-layer'
+                  ]
+                }
+              },
               { path: 'layers', component: LayerListComponent },
               { path: 'basemap', component: BasemapGalleryComponent }
             ]

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -18,6 +18,18 @@
   </div>
 </div>
 
-<tamu-gisc-legend [deduplicate]="true" [respectDefinitionExpression]="true"></tamu-gisc-legend>
+<tamu-gisc-legend
+  [deduplicate]="true"
+  [respectDefinitionExpression]="true"
+  [allowVisibilityToggle]="true"
+  [excludedLayerIds]="[
+    'aggieprint-locations-layer',
+    'accessible-entrances-layer',
+    'visitor-parking-layer',
+    'lactation-rooms-layer',
+    'poi-layer',
+    'construction_zone-layer'
+  ]"
+></tamu-gisc-legend>
 
 <tamu-gisc-layer-list></tamu-gisc-layer-list>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -21,15 +21,9 @@
 <tamu-gisc-legend
   [deduplicate]="true"
   [respectDefinitionExpression]="true"
-  [allowVisibilityToggle]="true"
-  [excludedLayerIds]="[
-    'aggieprint-locations-layer',
-    'accessible-entrances-layer',
-    'visitor-parking-layer',
-    'lactation-rooms-layer',
-    'poi-layer',
-    'construction_zone-layer'
-  ]"
+  [allowVisibilityToggle]="legendAllowVisibilityToggle"
+  [combineChildrenUnderPrimary]="legendCombineChildrenUnderPrimary"
+  [excludedLayerIds]="legendExcludedLayerIds"
 ></tamu-gisc-legend>
 
 <tamu-gisc-layer-list></tamu-gisc-layer-list>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -16,11 +16,28 @@ import esri = __esri;
   styleUrls: ['./sidebar-reference.component.scss']
 })
 export class SidebarReferenceComponent implements OnInit {
+  private readonly _physicsEventId = 'phys-eng-fest';
+
+  private readonly _physicsExcludedLayerIds = [
+    'aggieprint-locations-layer',
+    'accessible-entrances-layer',
+    'visitor-parking-layer',
+    'lactation-rooms-layer',
+    'poi-layer',
+    'construction_zone-layer',
+    'dining-locations-layer',
+    'family-friendly-bathrooms-locations-layer',
+    'emergency-phones-layer'
+  ];
+
   public shareUrl: string;
   public hasSettings: boolean;
   public settings: EventSettings;
   public mergedSettings: ResolvedEventSettings;
   public configuration: EventConfiguration | null;
+  public legendAllowVisibilityToggle = false;
+  public legendCombineChildrenUnderPrimary = false;
+  public legendExcludedLayerIds: string[] = [];
 
   constructor(
     private readonly router: Router,
@@ -35,6 +52,12 @@ export class SidebarReferenceComponent implements OnInit {
     this.configuration = this.eventSettingsService.eventConfiguration()?.configuration;
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
+
+    const isPhysicsMap = this.configuration?.id === this._physicsEventId;
+
+    this.legendAllowVisibilityToggle = isPhysicsMap;
+    this.legendCombineChildrenUnderPrimary = isPhysicsMap;
+    this.legendExcludedLayerIds = isPhysicsMap ? this._physicsExcludedLayerIds : [];
   }
 
   public onSearchResult(result: SearchSelection<unknown>): void {


### PR DESCRIPTION
This PR implements the Physics & Engineering Festival map update for issue #641 and finalizes legend behavior so Physics-specific UX changes do not affect other event maps.

![aggiemap_phys_fest_test](https://github.com/user-attachments/assets/902977ee-377f-47b0-ad2a-153245fa049e)


## Summary

* Rebuilds `phys-engineering-festival.definitions.ts` to use the new service:
  `https://gis.it.tamu.edu/arcgis/rest/services/TS/Physics_Fest/MapServer`
* Configures the three requested top-level groups:

  * **General Parking**
  * **Buses Entering from Eastbound University Dr**
  * **Buses Entering from Westbound University Dr**
* Uses arrow symbology for pedestrian paths and bus routes instead of thick lines.
* Fixes draw order so bus drop-off / pick-up icons render above route and path lines.

### Physics legend behavior

* Updates Physics legend behavior to match requested UX:

  * Group expand/collapse supports visibility toggling.
  * Child legend display is flattened so parking and path items appear at the same visual level.
  * Bus Drop Off / Pick Up entries appear above path and route entries.
* Hides non-Physics utility layers from the Physics legend by default:

  * AggiePrint
  * Accessible Entrances
  * Visitor Parking
  * Lactation Rooms
  * POI
  * Construction Zones
  * Dining Locations
  * Family Friendly Restroom Locations
  * Emergency Phones

## Scope Control / Regression Fix

Physics-only legend behavior is now gated by event id (`phys-eng-fest`) so non-Physics maps, such as Baseball, continue using default legend behavior.

Also adds an event-aware mobile wrapper, `EventLegendComponent`, so mobile legend settings are scoped to Physics only.

## Physics Dropdown Exception (Scope Guard)

The Physics & Engineering Festival map uses a non-standard legend dropdown behavior by design. This is intentionally implemented as an event-specific exception, not a global legend behavior change.

Physics-only behavior is enabled only when the event id is `phys-eng-fest`.

### Desktop

* Legend options are set conditionally in `SidebarReferenceComponent`.

### Mobile

* Legend options are set conditionally through `EventLegendComponent`, which is used by the mobile legend route.

### Additional guards

* Additional dropdown and header behavior in `legend-collection` is guarded so it only applies to Physics group layer ids (`phys-eng-festival-*`).

As a result, other maps, such as Baseball, should continue using the default legend and dropdown behavior with no Physics-specific side effects.

## New Files

* `event-legend.component.ts`
* `event-legend.component.html`

## Why These Files Were Needed

Previously, the mobile legend route pointed directly to the shared `LegendComponent` with static route data in `map.module.ts`, which caused Physics dropdown settings to apply to all maps.

We needed event-aware behavior that only applies to `phys-eng-fest`, so this wrapper reads `EventSettingsService` at runtime and passes inputs to `<tamu-gisc-legend>` conditionally.

This keeps shared legend components generic and avoids introducing more global, map-specific logic into them.

In short, these files isolate the Physics exception so non-Physics maps, such as Baseball, retain default legend behavior.

Closes #641 
