### PR TITLE
feat(aggiemap-angular): Add tab columns + new map type metadata for each parking map

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -11,7 +11,6 @@
     </div>
 
     <div class="discover-container">
-      <!-- Search Section -->
       <div class="search-section trailer-3">
         <h2>Search Maps</h2>
         <div class="search-input-container">
@@ -20,9 +19,9 @@
               <div class="flex flex-column">
                 <div class="flex flex-row align-center title">
                   <span class="app-name">{{ app.name }}</span>
-                  <span class="chip chip-internal" *ngIf="app.source === 'internal'">{{app.type | uppercase}}</span>
+                  <span class="chip chip-internal" *ngIf="app.source === 'internal'">{{ app.type | uppercase }}</span>
                   <span class="chip chip-external" *ngIf="app.source === 'external'">Experimental</span>
-                  <span class="chip chip-label" *ngFor="let label of app.labels">{{ label | uppercase}}</span>
+                  <span class="chip chip-label" *ngFor="let label of app.labels">{{ label | uppercase }}</span>
                 </div>
                 <span class="application-description" *ngIf="app.description">{{ app.description }}</span>
               </div>
@@ -31,50 +30,114 @@
         </div>
       </div>
 
-      <!-- Upcoming Events Section -->
       <div class="upcoming-events-section trailer-3">
         <h2>Upcoming Events</h2>
         <p class="section-description">Top 3 upcoming events.</p>
 
-        <div class="events-list" *ngIf="upcomingEvents.length > 0; else noUpcomingEvents">
-          <div class="event-card" *ngFor="let event of upcomingEvents; let i = index" (click)="onApplicationSelect(getApplicationFromEvent(event))">
+        <div class="events-list" *ngIf="upcomingApplications.length > 0; else noUpcomingEvents">
+          <div class="event-card" *ngFor="let app of upcomingApplications; let i = index" (click)="onApplicationSelect(app)">
             <div class="event-card-header">
               <span class="event-rank">#{{ i + 1 }}</span>
-              <h3 class="event-title">{{ event.name }}</h3>
+              <h3 class="event-title">{{ app.name }}</h3>
             </div>
             <div class="event-card-content">
-              <div class="event-dates"><strong>Dates:</strong> {{ getEventDateRange(event.eventDates) }}</div>
+              <div class="event-dates"><strong>Dates:</strong> {{ getEventDateRange(app.configuration.eventDates) }}</div>
             </div>
           </div>
         </div>
 
         <ng-template #noUpcomingEvents>
-          <div class="no-events-message">
+          <div class="empty-state">
             <p>No upcoming events found at this time.</p>
           </div>
         </ng-template>
       </div>
 
-      <!-- Parking Maps Section -->
-      <div class="parking-maps-section trailer-3" *ngIf="parkingColumns[0].length + parkingColumns[1].length > 0">
-        <h2>Parking Maps</h2>
-        <p class="section-description">Browse available parking maps for Texas A&M University campus.</p>
+      <div class="discover-tabs-section trailer-3">
+        <tamu-gisc-tabs class="discover-tabs">
+          <tamu-gisc-tab label="Parking Maps">
+            <div class="tab-section">
+              <h2>Parking Maps</h2>
+              <p class="section-description">Browse available parking maps for Texas A&amp;M University campus.</p>
 
-        <div class="parking-columns">
-          <ol class="parking-links">
-            <li class="parking-link-item" *ngFor="let app of parkingColumns[0]">
-              <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
-            </li>
-          </ol>
-          <ol class="parking-links" *ngIf="parkingColumns[1].length > 0" [attr.start]="parkingColumnStart">
-            <li class="parking-link-item" *ngFor="let app of parkingColumns[1]">
-              <a class="parking-link" [routerLink]="['/parking', app.id]" target="_blank" rel="noopener">{{ app.name }}</a>
-            </li>
-          </ol>
-        </div>
+              <div class="map-columns" *ngIf="parkingColumns[0].length + parkingColumns[1].length > 0; else noParkingMaps">
+                <ol class="map-links">
+                  <li class="map-link-item" *ngFor="let app of parkingColumns[0]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+
+                <ol class="map-links" *ngIf="parkingColumns[1].length > 0" [attr.start]="parkingColumnStart">
+                  <li class="map-link-item" *ngFor="let app of parkingColumns[1]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+              </div>
+
+              <ng-template #noParkingMaps>
+                <div class="empty-state">
+                  <p>No parking maps are available right now.</p>
+                </div>
+              </ng-template>
+            </div>
+          </tamu-gisc-tab>
+
+          <tamu-gisc-tab label="Campus Events">
+            <div class="tab-section">
+              <h2>Campus Events</h2>
+              <p class="section-description">Browse campus event maps for transportation, parking, and special events.</p>
+
+              <div class="map-columns" *ngIf="campusColumns[0].length + campusColumns[1].length > 0; else noCampusEvents">
+                <ol class="map-links">
+                  <li class="map-link-item" *ngFor="let app of campusColumns[0]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+
+                <ol class="map-links" *ngIf="campusColumns[1].length > 0" [attr.start]="campusColumnStart">
+                  <li class="map-link-item" *ngFor="let app of campusColumns[1]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+              </div>
+
+              <ng-template #noCampusEvents>
+                <div class="empty-state">
+                  <p>No campus event maps are available right now.</p>
+                </div>
+              </ng-template>
+            </div>
+          </tamu-gisc-tab>
+
+          <tamu-gisc-tab label="Athletic Events">
+            <div class="tab-section">
+              <h2>Athletic Events</h2>
+              <p class="section-description">Browse athletic event maps for game day parking and transportation information.</p>
+
+              <div class="map-columns" *ngIf="athleticColumns[0].length + athleticColumns[1].length > 0; else noAthleticEvents">
+                <ol class="map-links">
+                  <li class="map-link-item" *ngFor="let app of athleticColumns[0]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+
+                <ol class="map-links" *ngIf="athleticColumns[1].length > 0" [attr.start]="athleticColumnStart">
+                  <li class="map-link-item" *ngFor="let app of athleticColumns[1]">
+                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+                  </li>
+                </ol>
+              </div>
+
+              <ng-template #noAthleticEvents>
+                <div class="empty-state">
+                  <p>No athletic event maps are available right now.</p>
+                </div>
+              </ng-template>
+            </div>
+          </tamu-gisc-tab>
+        </tamu-gisc-tabs>
       </div>
 
-      <!-- Experimental Applications Section -->
       <div class="experimental-applications-section" *ngIf="(isDev | async) === true">
         <h2>Experimental Applications</h2>
         <p class="section-description">Explore experimental maps and applications</p>

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -7,12 +7,21 @@
   }
 }
 
-.search-section {
+.search-section,
+.upcoming-events-section,
+.tab-section,
+.experimental-applications-section {
   h2 {
     color: #500000;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.5rem;
     font-size: 1.5rem;
     font-weight: 600;
+  }
+}
+
+.search-section {
+  h2 {
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -75,15 +84,6 @@
   }
 }
 
-.upcoming-events-section {
-  h2 {
-    color: #500000;
-    margin-bottom: 0.5rem;
-    font-size: 1.5rem;
-    font-weight: 600;
-  }
-}
-
 .section-description {
   color: #666;
   font-style: italic;
@@ -117,10 +117,6 @@
   align-items: center;
   gap: 1rem;
   margin-bottom: 0.75rem;
-
-  @media (max-width: 768px) {
-    gap: 0.5rem;
-  }
 }
 
 .application-card-header {
@@ -156,8 +152,7 @@
   flex-shrink: 0;
 }
 
-.event-dates,
-.event-id {
+.event-dates {
   font-size: 0.875rem;
   color: #666;
 
@@ -166,7 +161,7 @@
   }
 }
 
-.no-events-message {
+.empty-state {
   text-align: center;
   padding: 2rem;
   color: #666;
@@ -175,31 +170,51 @@
   border-radius: 8px;
 }
 
-.experimental-applications-section {
-  h2 {
-    color: #500000;
-    margin-bottom: 0.5rem;
-    font-size: 1.5rem;
-    font-weight: 600;
-  }
+.discover-tabs-section {
+  margin-top: 2rem;
 }
 
-.applications-list {
+:host ::ng-deep tamu-gisc-tabs.discover-tabs {
+  display: block;
+  width: 100%;
+}
+
+:host ::ng-deep tamu-gisc-tabs.discover-tabs .tabs {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
+  border-bottom: 1px solid #e1e1e1;
 }
 
-.parking-maps-section {
-  h2 {
-    color: #500000;
-    margin-bottom: 0.5rem;
-    font-size: 1.5rem;
-    font-weight: 600;
-  }
+:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab {
+  padding: 0.1rem 1rem;
+  cursor: pointer;
+  color: #500000;
+  text-align: center;
+  border-bottom: 4px solid transparent;
+  font-size: 1.05rem;
+  font-weight: 600;
 }
 
-.parking-links {
+:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab p {
+  margin: 0;
+}
+
+:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab.active {
+  border-bottom-color: #500000;
+}
+
+:host ::ng-deep tamu-gisc-tabs.discover-tabs .content {
+  padding-top: 1.0rem;
+}
+
+.map-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 2rem;
+}
+
+.map-links {
   margin: 0;
   padding-left: 1.5rem;
   display: flex;
@@ -207,21 +222,11 @@
   gap: 0.5rem;
 }
 
-.parking-columns {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem 2rem;
-
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
-  }
-}
-
-.parking-link-item {
+.map-link-item {
   margin: 0;
 }
 
-.parking-link {
+.map-link {
   color: #500000;
   text-decoration: none;
   font-weight: 600;
@@ -230,6 +235,12 @@
   &:focus {
     text-decoration: underline;
   }
+}
+
+.applications-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
 }
 
 .application-description {
@@ -256,16 +267,39 @@
 }
 
 .chip-internal {
-  background-color: #1e88e5; /* md-bg-blue-500 */
+  background-color: #1e88e5;
   color: white;
 }
 
 .chip-external {
-  background-color: #f57c00; /* md-bg-orange-500 */
+  background-color: #f57c00;
   color: white;
 }
 
 .chip-label {
-  background-color: #e0e0e0; /* md-bg-gray-300 */
+  background-color: #e0e0e0;
   color: black;
+}
+
+@media (max-width: 768px) {
+  .event-card-header {
+    gap: 0.5rem;
+  }
+
+  :host ::ng-deep tamu-gisc-tabs.discover-tabs .tabs {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
+
+  :host ::ng-deep tamu-gisc-tabs.discover-tabs .tab {
+    min-width: 10rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .map-columns,
+  .applications-list {
+    grid-template-columns: 1fr;
+  }
 }

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -1,10 +1,10 @@
+import { Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { combineLatest, Observable } from 'rxjs';
 import { debounceTime, map, shareReplay, startWith } from 'rxjs/operators';
 
-import { EventConfiguration } from '@tamu-gisc/ts/events/ngx';
-import { Router } from '@angular/router';
+import { DiscoverMapType } from '@tamu-gisc/ts/events/ngx';
 
 import {
   DiscoverApplication,
@@ -23,10 +23,17 @@ export class DiscoverComponent implements OnInit {
   public externalApplications: ExternalDiscoverApplication[];
   private eventDiscoverApplications: InternalDiscoverApplication[];
   public allApplications: DiscoverApplication[];
-  private allEvents: EventConfiguration[];
-  public upcomingEvents: EventConfiguration[];
+
+  public upcomingApplications: InternalDiscoverApplication[] = [];
+
   public parkingColumns: InternalDiscoverApplication[][] = [[], []];
   public parkingColumnStart = 1;
+
+  public campusColumns: InternalDiscoverApplication[][] = [[], []];
+  public campusColumnStart = 1;
+
+  public athleticColumns: InternalDiscoverApplication[][] = [[], []];
+  public athleticColumnStart = 1;
 
   public searchControl = new FormControl();
   public filteredApplications: Observable<DiscoverApplication[]>;
@@ -44,38 +51,67 @@ export class DiscoverComponent implements OnInit {
     this.externalApplications = this.discoveryService.getExternalDiscoverApplications();
     this.allApplications = this.discoveryService.getAllDiscoverApplications();
 
-    // Transform event definitions into searchable format
-    this.allEvents = this.eventDiscoverApplications
-      .map((e) => e.configuration)
-      .filter((e: EventConfiguration) => {
-        return e !== null && !!e?.id && !!e?.name;
-      });
-
-    // Set up autocomplete filtering
     this.filteredApplications = combineLatest([this.searchControl.valueChanges.pipe(startWith('')), this.isDev]).pipe(
       debounceTime(100),
       map(([value, isDev]) => this._filterApplications(value || '', isDev)),
       shareReplay(1)
     );
 
-    // Calculate upcoming events
-    this.upcomingEvents = this.getUpcomingEvents();
+    this.upcomingApplications = this.getUpcomingApplications();
 
-    // Build ordered parking list and split into two columns
-    const parkingApplications = this.getParkingApplications();
-    this.parkingColumns = this.buildParkingColumns(parkingApplications);
-    this.parkingColumnStart = this.parkingColumns[0].length + 1;
+    const parkingApplications = this.getApplicationsByMapType('parking');
+    this.parkingColumns = this.buildApplicationColumns(parkingApplications);
+    this.parkingColumnStart = this.getSecondColumnStart(this.parkingColumns);
+
+    const campusApplications = this.getApplicationsByMapType('campus');
+    this.campusColumns = this.buildApplicationColumns(campusApplications);
+    this.campusColumnStart = this.getSecondColumnStart(this.campusColumns);
+
+    const athleticApplications = this.getApplicationsByMapType('athletics');
+    this.athleticColumns = this.buildApplicationColumns(athleticApplications);
+    this.athleticColumnStart = this.getSecondColumnStart(this.athleticColumns);
   }
 
-  private getParkingApplications(): InternalDiscoverApplication[] {
-    return this.eventDiscoverApplications
-      .filter((app) => app.type === 'parking')
-      .sort((a, b) => a.name.localeCompare(b.name));
+  private getApplicationsByMapType(mapType: DiscoverMapType): InternalDiscoverApplication[] {
+    const applications = this.eventDiscoverApplications.filter((app) => app.mapType === mapType);
+
+    if (mapType === 'parking') {
+      return applications.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    return this.sortEventApplications(applications);
   }
 
-  private buildParkingColumns(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[][] {
+  private getUpcomingApplications(): InternalDiscoverApplication[] {
+    const now = Date.now();
+
+    return this.sortEventApplications(this.eventDiscoverApplications)
+      .filter((app) => this.getEarliestUpcomingDate(app.configuration.eventDates, now) !== Number.POSITIVE_INFINITY)
+      .slice(0, 3);
+  }
+
+  private buildApplicationColumns(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[][] {
     const midpoint = Math.ceil(apps.length / 2);
     return [apps.slice(0, midpoint), apps.slice(midpoint)];
+  }
+
+  private getSecondColumnStart(columns: InternalDiscoverApplication[][]): number {
+    return columns[0].length + 1;
+  }
+
+  private sortEventApplications(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[] {
+    const now = Date.now();
+
+    return [...apps].sort((a, b) => {
+      const aNextDate = this.getEarliestUpcomingDate(a.configuration.eventDates, now);
+      const bNextDate = this.getEarliestUpcomingDate(b.configuration.eventDates, now);
+
+      if (aNextDate === bNextDate) {
+        return a.name.localeCompare(b.name);
+      }
+
+      return aNextDate - bNextDate;
+    });
   }
 
   private _filterApplications(value: string, isDev: boolean): DiscoverApplication[] {
@@ -103,46 +139,30 @@ export class DiscoverComponent implements OnInit {
     });
   }
 
-  private getUpcomingEvents(): EventConfiguration[] {
-    const now = new Date().getTime();
-
-    return this.allEvents
-      .filter((event) => {
-        // Check if any event date is upcoming or happening now
-        return event.eventDates.some((date) => {
-          const eventTime = this.parseEventDate(date);
-          return eventTime >= now;
-        });
-      })
-      .sort((a, b) => {
-        // Sort by earliest upcoming date
-        const aEarliest = this.getEarliestUpcomingDate(a.eventDates, now);
-        const bEarliest = this.getEarliestUpcomingDate(b.eventDates, now);
-        return aEarliest - bEarliest;
-      })
-      .slice(0, 3); // Top 3
-  }
-
   private parseEventDate(date: string | Date | number): number {
     if (typeof date === 'number') {
       return date;
     }
+
     if (date instanceof Date) {
       return date.getTime();
     }
-    // Treat date-only strings as local dates to avoid UTC day-shift issues.
+
     const dateOnlyMatch = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (dateOnlyMatch) {
       const [, year, month, day] = dateOnlyMatch;
       return new Date(Number(year), Number(month) - 1, Number(day)).getTime();
     }
+
     return new Date(date).getTime();
   }
 
   private getEarliestUpcomingDate(dates: Array<string | Date | number>, now: number): number {
-    const upcomingDates = dates.map((date) => this.parseEventDate(date)).filter((time) => time >= now);
+    const upcomingDates = dates
+      .map((date) => this.parseEventDate(date))
+      .filter((time) => Number.isFinite(time) && time >= now);
 
-    return upcomingDates.length > 0 ? Math.min(...upcomingDates) : Number.MAX_SAFE_INTEGER;
+    return upcomingDates.length > 0 ? Math.min(...upcomingDates) : Number.POSITIVE_INFINITY;
   }
 
   public onApplicationSelect(app: DiscoverApplication | undefined): void {
@@ -152,19 +172,14 @@ export class DiscoverComponent implements OnInit {
       window.open((app as ExternalDiscoverApplication).location, '_blank');
     } else if (app.source === 'internal') {
       const config = (app as InternalDiscoverApplication).configuration;
-      // Navigate to events intro page
       const routeSegment = app.type === 'event' ? 'events' : app.type;
       this.rt.navigate([`/${routeSegment}`, config.id]);
     }
   }
 
-  public displayApplicationOption(app: DiscoverApplication): string {
-    return app.name || app.id || '';
-  }
-
-  public formatEventDate(date: string | Date | number): string {
-    const dateObj = new Date(this.parseEventDate(date));
-    return dateObj.toLocaleDateString();
+  public getApplicationRoute(app: InternalDiscoverApplication): string[] {
+    const routeSegment = app.type === 'event' ? 'events' : app.type;
+    return [`/${routeSegment}`, app.id];
   }
 
   public getEventDateRange(dates: Array<string | Date | number>): string {
@@ -172,7 +187,7 @@ export class DiscoverComponent implements OnInit {
       return 'No dates available';
     }
 
-    const parsedDates = dates.map((date) => this.parseEventDate(date)).sort();
+    const parsedDates = dates.map((date) => this.parseEventDate(date)).sort((a, b) => a - b);
     const startDate = new Date(parsedDates[0]);
     const endDate = new Date(parsedDates[parsedDates.length - 1]);
 
@@ -181,11 +196,5 @@ export class DiscoverComponent implements OnInit {
     }
 
     return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
-  }
-
-  public getApplicationFromEvent(event: EventConfiguration): DiscoverApplication | undefined {
-    return this.allApplications.find(
-      (app) => app.source === 'internal' && (app as InternalDiscoverApplication).configuration === event
-    );
   }
 }

--- a/libs/aggiemap/ngx/discover/src/lib/discover.module.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/discover.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { AggiemapNgxSharedUiStructuralModule } from '@tamu-gisc/aggiemap/ngx/ui/shared';
 import { UIFormsModule } from '@tamu-gisc/ui-kits/ngx/forms';
+import { UILayoutModule } from '@tamu-gisc/ui-kits/ngx/layout';
 import { PipesModule } from '@tamu-gisc/common/ngx/pipes';
 
 import { DiscoverComponent } from './components/discover.component';
@@ -22,6 +23,7 @@ const routes: Routes = [
     FormsModule,
     ReactiveFormsModule,
     UIFormsModule,
+    UILayoutModule,
     RouterModule.forChild(routes),
     AggiemapNgxSharedUiStructuralModule,
     PipesModule

--- a/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
@@ -1,4 +1,4 @@
-import { EventConfiguration } from '@tamu-gisc/ts/events/ngx';
+import { DiscoverMapType, EventConfiguration } from '@tamu-gisc/ts/events/ngx';
 
 interface BaseDiscoverApplication {
   id: string;
@@ -23,6 +23,7 @@ export interface ExternalDiscoverApplication extends BaseDiscoverApplication {
 export interface InternalDiscoverApplication extends BaseDiscoverApplication {
   source: 'internal';
   type: 'event' | 'parking';
+  mapType: DiscoverMapType;
   configuration: EventConfiguration;
 }
 

--- a/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.spec.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.spec.ts
@@ -13,4 +13,27 @@ describe('DiscoveryService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('defaults standard event maps to the campus tab', () => {
+    const applications = service.getInternalDiscoverApplications();
+    const aggielandSaturday = applications.find((app) => app.id === 'aggieland-saturday');
+
+    expect(aggielandSaturday?.mapType).toBe('campus');
+  });
+
+  it('keeps general parking maps in the parking tab', () => {
+    const applications = service.getInternalDiscoverApplications();
+    const accessibleParking = applications.find((app) => app.id === 'accessible-parking');
+
+    expect(accessibleParking?.mapType).toBe('parking');
+  });
+
+  it('supports explicit discover tab overrides for athletics and campus parking maps', () => {
+    const applications = service.getInternalDiscoverApplications();
+    const football = applications.find((app) => app.id === 'football-parking');
+    const moveIn = applications.find((app) => app.id === 'move-in');
+
+    expect(football?.mapType).toBe('athletics');
+    expect(moveIn?.mapType).toBe('campus');
+  });
 });

--- a/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
@@ -21,6 +21,7 @@ export class DiscoveryService {
       id: event.discover?.id || event.configuration.id,
       source: 'internal' as const,
       type: event.discover?.type || 'event',
+      mapType: event.discover?.mapType || (event.discover?.type === 'parking' ? 'parking' : 'campus'),
       name: event.discover?.name || event.configuration.name,
       description: event.discover?.description || event.configuration.introductionText || '',
       configuration: event.configuration,

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -247,6 +247,7 @@ export const BaseballParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Baseball event parking with optional accessibility-focused view.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['baseball', 'parking', 'accessible', 'shuttle', 'closure']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -130,6 +130,7 @@ export const CrossCountryParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M cross country events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['cross country', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -608,6 +608,7 @@ export const FootballParkingEvent: AggiemapCustomMapConfiguration = {
     description: 'Transportation and parking information for football game days.',
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['football', 'gameday', 'parking', 'shuttles', 'transportation', 'bike']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -194,6 +194,7 @@ export const IndoorTrackParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M indoor track events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['indoor track', 'parking', 'visitor', 'accessible', 'crosswalk', 'team bus']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -66,6 +66,7 @@ export const MaroonWhiteTs: AggiemapCustomMapConfiguration = {
     description: 'Transportation and parking information for the Maroon & White Game.',
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['maroon', 'white', 'game', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -146,6 +146,7 @@ export const MensBasketball_Ts: AggiemapCustomMapConfiguration = {
     description: "Transportation and parking information for Men's Basketball events.",
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['bike', 'mens-basketball', 'cycling', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -609,6 +609,7 @@ export const MoveInTs: AggiemapCustomMapConfiguration = {
     description: 'Transportation and parking information for Fall Move In.',
     source: 'internal',
     type: 'parking',
+    mapType: 'campus',
     keywords: ['move in', 'fall move in', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -145,6 +145,7 @@ export const OutdoorTrackParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M outdoor track events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['outdoor track', 'parking', 'visitor', 'accessible', 'crosswalk']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -195,6 +195,7 @@ export const SavannahBananasParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Transportation and parking information for Savannah Bananas vs Texas Tailgaters at Kyle Field.',
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['savannah bananas', 'texas tailgaters', 'kyle field', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -187,6 +187,7 @@ export const SoccerParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M soccer events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['soccer', 'parking', 'visitor', 'accessible', 'crosswalk']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -142,6 +142,7 @@ export const SoftballParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M softball events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['softball', 'parking', 'visitor', 'accessible', 'crosswalk']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -121,6 +121,7 @@ export const SoftballRegionalsTs: AggiemapCustomMapConfiguration = {
     description: 'Transportation and parking information for Softball Regionals.',
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['softball', 'regionals', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -177,6 +177,7 @@ export const SwimmingParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M swimming events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['swimming', 'parking', 'visitor', 'accessible', 'crosswalk']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -75,6 +75,7 @@ export const TennisParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M tennis events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['tennis', 'parking']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -193,6 +193,7 @@ export const VolleyballParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking and transportation information for Texas A&M volleyball events.',
     source: 'internal',
     type: 'parking',
+    mapType: 'athletics',
     keywords: ['volleyball', 'parking', 'visitor', 'accessible', 'crosswalk']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -167,6 +167,7 @@ export const WomensBasketball_Ts: AggiemapCustomMapConfiguration = {
     description: "Transportation and parking information for Women's Basketball events.",
     source: 'internal',
     type: 'event',
+    mapType: 'athletics',
     keywords: ['bike', 'womens-basketball', 'cycling', 'parking', 'transportation']
   }
 };

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -317,6 +317,11 @@ interface IGeneralMapRoot extends IMapConfigurationBase {
 export type AggiemapCustomMapConfiguration = ISpecialEventRoot | IGeneralMapRoot;
 
 /**
+ * High-level discover grouping used by the tabbed Discover page UI.
+ */
+export type DiscoverMapType = 'parking' | 'campus' | 'athletics';
+
+/**
  * Metadata used to represent a map in the Discover application.
  */
 export interface DiscoverMetadata {
@@ -333,4 +338,10 @@ export interface DiscoverMetadata {
   labels?: string[];
   source: 'internal';
   type: 'event' | 'parking';
+  /**
+   * Optional tab grouping override for the Discover page.
+   *
+   * When omitted, consuming UIs can derive a sensible default from `type`.
+   */
+  mapType?: DiscoverMapType;
 }


### PR DESCRIPTION
This PR reorganizes the Discover page by grouping each parking map under three category tabs:

- Parking Maps
- Campus Events
- Athletic Events

![tabs](https://github.com/user-attachments/assets/2b7adb2c-8b47-4a2a-887e-b8c19ba95b01) 

## Changes:

- added the shared `UILayoutModule` / `tamu-gisc-tabs` implementation to the discover page (like the[ Geoservices page](https://geoservices-k8s.geoservices.tamu.edu/) given as an [example](https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/issues/642#issuecomment-4095210191) for this change)
- replaced the stacked lower-page list layout with a horizontal category tab row and two-column list content under each tab
- introduced `DiscoverMapType` metadata (`parking | campus | athletics`) for discover grouping 
  - i.e. Indoor Track Parking (`libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts`) now has `mapType: 'athletics'` metadata
- updated `DiscoveryService` to derive default discover map types and respect explicit overrides from map definitions
- added test coverage for discover map-type grouping behavior

## Implementation Notes

- parking maps remain alphabetically sorted
- campus and athletic map lists are sorted by next upcoming date, then by name
- route handling still respects the underlying map type (`/parking/...` vs `/events/...`)
- search behavior is unchanged

Closes #642 