### PR TITLE
feat(aggiemap-angular): Update Big Event map closures, layer order, map note support, and tool bring-back labeling

### DIFF
--- a/h --force-with-lease origin softball-parking
+++ b/h --force-with-lease origin softball-parking
@@ -1,0 +1,8 @@
+* [33mac12ab48[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32msoftball-parking[m[33m)[m Fixed popup issues
+* [33mf1b21dbe[m Fixed safety first issue
+* [33mc75b4d18[m Most maps functional except Safety First
+* [33m515a89e4[m Working through visibility + popup issues
+* [33m9db96c75[m Reverted map.services.ts and fixed swimming parking lot visibility
+* [33m2026558d[m WIP need to pull recent changes
+* [33m06e76f79[m[33m ([m[1;31morigin/development[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mverify-popups[m[33m, [m[1;32mparking-lot-popup-fix[m[33m, [m[1;32mnsc-and-summer-fix[m[33m)[m feat(aggiemap-angular): Add AVP Parking Map (#610)
+* [33ma8e92cc9[m fix(aggiemap-angular): Make Vendor parking map features visible + updated map service (#611)

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -231,7 +231,8 @@ export const BigEventConfiguration: EventConfiguration = {
   shortApplicationName: 'Big Event Map',
   eventDates: ['2026-03-21'],
   mapCenter: [-96.3463, 30.6059],
-  zoom: 17
+  zoom: 17,
+  enableResolvedSettingNotes: true
 };
 
 export const BigEventOptions: SpecialEventOptions = [

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -24,6 +24,18 @@ export enum BIG_EVENT_MAP_TYPE_OPTIONS {
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Big_Event/MapServer';
 
+const BIG_EVENT_LAYER_INDICES = {
+  PARKING_LOTS: 48,
+  ROAD_CLOSURES: 49,
+  TRAFFIC: 50
+} as const;
+
+const BIG_EVENT_ROAD_CLOSURE_EXPRESSIONS = {
+  PRE_KICKOFF: `Notes LIKE '%To Kickoff%'`,
+  LEAVE_KICKOFF: `Notes LIKE '%Leaving Kickoff%'`,
+  HIDE: '1 = 0'
+} as const;
+
 export const BigEventDefinitions = {
   TRAFFIC: {
     id: BIG_EVENT_LAYERS.TRAFFIC,
@@ -58,6 +70,7 @@ export const BigEventColdLayerSources: LayerSource[] = [
     // },
     visible: true,
     listMode: 'show',
+    layerIndex: BIG_EVENT_LAYER_INDICES.TRAFFIC,
     native: {
       outFields: ['*'],
       renderer: {
@@ -174,11 +187,24 @@ export const BigEventColdLayerSources: LayerSource[] = [
     url: BigEventDefinitions.ROAD_CLOSURES.url,
     popupComponent: MarkdownPopupComponent,
     visible: true,
+    listMode: 'show',
+    layerIndex: BIG_EVENT_LAYER_INDICES.ROAD_CLOSURES,
     native: {
-      listMode: 'show',
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'simple-fill',
+          style: 'diagonal-cross',
+          color: [230, 0, 0, 1],
+          outline: {
+            color: [230, 0, 0, 1],
+            width: 1
+          }
+        } as unknown as esri.SimpleFillSymbolProperties
+      }
     }
-  },
+  } as unknown as LayerSource,
   {
     type: 'feature',
     id: BigEventDefinitions.PARKING_LOTS.id,
@@ -191,6 +217,7 @@ export const BigEventColdLayerSources: LayerSource[] = [
     // },
     visible: true,
     listMode: 'show',
+    layerIndex: BIG_EVENT_LAYER_INDICES.PARKING_LOTS,
     native: {
       outFields: ['*']
     }
@@ -220,10 +247,11 @@ export const BigEventOptions: SpecialEventOptions = [
       },
       {
         label: 'Leaving Kickoff',
-        value: BIG_EVENT_MAP_TYPE_OPTIONS.LEAVE_KICKOFF
+        value: BIG_EVENT_MAP_TYPE_OPTIONS.LEAVE_KICKOFF,
+        note: 'No entry to Reed lots during tool distribution'
       },
       {
-        label: 'Tool Return',
+        label: 'Tool Bring-Back',
         value: BIG_EVENT_MAP_TYPE_OPTIONS.TOOL_RETURN
       }
     ],
@@ -249,15 +277,18 @@ export const BigEventOptions: SpecialEventOptions = [
         },
         {
           layerId: BIG_EVENT_LAYERS.ROAD_CLOSURES,
-          field: 'OBJECTID',
           conversions: [
             {
               input: BIG_EVENT_MAP_TYPE_OPTIONS.PRE_KICKOFF,
-              output: 81
+              expression: BIG_EVENT_ROAD_CLOSURE_EXPRESSIONS.PRE_KICKOFF
+            },
+            {
+              input: BIG_EVENT_MAP_TYPE_OPTIONS.LEAVE_KICKOFF,
+              expression: BIG_EVENT_ROAD_CLOSURE_EXPRESSIONS.LEAVE_KICKOFF
             },
             {
               input: BIG_EVENT_MAP_TYPE_OPTIONS.TOOL_RETURN,
-              output: 999 // Some bogus value that will always return no results, to hide layer when this input is selected
+              expression: BIG_EVENT_ROAD_CLOSURE_EXPRESSIONS.HIDE
             }
           ]
         }

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -54,6 +54,13 @@ export interface EventConfiguration {
   zoom?: number;
 
   /**
+   * Enables rendering resolved selection notes in shared UI surfaces like the map sidebar.
+   *
+   * Defaults to `false` when omitted so existing events are unaffected.
+   */
+  enableResolvedSettingNotes?: boolean;
+
+  /**
    * Events can have exceptions for default map layers. This property allows for the ability to
    * define a set of default layer overrides that apply to a specific event.
    *
@@ -249,7 +256,7 @@ export interface EventAccommodationOption {
   group?: string;
 
   /**
-   * Optional note to surface anywhere the resolved selection is displayed.
+   * Optional note that can be surfaced by events that opt into resolved setting notes.
    */
   note?: string;
 }

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -61,6 +61,27 @@ export interface EventConfiguration {
   enableResolvedSettingNotes?: boolean;
 
   /**
+   * Allows legend entries to expose visibility toggles when supported by the consuming UI.
+   *
+   * Defaults to `false` when omitted.
+   */
+  legendAllowVisibilityToggle?: boolean;
+
+  /**
+   * Groups child legend items under their primary parent label when supported by the consuming UI.
+   *
+   * Defaults to `false` when omitted.
+   */
+  legendCombineChildrenUnderPrimary?: boolean;
+
+  /**
+   * Omits specific layer ids from the legend when supported by the consuming UI.
+   *
+   * Defaults to an empty array when omitted.
+   */
+  legendExcludedLayerIds?: Array<string>;
+
+  /**
    * Events can have exceptions for default map layers. This property allows for the ability to
    * define a set of default layer overrides that apply to a specific event.
    *

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -249,8 +249,9 @@ export interface EventAccommodationOption {
   group?: string;
 
   /**
-   * Operations to apply to layers based on the selected option value.
+   * Optional note to surface anywhere the resolved selection is displayed.
    */
+  note?: string;
 }
 
 export interface ResolvedEventSetting {
@@ -259,6 +260,7 @@ export interface ResolvedEventSetting {
   option: {
     value: string | boolean | number | null;
     label: string;
+    note?: string;
   } | null;
 }
 

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -8,10 +8,11 @@
   <div class="sidebar-component-content-container">
     <p>Make coordination easy! The following link can be shared with friends and family to load your configured map.</p>
 
-    <p *ngIf="moveInSummary"><strong>{{ moveInSummary }}</strong></p>
-
-    <ul *ngIf="!moveInSummary">
-      <li *ngFor="let pair of mergedSettings | keyvalue"><strong>{{ pair.value.shortDescription }}: {{ pair.value.option?.label }}</strong></li>
+    <ul class="settings-list">
+      <li *ngFor="let pair of mergedSettings | keyvalue">
+        <strong>{{ pair.value.shortDescription }}: {{ pair.value.option?.label }}</strong>
+        <p *ngIf="pair.value.option?.note" class="setting-note">{{ pair.value.option?.note }}</p>
+      </li>
     </ul>
 
     <tamu-gisc-copy-field [text]="shareUrl"></tamu-gisc-copy-field>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -11,7 +11,7 @@
     <ul class="settings-list">
       <li *ngFor="let pair of mergedSettings | keyvalue">
         <strong>{{ pair.value.shortDescription }}: {{ pair.value.option?.label }}</strong>
-        <p *ngIf="pair.value.option?.note" class="setting-note">{{ pair.value.option?.note }}</p>
+        <p *ngIf="showResolvedSettingNotes && pair.value.option?.note" class="setting-note">{{ pair.value.option?.note }}</p>
       </li>
     </ul>
 

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
@@ -1,3 +1,12 @@
+.settings-list {
+  margin-bottom: 1rem;
+}
+
+.setting-note {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+}
+
 .settings-edit {
   text-align: right;
   font-size: 0.75rem;

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -16,20 +16,6 @@ import esri = __esri;
   styleUrls: ['./sidebar-reference.component.scss']
 })
 export class SidebarReferenceComponent implements OnInit {
-  private readonly _physicsEventId = 'phys-eng-fest';
-
-  private readonly _physicsExcludedLayerIds = [
-    'aggieprint-locations-layer',
-    'accessible-entrances-layer',
-    'visitor-parking-layer',
-    'lactation-rooms-layer',
-    'poi-layer',
-    'construction_zone-layer',
-    'dining-locations-layer',
-    'family-friendly-bathrooms-locations-layer',
-    'emergency-phones-layer'
-  ];
-
   public shareUrl: string;
   public hasSettings: boolean;
   public settings: EventSettings;
@@ -54,12 +40,6 @@ export class SidebarReferenceComponent implements OnInit {
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
-
-    const isPhysicsMap = this.configuration?.id === this._physicsEventId;
-
-    this.legendAllowVisibilityToggle = isPhysicsMap;
-    this.legendCombineChildrenUnderPrimary = isPhysicsMap;
-    this.legendExcludedLayerIds = isPhysicsMap ? this._physicsExcludedLayerIds : [];
   }
 
   public onSearchResult(result: SearchSelection<unknown>): void {

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -38,6 +38,7 @@ export class SidebarReferenceComponent implements OnInit {
   public legendAllowVisibilityToggle = false;
   public legendCombineChildrenUnderPrimary = false;
   public legendExcludedLayerIds: string[] = [];
+  public showResolvedSettingNotes = false;
 
   constructor(
     private readonly router: Router,
@@ -50,6 +51,7 @@ export class SidebarReferenceComponent implements OnInit {
   public ngOnInit(): void {
     this.hasSettings = this.eventSettingsService.queryParamsFromSettings !== null;
     this.configuration = this.eventSettingsService.eventConfiguration()?.configuration;
+    this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
 

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -38,7 +38,9 @@ export class SidebarReferenceComponent implements OnInit {
     this.hasSettings = this.eventSettingsService.queryParamsFromSettings !== null;
     this.configuration = this.eventSettingsService.eventConfiguration()?.configuration;
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
-    this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
+    this.legendAllowVisibilityToggle = this.configuration?.legendAllowVisibilityToggle ?? false;
+    this.legendCombineChildrenUnderPrimary = this.configuration?.legendCombineChildrenUnderPrimary ?? false;
+    this.legendExcludedLayerIds = this.configuration?.legendExcludedLayerIds ?? [];
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
   }

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -38,6 +38,7 @@ export class SidebarReferenceComponent implements OnInit {
     this.hasSettings = this.eventSettingsService.queryParamsFromSettings !== null;
     this.configuration = this.eventSettingsService.eventConfiguration()?.configuration;
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
+    this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
   }

--- a/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
@@ -8,7 +8,6 @@ import { LayerSource } from '@tamu-gisc/common/types';
 
 import {
   AggiemapCustomMapConfiguration,
-  EventAccommodationOption,
   EventSettings,
   ResolvedEventSettings,
   SpecialEventOptions
@@ -256,15 +255,20 @@ export class EventSettingsService {
         const value = settings[option.value];
 
         if (value !== undefined) {
+          const selectedChoice = option.choices.find((o) => o.value === value);
+
           return [
             ...merged,
             {
               key: option.value,
               shortDescription: option.shortDescription,
-              option: {
-                value: value,
-                label: (option.choices.find((o) => o.value === value) as EventAccommodationOption).label
-              }
+              option: selectedChoice
+                ? {
+                    value: value,
+                    label: selectedChoice.label,
+                    note: selectedChoice.note
+                  }
+                : null
             }
           ];
         } else {


### PR DESCRIPTION
This PR updates the Big Event transportation map configuration to match the latest kickoff and tool bring-back requirements, and adds a small opt-in mechanism for showing selection notes in shared event UI.

**Changes:**

- Updated Big Event road closure filtering in `big-event.definitions.ts` to use the published `Notes` field instead of hardcoded `OBJECTID` values.
- Adds Megan's  requested changes:
  - `Pre-Kickoff Parking` now shows the 3 intended closures.
  - `Leaving Kickoff` removes the Olsen closure and keeps the leaving-only closures.
  - `Tool Return` was renamed to `Tool Bring-Back`.
  - Reordered Big Event layers so parking lots render below closures and traffic arrows.
  - Changed Big Event closure styling from solid red polygons to a repeated red hatch pattern.
  - Added a `Leaving Kickoff` note: `No entry to Reed lots during tool distribution`.

**Shared support added for the Big Event note**

To support that map-specific note without affecting existing events by default:

- `special-event.interface.ts`
  - Added optional `note` support on event accommodation choices.
  - Added optional `enableResolvedSettingNotes` on `EventConfiguration` so note display is explicitly opt-in per event.

- `event-settings.service.ts`
  - Updated resolved settings generation so a selected option can carry its optional `note` into shared UI.

- `sidebar-reference.component.ts`
  - Added logic to read `configuration.enableResolvedSettingNotes` and only allow note rendering when an event opts in.

- `sidebar-reference.component.html`
  - Updated the sidebar settings summary to render an optional note beneath a selected setting when enabled.

- `sidebar-reference.component.scss`
  - Added minimal styling for the optional note display in the sidebar.

- `big-event.definitions.ts`
  - Enabled `enableResolvedSettingNotes: true` for Big Event so the Reed lots note appears only on this event’s map.

**Why this is safe for other maps**

- The note support is optional and event-gated.
- No other event definition enables `enableResolvedSettingNotes`, so existing maps keep their current behavior.

<img width="2198" height="1054" alt="image" src="https://github.com/user-attachments/assets/0b94b9ed-505e-439a-a056-12dfa0d7eec4" />

<img width="2083" height="1079" alt="image" src="https://github.com/user-attachments/assets/0535530a-adb9-4758-b0e8-b4f653c994c5" />

<img width="2112" height="1046" alt="image" src="https://github.com/user-attachments/assets/ec19acd3-4091-4a34-9415-857c06740d14" />

Closes #649  