### PR TITLE
fix(aggiemap-angular): Remove unnecessary reserved parking layers and updated volleyball on sports maps

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -46,12 +46,6 @@ const crossCountryAreaRenderer: FeatureRenderer = {
 const crossCountryParkingRenderer: FeatureRenderer = {
   type: 'unique-value',
   field: 'GIS.TS.SPEV_Lot_Use.TrackXC',
-  defaultLabel: 'Reserved Parking - Permit Required',
-  defaultSymbol: {
-    type: 'simple-fill',
-    color: [241, 184, 96, 255],
-    outline: null
-  } as unknown as esri.SymbolProperties,
   uniqueValueInfos: [
     {
       value: 'EventParking',

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -110,12 +110,6 @@ export const SoccerParkingColdLayerSources: LayerSource[] = [
       renderer: {
         type: 'unique-value',
         field: 'GIS.TS.SPEV_Lot_Use.Soccer',
-        defaultLabel: 'Reserved Parking - Permit Required',
-        defaultSymbol: {
-          type: 'simple-fill',
-          color: [241, 184, 96, 255],
-          outline: null
-        } as unknown as esri.SymbolProperties,
         uniqueValueInfos: [
           {
             value: 'AnyValidRec',

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -107,12 +107,6 @@ export const SwimmingParkingColdLayerSources: LayerSource[] = [
       renderer: {
         type: 'unique-value',
         field: 'GIS.TS.SPEV_Lot_Use.Swimming',
-        defaultLabel: 'Reserved Parking - Permit Required',
-        defaultSymbol: {
-          type: 'simple-fill',
-          color: [241, 184, 96, 255],
-          outline: null
-        } as unknown as esri.SymbolProperties,
         uniqueValueInfos: [
           {
             value: 'AnyValidRec',

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -110,7 +110,7 @@ export const VolleyballParkingColdLayerSources: LayerSource[] = [
       renderer: {
         type: 'unique-value',
         field: 'GIS.TS.SPEV_Lot_Use.Volleyball',
-        defaultLabel: 'Reserved Parking - Permit Required',
+        defaultLabel: 'Accessible Parking Only',
         defaultSymbol: {
           type: 'simple-fill',
           color: [241, 184, 96, 255],


### PR DESCRIPTION
This PR removes the Reserved Parking layers from Soccer, Swimming, and Cross Country, and updated the Reserved Parking on Volleyball to "Accessible Parking Only."

Close #654