### PR TITLE
fix(aggiemap-angular): Update factory in deployment environment to use env. "dev"

### DIFF
--- a/apps/aggiemap-angular/src/environments/environment.ts
+++ b/apps/aggiemap-angular/src/environments/environment.ts
@@ -13,7 +13,7 @@ export { SelectionSymbols, Polygons } from '@tamu-gisc/aggiemap/ngx/common';
 export * from './notification-events';
 
 const sources = factory({
-  environment: 'prod'
+  environment: 'dev'
 });
 
 export const { Definitions, Connections, SearchSources, ThreeDLayers, LayerSources } = sources;


### PR DESCRIPTION
Updates the factory to use env. "dev" in https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/blob/95e05eb16cac691f55bbb1f75ee0d531dc470f0d/apps/aggiemap-angular/src/environments/environment.ts#L16[/+][-]

Closes #663 