### PR TITLE
fix(aggiemap-angular) Put main campus parking back in all.definitions file

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -50,6 +50,7 @@ import { AVPParkingTs } from './avp-parking.definitions';
 import { NscParkingTs } from './nsc-parking.definitions';
 import { BreakSummerParkingTs } from './break-summer.definitions';
 import { SustainableTransportationTs } from './sustainable-transportation.definitions';
+import { TsMainParkingTs } from './main-parking.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -102,5 +103,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   AVPParkingTs,
   NscParkingTs,
   BreakSummerParkingTs,
-  SustainableTransportationTs
+  SustainableTransportationTs,
+  TsMainParkingTs
 ];


### PR DESCRIPTION
Main campus parking got removed from the definitions registry file and thus stopped showing up on Aggiemap. This PR adds it back.