### PR TITLE
fix(aggiemap-angular): Reorder Physics Festival layers and fix issues with visibility toggle

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -213,7 +213,7 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
     type: 'group',
     id: PhysEngFestDefinitions.EASTBOUND_UNIVERSITY_GROUP.id,
     title: PhysEngFestDefinitions.EASTBOUND_UNIVERSITY_GROUP.name,
-    visible: true,
+    visible: false,
     listMode: 'show',
     sources: [
       {
@@ -269,7 +269,7 @@ export const PhysEngFestivalColdLayerSources: LayerSource[] = [
     type: 'group',
     id: PhysEngFestDefinitions.WESTBOUND_UNIVERSITY_GROUP.id,
     title: PhysEngFestDefinitions.WESTBOUND_UNIVERSITY_GROUP.name,
-    visible: true,
+    visible: false,
     listMode: 'show',
     sources: [
       {
@@ -331,7 +331,38 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   introductionText: 'Get the best parking information for the Physics and Engineering Festival.',
   eventDates: ['2026-03-28'],
   mapCenter: [-96.33771, 30.62143],
-  zoom: 17
+  zoom: 17,
+  legendAllowVisibilityToggle: true,
+  legendCombineChildrenUnderPrimary: true,
+  legendExcludedLayerIds: [
+    'aggieprint-locations-layer',
+    'accessible-entrances-layer',
+    'visitor-parking-layer',
+    'lactation-rooms-layer',
+    'poi-layer',
+    'construction_zone-layer',
+    'dining-locations-layer',
+    'family-friendly-bathrooms-locations-layer',
+    'emergency-phones-layer'
+  ],
+  defaultLayerOverrides: {
+    'aggieprint-locations-layer': { listMode: 'hide' },
+    'accessible-entrances-layer': { listMode: 'hide' },
+    'visitor-parking-layer': { listMode: 'hide' },
+    'lactation-rooms-layer': { listMode: 'hide' },
+    'poi-layer': { listMode: 'hide' },
+    'construction_zone-layer': { listMode: 'hide' },
+    'dining-locations-layer': { listMode: 'hide' },
+    'family-friendly-bathrooms-locations-layer': { listMode: 'hide' },
+    'emergency-phones-layer': { listMode: 'hide' },
+    'bonfire-layer': { listMode: 'hide' },
+    'surface-lots-layer': { listMode: 'hide' },
+    'bike-locations-layer': { listMode: 'hide' },
+    'sustainable-transportation-group-layer': {
+      listMode: 'hide',
+      native: { listMode: 'hide' }
+    }
+  }
 };
 
 export const PhysicsAndEngineeringFestivalOptions: SpecialEventOptions = [];


### PR DESCRIPTION
This PR sets the General Parking as the default layer for the Physics festival maps and fixes an issue with the toggle-able visibility from the dropdowns not working.

Before:

<img width="1740" height="1193" alt="image" src="https://github.com/user-attachments/assets/180c8644-8c59-4b31-ad3b-e72bb9e68aa6" />

After:
<img width="2103" height="1050" alt="image" src="https://github.com/user-attachments/assets/1ac28ce0-f795-4fa9-b893-61ac75160a45" />

Closes #655 