### PR TITLE
feat(aggiemap-angular): Add sustainable transportation layers

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.spec.ts
@@ -11,54 +11,123 @@ describe('LayerSources', () => {
   beforeEach(() => {
     connections = {} as IComposedConnections;
     definitions = {
-      BUILDINGS: { layerId: 'buildings', name: 'Buildings', url: 'buildings-url', popupComponent: 'buildings-popup' },
+      BUILDINGS: {
+        id: 'buildings',
+        layerId: 'buildings',
+        name: 'Buildings',
+        url: 'buildings-url',
+        popupComponent: 'buildings-popup'
+      },
       CONSTRUCTION: {
+        id: 'construction',
         layerId: 'construction',
         name: 'Construction',
         url: 'construction-url',
         popupComponent: 'construction-popup'
       },
-      POINTS_OF_INTEREST: { layerId: 'poi', name: 'Points of Interest', url: 'poi-url', popupComponent: 'poi-popup' },
-      RESTROOMS: { layerId: 'restrooms', name: 'Restrooms', url: 'restrooms-url', popupComponent: 'restrooms-popup' },
+      POINTS_OF_INTEREST: {
+        id: 'poi',
+        layerId: 'poi',
+        name: 'Points of Interest',
+        url: 'poi-url',
+        popupComponent: 'poi-popup'
+      },
+      BONFIRE: {
+        id: 'bonfire',
+        layerId: 'bonfire',
+        name: 'Bonfire',
+        url: 'bonfire-url',
+        popupComponent: 'bonfire-popup'
+      },
       LACTATION_ROOMS: {
+        id: 'lactation',
         layerId: 'lactation',
         name: 'Lactation Rooms',
         url: 'lactation-url',
         popupComponent: 'lactation-popup'
       },
       SURFACE_LOTS: {
+        id: 'surface-lots',
         layerId: 'surface-lots',
         name: 'Surface Lots',
         url: 'surface-lots-url',
         popupComponent: 'surface-lots-popup'
       },
       VISITOR_PARKING: {
+        id: 'visitor-parking',
         layerId: 'visitor-parking',
         name: 'Visitor Parking',
         url: 'visitor-parking-url',
         popupComponent: 'visitor-parking-popup'
       },
+      TRANSPORTATION_PARKING: {
+        id: 'transportation-parking',
+        layerId: 'transportation-parking',
+        name: 'Transportation Parking',
+        url: 'transportation-parking-url',
+        popupComponent: 'transportation-parking-popup'
+      },
       ACESSIBLE_ENTRANCES: {
+        id: 'accessible-entrances',
         layerId: 'accessible-entrances',
         name: 'Accessible Entrances',
         url: 'accessible-entrances-url',
         popupComponent: 'accessible-entrances-popup'
       },
-      EMERGENCY_PHONES: { layerId: 'emergency-phones', name: 'Emergency Phones', url: 'emergency-phones-url' },
-      BIKE_LOCATIONS: { layerId: 'bike-locations', name: 'Bike Locations', url: 'bike-locations-url' }
-    } as IComposedIDefinitions;
+      EMERGENCY_PHONES: {
+        id: 'emergency-phones',
+        layerId: 'emergency-phones',
+        name: 'Emergency Phones',
+        url: 'emergency-phones-url'
+      },
+      BIKE_RACKS: {
+        id: 'bike-racks',
+        layerId: 'bike-racks',
+        name: 'Bike Racks',
+        url: 'bike-racks-url'
+      },
+      BIKE_LOCATIONS: {
+        id: 'bike-locations',
+        layerId: 'bike-locations',
+        name: 'Bike Locations',
+        url: 'bike-locations-url'
+      },
+      DINING_LOCATIONS: {
+        id: 'dining-locations',
+        layerId: 'dining-locations',
+        name: 'Dining Locations',
+        url: 'dining-locations-url',
+        popupComponent: 'dining-popup'
+      },
+      AGGIEPRINT_LOCATIONS: {
+        id: 'aggieprint-locations',
+        layerId: 'aggieprint-locations',
+        name: 'AggiePrint Locations',
+        url: 'aggieprint-locations-url',
+        popupComponent: 'aggieprint-popup'
+      },
+      FAMILY_FRIENDLY_BATHROOMS: {
+        id: 'family-friendly-bathrooms',
+        layerId: 'family-friendly-bathrooms',
+        name: 'Family Friendly Bathrooms',
+        url: 'family-friendly-bathrooms-url',
+        popupComponent: 'family-friendly-bathrooms-popup'
+      }
+    };
     options = { exclude: [] };
   });
 
   it('should return all layer sources when no options are provided', () => {
     const result = LayerSources(connections, definitions);
-    expect(result.length).toBe(12);
+
+    expect(result.length).toBe(16);
   });
 
   it('should exclude specified layers', () => {
     options.exclude = ['BUILDINGS', 'CONSTRUCTION'];
     const result = LayerSources(connections, definitions, options);
-    expect(result.length).toBe(10);
+
+    expect(result.length).toBe(14);
     expect(result.find((layer) => layer.id === 'buildings')).toBeUndefined();
     expect(result.find((layer) => layer.id === 'construction')).toBeUndefined();
   });
@@ -66,16 +135,18 @@ describe('LayerSources', () => {
   it('should include all layers if exclude list is empty', () => {
     options.exclude = [];
     const result = LayerSources(connections, definitions, options);
-    expect(result.length).toBe(12);
+
+    expect(result.length).toBe(16);
   });
 
-  it('should return an empty array if all layers are excluded', () => {
+  it('should retain only non-definition-backed top-level layers when all definitions are excluded', () => {
     options.exclude = Object.keys(definitions) as Array<keyof IComposedIDefinitions>;
-    const differenceExpected = options.exclude.length;
-
-    const resultWithNoExclusions = LayerSources(connections, definitions);
     const resultWithExclusions = LayerSources(connections, definitions, options);
 
-    expect(resultWithNoExclusions.length - resultWithExclusions.length).toBe(differenceExpected);
+    expect(resultWithExclusions.map((layer) => layer.id)).toEqual([
+      'selection-layer',
+      'bus-route-layer',
+      'sustainable-transportation-group-layer'
+    ]);
   });
 });

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Popups } from '@tamu-gisc/aggiemap/ngx/popups';
 
 import { IComposedIDefinitions } from '../definitions';
 import { IComposedConnections } from '../connections';
@@ -20,6 +21,9 @@ export function LayerSources(
   definitions: IComposedIDefinitions,
   options?: IFactoryExcludeOptions<IComposedIDefinitions>
 ): Array<LayerSource> {
+  const bikeMapUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/BikeMap/MapServer');
+  const evChargeStationsUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/EVChargeStations/MapServer');
+
   const all: Array<LayerSource> = [
     {
       type: 'feature',
@@ -216,6 +220,122 @@ export function LayerSources(
             color: '#03C4A6'
           }
         }
+      }
+    },
+    {
+      type: 'feature',
+      id: 'ev-charge-stations-layer',
+      title: 'EV Charge Stations (Main + RELLIS)',
+      url: `${evChargeStationsUrl}/0`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.EV_ID}',
+        description:
+          '<strong>Network</strong>: {attributes.EV_Network}\n' +
+          '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+          '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+          '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-rack-areas-layer',
+      title: 'Bike Rack Areas',
+      url: `${bikeMapUrl}/4`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Type}',
+        description: '<strong>Total Capacity</strong>: {attributes.Total_Capacity}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-fix-stations-layer',
+      title: 'Bike Fix Stations',
+      url: `${bikeMapUrl}/1`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Bike_Sta_Name}',
+        description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-lanes-layer',
+      title: 'Bike Lanes',
+      url: `${bikeMapUrl}/2`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Use_}',
+        description: '<strong>Location</strong>: {attributes.Location}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'city-bike-lanes-routes-layer',
+      title: 'City Bike Lanes and Routes',
+      url: `${bikeMapUrl}/3`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Use_}',
+        description: '<strong>Location</strong>: {attributes.Location}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-racks-map-layer',
+      title: 'Bike Racks',
+      url: `${bikeMapUrl}/0`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Type}',
+        description:
+          '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' + '<strong>Notes</strong>: {attributes.BR_Notes}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-dismount-zones-layer',
+      title: 'Bike Dismount Zones',
+      url: `${bikeMapUrl}/5`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: 'Bike Dismount Zone'
+      },
+      native: {
+        ...commonLayerProps
       }
     },
     {

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -23,6 +23,124 @@ export function LayerSources(
 ): Array<LayerSource> {
   const bikeMapUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/BikeMap/MapServer');
   const evChargeStationsUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/EVChargeStations/MapServer');
+  const sustainableTransportationSources: Array<LayerSource> = [
+    {
+      type: 'feature',
+      id: 'ev-charge-stations-layer',
+      title: 'EV Charge Stations (Main + RELLIS)',
+      url: `${evChargeStationsUrl}/0`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.EV_ID}',
+        description:
+          '<strong>Network</strong>: {attributes.EV_Network}\n' +
+          '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+          '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+          '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-rack-areas-layer',
+      title: 'Bike Rack Areas',
+      url: `${bikeMapUrl}/4`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Type}',
+        description: '<strong>Total Capacity</strong>: {attributes.Total_Capacity}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-fix-stations-layer',
+      title: 'Bike Fix Stations',
+      url: `${bikeMapUrl}/1`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Bike_Sta_Name}',
+        description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-lanes-layer',
+      title: 'Bike Lanes',
+      url: `${bikeMapUrl}/2`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Use_}',
+        description: '<strong>Location</strong>: {attributes.Location}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'city-bike-lanes-routes-layer',
+      title: 'City Bike Lanes and Routes',
+      url: `${bikeMapUrl}/3`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Use_}',
+        description: '<strong>Location</strong>: {attributes.Location}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-racks-map-layer',
+      title: 'Bike Racks',
+      url: `${bikeMapUrl}/0`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.Type}',
+        description:
+          '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' + '<strong>Notes</strong>: {attributes.BR_Notes}'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    },
+    {
+      type: 'feature',
+      id: 'bike-dismount-zones-layer',
+      title: 'Bike Dismount Zones',
+      url: `${bikeMapUrl}/5`,
+      listMode: 'show',
+      visible: true,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: 'Bike Dismount Zone'
+      },
+      native: {
+        ...commonLayerProps
+      }
+    }
+  ];
 
   const all: Array<LayerSource> = [
     {
@@ -223,119 +341,14 @@ export function LayerSources(
       }
     },
     {
-      type: 'feature',
-      id: 'ev-charge-stations-layer',
-      title: 'EV Charge Stations (Main + RELLIS)',
-      url: `${evChargeStationsUrl}/0`,
+      type: 'group',
+      id: 'sustainable-transportation-group-layer',
+      title: 'Sustainable Transportation',
       listMode: 'show',
       visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.EV_ID}',
-        description:
-          '<strong>Network</strong>: {attributes.EV_Network}\n' +
-          '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-          '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-          '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-      },
+      sources: sustainableTransportationSources,
       native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-rack-areas-layer',
-      title: 'Bike Rack Areas',
-      url: `${bikeMapUrl}/4`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Type}',
-        description: '<strong>Total Capacity</strong>: {attributes.Total_Capacity}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-fix-stations-layer',
-      title: 'Bike Fix Stations',
-      url: `${bikeMapUrl}/1`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Bike_Sta_Name}',
-        description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-lanes-layer',
-      title: 'Bike Lanes',
-      url: `${bikeMapUrl}/2`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Use_}',
-        description: '<strong>Location</strong>: {attributes.Location}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'city-bike-lanes-routes-layer',
-      title: 'City Bike Lanes and Routes',
-      url: `${bikeMapUrl}/3`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Use_}',
-        description: '<strong>Location</strong>: {attributes.Location}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-racks-map-layer',
-      title: 'Bike Racks',
-      url: `${bikeMapUrl}/0`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Type}',
-        description:
-          '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' + '<strong>Notes</strong>: {attributes.BR_Notes}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-dismount-zones-layer',
-      title: 'Bike Dismount Zones',
-      url: `${bikeMapUrl}/5`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: 'Bike Dismount Zone'
-      },
-      native: {
-        ...commonLayerProps
+        listMode: 'hide-children'
       }
     },
     {

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.module.ts
@@ -112,7 +112,7 @@ const routes: Routes = [
             component: MobileSidebarComponent,
             children: [
               { path: '', component: MainMobileSidebarComponent },
-              { path: 'legend', component: LegendComponent },
+              { path: 'legend', component: LegendComponent, data: { deduplicate: true } },
               { path: 'layers', component: LayerListComponent },
               { path: 'basemap', component: BasemapGalleryComponent }
             ]

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -2,4 +2,4 @@
 
 <tamu-gisc-layer-list></tamu-gisc-layer-list>
 
-<tamu-gisc-legend></tamu-gisc-legend>
+<tamu-gisc-legend [deduplicate]="true"></tamu-gisc-legend>

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -41,6 +41,7 @@ import { MotorcycleParkingTs } from './motorcycle-parking.definitions';
 import { AVPParkingTs } from './avp-parking.definitions';
 import { NscParkingTs } from './nsc-parking.definitions';
 import { BreakSummerParkingTs } from './break-summer.definitions';
+import { SustainableTransportationTs } from './sustainable-transportation.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -84,5 +85,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   MotorcycleParkingTs,
   AVPParkingTs,
   NscParkingTs,
-  BreakSummerParkingTs
+  BreakSummerParkingTs,
+  SustainableTransportationTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,0 +1,186 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
+
+export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
+  EV_CHARGERS = 'sustainable-transportation-ev-chargers',
+  BIKE_RACKS = 'sustainable-transportation-bike-racks',
+  BIKE_RACK_AREAS = 'sustainable-transportation-bike-rack-areas',
+  BIKE_FIX_STATIONS = 'sustainable-transportation-bike-fix-stations',
+  BIKE_LANES = 'sustainable-transportation-bike-lanes',
+  CITY_BIKE_LANES_ROUTES = 'sustainable-transportation-city-bike-lanes-routes',
+  BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
+}
+
+const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
+const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+
+export const SustainableTransportationDefinitions = {
+  EV_CHARGERS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    name: 'EV Charge Stations (Main + RELLIS)',
+    url: `${evLayersUrl}/0`
+  },
+  BIKE_RACKS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
+    name: 'Bike Racks',
+    url: `${bikeLayersUrl}/0`
+  },
+  BIKE_FIX_STATIONS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
+    name: 'Bike Fix Stations',
+    url: `${bikeLayersUrl}/1`
+  },
+  BIKE_LANES: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
+    name: 'Bike Lanes',
+    url: `${bikeLayersUrl}/2`
+  },
+  CITY_BIKE_LANES_ROUTES: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
+    name: 'City Bike Lanes and Routes',
+    url: `${bikeLayersUrl}/3`
+  },
+  BIKE_RACK_AREAS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACK_AREAS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACK_AREAS,
+    name: 'Bike Rack Areas',
+    url: `${bikeLayersUrl}/4`
+  },
+  BIKE_DISMOUNT_ZONES: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
+    name: 'Bike Dismount Zones',
+    url: `${bikeLayersUrl}/5`
+  }
+};
+
+export const SustainableTransportationColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.EV_CHARGERS.id,
+    title: SustainableTransportationDefinitions.EV_CHARGERS.name,
+    url: SustainableTransportationDefinitions.EV_CHARGERS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_RACK_AREAS.id,
+    title: SustainableTransportationDefinitions.BIKE_RACK_AREAS.name,
+    url: SustainableTransportationDefinitions.BIKE_RACK_AREAS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_RACKS.id,
+    title: SustainableTransportationDefinitions.BIKE_RACKS.name,
+    url: SustainableTransportationDefinitions.BIKE_RACKS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
+    title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
+    url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_LANES.id,
+    title: SustainableTransportationDefinitions.BIKE_LANES.name,
+    url: SustainableTransportationDefinitions.BIKE_LANES.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.id,
+    title: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.name,
+    url: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.id,
+    title: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.name,
+    url: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  }
+];
+
+export const SustainableTransportationConfiguration: EventConfiguration = {
+  id: 'sustainable-transportation',
+  name: 'Sustainable Transportation',
+  applicationName: 'Sustainable Transportation Map',
+  shortApplicationName: 'Sustainable Transportation',
+  introductionText:
+    'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
+  mapCenter: [-96.4005, 30.6193],
+  eventDates: [],
+  zoom: 11
+};
+
+export const SustainableTransportationOptions: SpecialEventOptions = [];
+
+export const SustainableTransportationTs: AggiemapCustomMapConfiguration = {
+  configuration: SustainableTransportationConfiguration,
+  options: SustainableTransportationOptions,
+  sources: SustainableTransportationColdLayerSources,
+  references: SUSTAINABLE_TRANSPORTATION_LAYERS,
+  type: 'general-map',
+  discover: {
+    id: SustainableTransportationConfiguration.id,
+    name: SustainableTransportationConfiguration.name,
+    description: 'Bike amenities and EV charging locations for Main Campus and the RELLIS Campus.',
+    source: 'internal',
+    type: 'parking',
+    keywords: [
+      'sustainable transportation',
+      'bike',
+      'bike racks',
+      'bike fix stations',
+      'bike lanes',
+      'dismount zones',
+      'ev',
+      'ev chargers',
+      'electric vehicle',
+      'rellis'
+    ]
+  }
+};


### PR DESCRIPTION
Adds Sustainable Transportation map content to AggieMap and makes it available in both:

A new custom map (sustainable-transportation)
The default/main AggieMap layer list

<img width="2313" height="1220" alt="image" src="https://github.com/user-attachments/assets/a0a7c4a1-366e-4941-8092-46f01a9fdd7f" />

Layers are visible on RELLIS campus as well:

<img width="1995" height="1114" alt="image" src="https://github.com/user-attachments/assets/b2639c43-0f13-426d-abe4-e37e87ed40af" />

Closes #537 