### PR TITLE
fix(aggiemap-angular) Combine Sustainable Transporation bike rack layers

### DIFF
--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -21,6 +21,7 @@
       [deduplicateChildren]="deduplicate"
       [respectDefinitionExpression]="respectDefinitionExpression"
       [hideGroupHeader]="hideElementGroupHeaders"
+      [useBikeRackLegendTransform]="useBikeRackLegendTransform"
     ></tamu-gisc-legend-element>
 
     <tamu-gisc-legend-collection
@@ -31,6 +32,7 @@
       [respectDefinitionExpression]="respectDefinitionExpression"
       [allowVisibilityToggle]="allowVisibilityToggle"
       [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
+      [useBikeRackLegendTransform]="useBikeRackLegendTransform"
       [hideElementGroupHeaders]="childHideElementGroupHeaders"
     ></tamu-gisc-legend-collection>
   </div>

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -32,6 +32,9 @@ export class LegendCollectionComponent {
   public combineChildrenUnderPrimary = false;
 
   @Input()
+  public useBikeRackLegendTransform: boolean | undefined = undefined;
+
+  @Input()
   public hideElementGroupHeaders = false;
 
   public expanded = true;

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -11,7 +11,7 @@ of the table -->
     (keydown.enter)="toggleExpanded()"
     (keydown.space)="toggleExpanded(); $event.preventDefault()"
   >
-    <span class="material-icons">{{ expanded ? 'expand_more' : 'chevron_right' }}</span> {{ groupTitle }}
+    <span class="material-icons">{{ expanded ? 'expand_more' : 'chevron_right' }}</span> {{ displayGroupTitle }}
   </div>
 
   <!-- Safety First layers always use the hardcoded fallback regardless of element type -->
@@ -54,10 +54,10 @@ of the table -->
           </div>
 
           <!-- Apply the legend item from the parent group or child -->
-          <div [ngSwitch]="element.infos?.length">
-            <div *ngSwitchCase="1" class="group-title">{{ groupTitle }}</div>
-            <div *ngSwitchDefault class="label">{{ info?.label }}</div>
-          </div>
+          <div *ngIf="useGroupTitleLabel; else legendInfoLabel" class="group-title">{{ displayGroupTitle }}</div>
+          <ng-template #legendInfoLabel>
+            <div class="label">{{ info?.label }}</div>
+          </ng-template>
         </div>
       </div>
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -41,6 +41,7 @@ of the table -->
                 [deduplicateChildren]="deduplicateChildren"
                 [respectDefinitionExpression]="respectDefinitionExpression"
                 [hideGroupHeader]="hideGroupHeader"
+                [useBikeRackLegendTransform]="useBikeRackLegendTransform"
               ></tamu-gisc-legend-element>
             </div>
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 
 import { EsriModuleProviderService } from '@tamu-gisc/maps/esri';
 
@@ -22,6 +23,7 @@ describe('LegendElementComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(LegendElementComponent);
     component = fixture.componentInstance;
+    component.element = { type: 'symbol-table', infos: [] } as unknown as __esri.LegendElement;
     fixture.detectChanges();
   });
 
@@ -39,5 +41,50 @@ describe('LegendElementComponent', () => {
 
     component.toggleExpanded();
     expect(component.expanded).toBe(false);
+  });
+
+  it('keeps shared mobility entries separate while combining regular bike racks', async () => {
+    component.groupTitle = 'Bike Racks';
+    component.layer = {
+      id: 'bike-racks-map-layer',
+      url: 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0'
+    } as unknown as __esri.Layer;
+    component.element = {
+      type: 'symbol-table',
+      infos: [
+        {
+          type: 'symbol-table',
+          title: 'Shared Mobility',
+          infos: [
+            { label: 'Hub Corral', src: 'red-icon', value: 'hub' },
+            { label: 'Shared Mobility Racks', src: 'teal-icon', value: 'shared' }
+          ]
+        },
+        {
+          type: 'symbol-table',
+          title: 'Regular Bike Racks',
+          infos: [
+            { label: 'Coat Hanger', src: 'blue-icon', value: 'coat' },
+            { label: 'DP', src: 'blue-icon', value: 'dp' }
+          ]
+        }
+      ]
+    } as unknown as __esri.LegendElement;
+
+    await component.ngOnInit();
+
+    const infos = await firstValueFrom(component.infos);
+
+    expect(component.showGroupHeader).toBe(false);
+    expect(component.useGroupTitleLabel).toBe(false);
+    expect(infos).toHaveLength(3);
+    expect(infos.map((info) => (info as { label?: string }).label)).toEqual([
+      'Hub Corral',
+      'Shared Mobility Racks',
+      'Bike Racks'
+    ]);
+    expect((infos[0] as { src?: string }).src).toBe('red-icon');
+    expect((infos[1] as { src?: string }).src).toBe('teal-icon');
+    expect((infos[2] as { src?: string }).src).toBe('blue-icon');
   });
 });

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -43,7 +43,35 @@ describe('LegendElementComponent', () => {
     expect(component.expanded).toBe(false);
   });
 
-  it('keeps shared mobility entries separate while combining regular bike racks', async () => {
+  it('does not transform non-bike-rack legend entries by default', async () => {
+    component.groupTitle = 'Bike Racks';
+    component.layer = {
+      id: 'some-other-layer',
+      url: 'https://gis.it.tamu.edu/arcgis/rest/services/TS/OtherLayer/MapServer/0'
+    } as unknown as __esri.Layer;
+    component.element = {
+      infos: [
+        { label: 'Hub Corral', src: 'red-icon', value: 'hub' },
+        { label: 'Shared Mobility Racks', src: 'teal-icon', value: 'shared' },
+        { label: 'Coat Hanger', src: 'blue-icon', value: 'coat' },
+        { label: 'DP', src: 'blue-icon', value: 'dp' }
+      ]
+    } as unknown as __esri.LegendElement;
+
+    await component.ngOnInit();
+
+    const infos = await firstValueFrom(component.infos);
+
+    expect(infos.map((info) => (info as { label?: string }).label)).toEqual([
+      'Hub Corral',
+      'Shared Mobility Racks',
+      'Coat Hanger',
+      'DP'
+    ]);
+    expect(component.useGroupTitleLabel).toBe(false);
+  });
+
+  it('keeps shared mobility entries separate while combining regular bike racks by default', async () => {
     component.groupTitle = 'Bike Racks';
     component.layer = {
       id: 'bike-racks-map-layer',
@@ -86,5 +114,50 @@ describe('LegendElementComponent', () => {
     expect((infos[0] as { src?: string }).src).toBe('red-icon');
     expect((infos[1] as { src?: string }).src).toBe('teal-icon');
     expect((infos[2] as { src?: string }).src).toBe('blue-icon');
+  });
+
+  it('can explicitly disable the bike rack legend transform', async () => {
+    component.groupTitle = 'Bike Racks';
+    component.useBikeRackLegendTransform = false;
+    component.layer = {
+      id: 'bike-racks-map-layer',
+      url: 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0'
+    } as unknown as __esri.Layer;
+    component.element = {
+      infos: [
+        { label: 'Hub Corral', src: 'red-icon', value: 'hub' },
+        { label: 'Shared Mobility Racks', src: 'teal-icon', value: 'shared' },
+        { label: 'Coat Hanger', src: 'blue-icon', value: 'coat' },
+        { label: 'DP', src: 'blue-icon', value: 'dp' }
+      ]
+    } as unknown as __esri.LegendElement;
+
+    await component.ngOnInit();
+
+    const infos = await firstValueFrom(component.infos);
+
+    expect(infos.map((info) => (info as { label?: string }).label)).toEqual([
+      'Hub Corral',
+      'Shared Mobility Racks',
+      'Coat Hanger',
+      'DP'
+    ]);
+  });
+
+  it('uses the group title label for non-bike single-entry legend elements', async () => {
+    component.groupTitle = 'Baseball Symbols';
+    component.layer = {
+      id: 'baseball-event-symbols',
+      url: 'https://gis.tamu.edu/arcgis/rest/services/TS/BaseballParking/MapServer/0'
+    } as unknown as __esri.Layer;
+    component.element = {
+      infos: [{ label: 'Reserved', src: 'baseball-icon', value: 'reserved' }]
+    } as unknown as __esri.LegendElement;
+
+    await component.ngOnInit();
+
+    expect(component.showGroupHeader).toBe(false);
+    expect(component.useGroupTitleLabel).toBe(true);
+    expect(component.displayGroupTitle).toBe('Baseball Symbols');
   });
 });

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -87,6 +87,9 @@ export class LegendElementComponent implements OnInit {
   @Input()
   public hideGroupHeader = false;
 
+  @Input()
+  public useBikeRackLegendTransform: boolean | undefined = undefined;
+
   public infos: Observable<Array<LegendInfo>>;
   public expanded = true;
 
@@ -95,7 +98,7 @@ export class LegendElementComponent implements OnInit {
       return false;
     }
 
-    if (this.shouldUseCustomBikeRackLegend) {
+    if (this.shouldApplyBikeRackLegendTransform) {
       return false;
     }
 
@@ -105,7 +108,7 @@ export class LegendElementComponent implements OnInit {
   }
 
   public get useGroupTitleLabel(): boolean {
-    return !this.shouldUseCustomBikeRackLegend && this.element?.infos?.length === 1;
+    return !this.shouldApplyBikeRackLegendTransform && this.element?.infos?.length === 1;
   }
 
   public get displayGroupTitle(): string {
@@ -125,7 +128,7 @@ export class LegendElementComponent implements OnInit {
     }
 
     const operableInfos = (this.element.infos ?? []) as Array<LegendInfo>;
-    const displayInfos = this.shouldUseCustomBikeRackLegend ? this._getBikeRackLegendInfos(operableInfos) : operableInfos;
+    const displayInfos = this.shouldApplyBikeRackLegendTransform ? this._getBikeRackLegendInfos(operableInfos) : operableInfos;
 
     this.infos = iif(
       () => {
@@ -348,6 +351,12 @@ export class LegendElementComponent implements OnInit {
     } else {
       return of(null);
     }
+  }
+
+  private get shouldApplyBikeRackLegendTransform(): boolean {
+    return this.useBikeRackLegendTransform === undefined
+      ? this.shouldUseCustomBikeRackLegend
+      : this.useBikeRackLegendTransform && this.shouldUseCustomBikeRackLegend;
   }
 
   private get shouldUseCustomBikeRackLegend(): boolean {

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -55,6 +55,15 @@ export class LegendElementComponent implements OnInit {
 
   private readonly sportsSafetyFirstLegendLabel = 'Please use marked crosswalks. No mid-street crossing.';
 
+  private readonly collapsedLegendLayerIds = new Set([
+    'bike-racks-layer',
+    'bike-racks-map-layer',
+    'sustainable-transportation-bike-racks',
+    'ts-bike-racks'
+  ]);
+
+  private readonly collapsedLegendLayerUrls = ['/TS/TS_Bicycles/MapServer/3', '/TS/BikeMap/MapServer/0'];
+
   @Input()
   public element: ILegendElement;
 
@@ -86,9 +95,21 @@ export class LegendElementComponent implements OnInit {
       return false;
     }
 
+    if (this.shouldUseCustomBikeRackLegend) {
+      return false;
+    }
+
     const infos = this.element?.infos as { length?: number } | undefined;
 
     return typeof infos?.length === 'number' && infos.length > 1;
+  }
+
+  public get useGroupTitleLabel(): boolean {
+    return !this.shouldUseCustomBikeRackLegend && this.element?.infos?.length === 1;
+  }
+
+  public get displayGroupTitle(): string {
+    return this.groupTitle;
   }
 
   public toggleExpanded(): void {
@@ -104,17 +125,18 @@ export class LegendElementComponent implements OnInit {
     }
 
     const operableInfos = (this.element.infos ?? []) as Array<LegendInfo>;
+    const displayInfos = this.shouldUseCustomBikeRackLegend ? this._getBikeRackLegendInfos(operableInfos) : operableInfos;
 
     this.infos = iif(
       () => {
         return this.deduplicateChildren;
       },
       from(
-        operableInfos.filter((info, index, self) => {
+        displayInfos.filter((info, index, self) => {
           return index === self.findIndex((t) => t.label === info.label);
         }) as Array<LegendInfo>
       ),
-      from(operableInfos)
+      from(displayInfos)
     ).pipe(
       concatMap((info: LegendInfo) => {
         // If we are not respecting definition expressions, return the current legend info as-is
@@ -326,6 +348,134 @@ export class LegendElementComponent implements OnInit {
     } else {
       return of(null);
     }
+  }
+
+  private get shouldUseCustomBikeRackLegend(): boolean {
+    const layerCandidates = [this.layer, (this.layer as unknown as esri.Sublayer)?.layer].filter((candidate) => {
+      return candidate !== null && candidate !== undefined;
+    }) as Array<{ id?: string; url?: string }>;
+
+    return layerCandidates.some((candidate) => {
+      const url = candidate.url ?? '';
+
+      return (
+        this.collapsedLegendLayerIds.has(candidate.id ?? '') ||
+        this.collapsedLegendLayerUrls.some((collapsedUrl) => url.includes(collapsedUrl))
+      );
+    });
+  }
+
+  private _getBikeRackLegendInfos(infos: Array<LegendInfo>): Array<LegendInfo> {
+    const flattenedInfos = this._flattenLegendInfos(infos);
+
+    if (flattenedInfos.length <= 1) {
+      return flattenedInfos;
+    }
+
+    const hubCorralInfo = flattenedInfos.find((info) => this._matchesLegendInfoLabel(info, 'Hub Corral'));
+    const sharedMobilityInfo = flattenedInfos.find((info) => this._matchesLegendInfoLabel(info, 'Shared Mobility Racks'));
+    const regularBikeRackInfos = flattenedInfos.filter((info) => !this._isBikeRackSpecialLegendLabel(info));
+
+    const displayInfos: Array<LegendInfo> = [];
+
+    if (hubCorralInfo) {
+      displayInfos.push(hubCorralInfo);
+    }
+
+    if (sharedMobilityInfo) {
+      displayInfos.push(sharedMobilityInfo);
+    }
+
+    if (regularBikeRackInfos.length > 0) {
+      const representativeInfo = this._getRepresentativeLegendInfo(regularBikeRackInfos);
+
+      displayInfos.push({
+        ...(representativeInfo as unknown as Record<string, unknown>),
+        label: 'Bike Racks'
+      } as LegendInfo);
+    }
+
+    return displayInfos.length > 0 ? displayInfos : flattenedInfos;
+  }
+
+  private _flattenLegendInfos(infos: Array<LegendInfo>): Array<LegendInfo> {
+    return infos.reduce<Array<LegendInfo>>((acc, info) => {
+      const nestedInfos = this._toLegendInfoArray((info as { infos?: unknown }).infos);
+
+      if ((info as { type?: string }).type === 'symbol-table' && nestedInfos.length > 0) {
+        return acc.concat(this._flattenLegendInfos(nestedInfos));
+      }
+
+      return acc.concat(info);
+    }, []);
+  }
+
+  private _toLegendInfoArray(infos: unknown): Array<LegendInfo> {
+    if (!infos) {
+      return [];
+    }
+
+    if (Array.isArray(infos)) {
+      return infos as Array<LegendInfo>;
+    }
+
+    const collection = infos as { toArray?: () => Array<LegendInfo>; length?: number; getItemAt?: (index: number) => LegendInfo };
+
+    if (typeof collection.toArray === 'function') {
+      return collection.toArray();
+    }
+
+    if (typeof collection.length === 'number' && typeof collection.getItemAt === 'function') {
+      return Array.from({ length: collection.length }, (_, index) => collection.getItemAt(index));
+    }
+
+    return [];
+  }
+
+  private _matchesLegendInfoLabel(info: LegendInfo, label: string): boolean {
+    return ((info as { label?: string }).label ?? '').trim().toLowerCase() === label.toLowerCase();
+  }
+
+  private _isBikeRackSpecialLegendLabel(info: LegendInfo): boolean {
+    return this._matchesLegendInfoLabel(info, 'Hub Corral') || this._matchesLegendInfoLabel(info, 'Shared Mobility Racks');
+  }
+
+  private _getRepresentativeLegendInfo(infos: Array<LegendInfo>): LegendInfo {
+    const counts = new Map<string, { count: number; firstIndex: number }>();
+
+    infos.forEach((info, index) => {
+      const key = this._getLegendInfoSymbolKey(info);
+      const existing = counts.get(key);
+
+      counts.set(key, {
+        count: (existing?.count ?? 0) + 1,
+        firstIndex: existing?.firstIndex ?? index
+      });
+    });
+
+    const representativeKey = Array.from(counts.entries()).sort((a, b) => {
+      if (a[1].count !== b[1].count) {
+        return b[1].count - a[1].count;
+      }
+
+      return a[1].firstIndex - b[1].firstIndex;
+    })[0]?.[0];
+
+    return infos.find((info) => this._getLegendInfoSymbolKey(info) === representativeKey) ?? infos[0];
+  }
+
+  private _getLegendInfoSymbolKey(info: LegendInfo): string {
+    const legendInfo = info as { src?: string; preview?: unknown; label?: string };
+
+    if (legendInfo.src) {
+      return `src:${legendInfo.src}`;
+    }
+
+    if (legendInfo.preview) {
+      return `preview:${String(legendInfo.preview)}`;
+    }
+
+    return `label:${legendInfo.label ?? ''}`;
   }
 }
 

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.html
@@ -13,5 +13,6 @@
     [respectDefinitionExpression]="respectDefinitionExpression"
     [allowVisibilityToggle]="allowVisibilityToggle"
     [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
+    [useBikeRackLegendTransform]="useBikeRackLegendTransform"
   ></tamu-gisc-legend-collection>
 </div>

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -36,6 +36,9 @@ export class LegendComponent implements OnInit, OnDestroy {
   @Input()
   public combineChildrenUnderPrimary = false;
 
+  @Input()
+  public useBikeRackLegendTransform: boolean | undefined = undefined;
+
   public legend: Observable<Array<esri.ActiveLayerInfo>>;
 
   public responsive: ResponsiveSnapshot;
@@ -60,6 +63,8 @@ export class LegendComponent implements OnInit, OnDestroy {
       this.excludedLayerIds = routeData['excludedLayerIds'] ?? this.excludedLayerIds;
       this.combineChildrenUnderPrimary =
         routeData['combineChildrenUnderPrimary'] ?? this.combineChildrenUnderPrimary;
+      this.useBikeRackLegendTransform =
+        routeData['useBikeRackLegendTransform'] ?? this.useBikeRackLegendTransform;
     }
 
     this.legend = this.legendService.legend({


### PR DESCRIPTION
This PR combines the numerous bike rack types under Sustainable Transporation into one bike rack layer:

### Before:
<img width="409" height="1117" alt="image" src="https://github.com/user-attachments/assets/3e454c0f-35f8-4d69-947d-2d81f8465b50" />

### After:
<img width="401" height="704" alt="image" src="https://github.com/user-attachments/assets/dd0c93ff-4221-4d56-83c0-c4e301cf1028" />

Closes #661 