### PR TITLE
fix(aggiemap-angular): Reordered traffic layers to top

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -11,9 +11,9 @@ import {
 import esri = __esri;
 
 export enum BIG_EVENT_LAYERS {
+  TRAFFIC = 'big-event-traffic',
   ROAD_CLOSURES = 'big-event-road-closures',
   PARKING_LOTS = 'big-event-parking-lots',
-  TRAFFIC = 'big-event-traffic'
 }
 
 export enum BIG_EVENT_MAP_TYPE_OPTIONS {


### PR DESCRIPTION
Puts traffic layers on top of other layers, as requested by Megan (@meganmcmullen-rgb in https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/issues/644#issuecomment-4005876905_

<img width="2357" height="1194" alt="image" src="https://github.com/user-attachments/assets/1cbaabae-25ef-4e3b-9633-3940adee65ef" />
