### PR TITLE
fix(aggiemap-angular): Fix issue with safety-first on sport map legends

### DIFF
--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -1,7 +1,7 @@
 <div class="legend-collection">
   <div
     class="collection-group-title"
-    *ngIf="hasChildren"
+    *ngIf="showGroupTitle"
     tabindex="0"
     role="button"
     (click)="toggleExpanded()"
@@ -24,7 +24,7 @@
     ></tamu-gisc-legend-element>
 
     <tamu-gisc-legend-collection
-      *ngFor="let childGroup of childGroups; trackBy: trackByLegendGroup"
+      *ngFor="let childGroup of visibleChildGroups; trackBy: trackByLegendGroup"
       [group]="childGroup"
       [layer]="childGroup.layer"
       [deduplicate]="deduplicate"

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.spec.ts
@@ -53,4 +53,28 @@ describe('LegendCollectionComponent', () => {
     expect(component.isLayerVisible).toBe(false);
     expect(component.isExpanded).toBe(false);
   });
+
+  it('hides duplicate sports safety-first child groups when parent legend elements already exist', () => {
+    component.group = {
+      title: 'Safety First',
+      children: [{ title: 'Safety First Child' }],
+      legendElements: [{ infos: [{ label: 'Please use marked crosswalks. No mid-street crossing.', value: 'safety-first' }] }],
+      layer: { id: 'volleyball-parking-safety-first' }
+    } as unknown as __esri.ActiveLayerInfo;
+
+    expect(component.visibleChildGroups).toEqual([]);
+    expect(component.hasChildren).toBe(false);
+  });
+
+  it('keeps sports safety-first child groups when the parent has no legend elements', () => {
+    component.group = {
+      title: 'Safety First',
+      children: [{ title: 'Safety First Child' }],
+      legendElements: [],
+      layer: { id: 'volleyball-parking-safety-first' }
+    } as unknown as __esri.ActiveLayerInfo;
+
+    expect(component.visibleChildGroups).toHaveLength(1);
+    expect(component.hasChildren).toBe(true);
+  });
 });

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -63,8 +63,16 @@ export class LegendCollectionComponent {
     return this._toArray<esri.LegendElement>(this.group?.legendElements);
   }
 
+  public get visibleChildGroups(): IActiveLayerInfo[] {
+    if (this._shouldHideSportsSafetyFirstChildGroups()) {
+      return [];
+    }
+
+    return this.childGroups;
+  }
+
   public get hasChildren(): boolean {
-    return this.childGroups.length > 0;
+    return this.visibleChildGroups.length > 0;
   }
 
   public get childHideElementGroupHeaders(): boolean {
@@ -143,6 +151,23 @@ export class LegendCollectionComponent {
 
   private _isPhysicsFestivalGroup(layerId?: string): boolean {
     return layerId?.startsWith('phys-eng-festival-') ?? false;
+  }
+
+  private readonly _sportsSafetyFirstLayerIds = new Set([
+    'softball-parking-safety-first',
+    'swimming-parking-safety-first',
+    'soccer-parking-safety-first',
+    'volleyball-parking-safety-first',
+    'indoor-track-parking-safety-first',
+    'outdoor-track-parking-safety-first'
+  ]);
+
+  public get showGroupTitle(): boolean {
+    return this.hasChildren && !this._sportsSafetyFirstLayerIds.has(this.group?.layer?.id);
+  }
+
+  private _shouldHideSportsSafetyFirstChildGroups(): boolean {
+    return this._sportsSafetyFirstLayerIds.has(this.group?.layer?.id) && this.legendElements.length > 0 && this.childGroups.length > 0;
   }
 
   private _getPhysicsFestivalChildPriority(title?: string): number {

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -36,6 +36,15 @@ export class LegendCollectionComponent {
 
   public expanded = true;
 
+  private readonly _sportsSafetyFirstLayerIds = new Set([
+    'softball-parking-safety-first',
+    'swimming-parking-safety-first',
+    'soccer-parking-safety-first',
+    'volleyball-parking-safety-first',
+    'indoor-track-parking-safety-first',
+    'outdoor-track-parking-safety-first'
+  ]);
+
   public get childGroups(): IActiveLayerInfo[] {
     const children = this._toArray<IActiveLayerInfo>(this.group?.children);
 
@@ -152,15 +161,6 @@ export class LegendCollectionComponent {
   private _isPhysicsFestivalGroup(layerId?: string): boolean {
     return layerId?.startsWith('phys-eng-festival-') ?? false;
   }
-
-  private readonly _sportsSafetyFirstLayerIds = new Set([
-    'softball-parking-safety-first',
-    'swimming-parking-safety-first',
-    'soccer-parking-safety-first',
-    'volleyball-parking-safety-first',
-    'indoor-track-parking-safety-first',
-    'outdoor-track-parking-safety-first'
-  ]);
 
   public get showGroupTitle(): boolean {
     return this.hasChildren && !this._sportsSafetyFirstLayerIds.has(this.group?.layer?.id);

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -14,43 +14,55 @@ of the table -->
     <span class="material-icons">{{ expanded ? 'expand_more' : 'chevron_right' }}</span> {{ groupTitle }}
   </div>
 
+  <!-- Safety First layers always use the hardcoded fallback regardless of element type -->
+  <ng-container *ngIf="useSportsSafetyFirstFallback(); else standardRendering">
+    <div class="legend-info">
+      <div class="image-container">
+        <img [src]="getSportsSafetyFirstLegendSrc()" alt="Safety First icon" />
+      </div>
+      <div class="label">{{ getSportsSafetyFirstLegendLabel() }}</div>
+    </div>
+  </ng-container>
+
   <!-- Switch through the different element types. The default is a "not supported" message printout. -->
-  <ng-container [ngSwitch]="element?.type">
-    <!-- For SymbolTable element type -->
-    <div *ngSwitchCase="'symbol-table'" class="element-group">
-      <div class="legend-info" *ngFor="let info of infos | async" [hidden]="showGroupHeader && !expanded">
-        <div [ngSwitch]="info.type">
-          <!-- Support for infos with nested infos. This case will continue to recursively iterate through n-nested infos until reaching the last node. -->
-          <div *ngSwitchCase="'symbol-table'">
-            <tamu-gisc-legend-element
-              *ngFor="let subInfo of info?.infos"
-              [element]="subInfo"
-              [layer]="layer"
-              [groupTitle]="info.title"
-              [deduplicateChildren]="deduplicateChildren"
-              [respectDefinitionExpression]="respectDefinitionExpression"
-              [hideGroupHeader]="hideGroupHeader"
-            ></tamu-gisc-legend-element>
+  <ng-template #standardRendering>
+    <ng-container [ngSwitch]="element.type">
+      <!-- For SymbolTable element type -->
+      <div *ngSwitchCase="'symbol-table'" class="element-group">
+        <div class="legend-info" *ngFor="let info of infos | async" [hidden]="showGroupHeader && !expanded">
+          <div [ngSwitch]="$any(info).type">
+            <!-- Support for infos with nested infos. This case will continue to recursively iterate through n-nested infos until reaching the last node. -->
+            <div *ngSwitchCase="'symbol-table'">
+              <tamu-gisc-legend-element
+                *ngFor="let subInfo of $any(info).infos"
+                [element]="subInfo"
+                [layer]="layer"
+                [groupTitle]="$any(info).title"
+                [deduplicateChildren]="deduplicateChildren"
+                [respectDefinitionExpression]="respectDefinitionExpression"
+                [hideGroupHeader]="hideGroupHeader"
+              ></tamu-gisc-legend-element>
+            </div>
+
+            <!-- This case will be reached of every info node and will terminate either with an info.preview or info.src -->
+            <div *ngSwitchDefault>
+              <ng-container [ngSwitch]="$any(info).preview !== undefined">
+                <div *ngSwitchCase="true" class="image-container" [elementInsert]="$any(info).preview"></div>
+                <img *ngSwitchCase="false" class="image-container" [src]="$any(info).src" [ngStyle]="{opacity: $any(info).opacity}" alt="Layer legend icon" />
+              </ng-container>
+            </div>
           </div>
 
-          <!-- This case will be reached of every info node and will terminate either with an info.preview or info.src -->
-          <div *ngSwitchDefault>
-            <ng-container [ngSwitch]="info.preview !== undefined">
-              <div *ngSwitchCase="true" class="image-container" [elementInsert]="info.preview"></div>
-              <img *ngSwitchCase="false" class="image-container" [src]="info.src" [ngStyle]="{opacity: info.opacity}" alt="Layer legend icon" />
-            </ng-container>
+          <!-- Apply the legend item from the parent group or child -->
+          <div [ngSwitch]="element.infos?.length">
+            <div *ngSwitchCase="1" class="group-title">{{ groupTitle }}</div>
+            <div *ngSwitchDefault class="label">{{ info?.label }}</div>
           </div>
-        </div>
-
-        <!-- Apply the legend item from the parent group or child -->
-        <div [ngSwitch]="element.infos?.length">
-          <div *ngSwitchCase="1" class="group-title">{{ groupTitle }}</div>
-          <div *ngSwitchDefault class="label">{{ info?.label }}</div>
         </div>
       </div>
-    </div>
 
-    <!-- Default printout -->
-    <div *ngSwitchDefault>Unsupported legend element type: {{ element?.type }}</div>
-  </ng-container>
+      <!-- Default printout -->
+      <div *ngSwitchDefault>Unsupported legend element type: {{ element.type }}</div>
+    </ng-container>
+  </ng-template>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -165,7 +165,10 @@ export class LegendElementComponent implements OnInit {
   }
 
   public useSportsSafetyFirstFallback(): boolean {
-    return this.sportsSafetyFirstLayerIds.has(this.layer?.id) && (this.element?.infos?.length ?? 0) === 0;
+    return (
+      this.sportsSafetyFirstLayerIds.has(this.layer?.id) ||
+      this.sportsSafetyFirstLayerIds.has((this.layer as unknown as esri.Sublayer)?.layer?.id)
+    );
   }
 
   public getSportsSafetyFirstLegendSrc(): string {


### PR DESCRIPTION
This PR fixes issues with the legend functionality for the new sporting maps. Somewhere in the chaos of dealing with the merge conflicts, the previously fixed issue with the safety-first layer not properly appearing on the legend reappeared. 

### **Changes:**

- `legend-element.component.ts`
Updated useSportsSafetyFirstFallback() to recognize Safety First layers in two ways: directly by the parent MapImageLayer ID, and indirectly when the layer passed in is a child sublayer of one. Also removed the requirement for the element to have zero info. Safety First layers now always use the fallback regardless.

- `legend-element.component.html`
Wired up the fallback rendering that was already written in the component but never used in the template. Moved it before the element type switch so it takes priority over all element types. Previously it only fired in the "unknown type" default case, meaning symbol-table elements slipped through and showed "Safety First" as the label.

- `legend-collection.component.ts`
Added the Safety First layer IDs to this component as well. Used them in two places: showGroupTitle suppresses the bold "Safety First" group header that was appearing above the legend entry, and visibleChildGroups / _shouldHideSportsSafetyFirstChildGroups() prevents duplicate rendering when the parent layer has its own legend elements alongside child sublayer groups.

- `legend-collection.component.html`
Swapped hasChildren for showGroupTitle on the group title header, and childGroups for visibleChildGroups on the child collection loop, applying the two new conditions from the component.

Before:
<img width="416" height="833" alt="Screenshot 2026-03-16 162449" src="https://github.com/user-attachments/assets/46262b16-abb3-4ffb-b264-75c02de44675" />

After:
<img width="413" height="667" alt="image" src="https://github.com/user-attachments/assets/9a04e610-2be9-4b33-9043-c42168e2ff42" />




