### PR TITLE
feat(aggiemap-angular): Skip unnecessary builder on maps with no selection options

### DIFF
--- a/libs/ts/events/ngx/src/lib/guards/builder-access/builder-access.guard.spec.ts
+++ b/libs/ts/events/ngx/src/lib/guards/builder-access/builder-access.guard.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, UrlSegment, UrlTree } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { BuilderAccessGuard } from './builder-access.guard';
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+describe('BuilderAccessGuard', () => {
+  let guard: BuilderAccessGuard;
+  let router: Router;
+  let eventSettingsService: { validateEventQueryParams: jest.Mock; hasOptions: boolean };
+
+  beforeEach(() => {
+    eventSettingsService = {
+      validateEventQueryParams: jest.fn(),
+      hasOptions: false
+    };
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        BuilderAccessGuard,
+        { provide: EventSettingsService, useValue: eventSettingsService }
+      ]
+    });
+
+    guard = TestBed.inject(BuilderAccessGuard);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow access when the event has configurable options', () => {
+    eventSettingsService.hasOptions = true;
+
+    const result = guard.canActivate({} as ActivatedRouteSnapshot);
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to the map when the event has no configurable options', () => {
+    const eventRoute = {
+      pathFromRoot: [
+        { url: [] },
+        { url: [new UrlSegment('parking', {})] },
+        { url: [new UrlSegment('avp-parking', {})] }
+      ]
+    } as unknown as ActivatedRouteSnapshot;
+
+    const route = {
+      parent: eventRoute,
+      queryParams: { foo: 'bar' },
+      fragment: 'legend'
+    } as unknown as ActivatedRouteSnapshot;
+
+    const result = guard.canActivate(route) as UrlTree;
+
+    expect(eventSettingsService.validateEventQueryParams).toHaveBeenCalledWith(eventRoute, true);
+    expect(router.serializeUrl(result)).toBe('/parking/avp-parking/map?foo=bar#legend');
+  });
+});

--- a/libs/ts/events/ngx/src/lib/guards/builder-access/builder-access.guard.ts
+++ b/libs/ts/events/ngx/src/lib/guards/builder-access/builder-access.guard.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, UrlTree } from '@angular/router';
+
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BuilderAccessGuard implements CanActivate {
+  constructor(
+    private readonly router: Router,
+    private readonly eventSettingsService: EventSettingsService
+  ) {}
+
+  public canActivate(route: ActivatedRouteSnapshot): boolean | UrlTree {
+    const eventRoute = route.parent ?? route;
+
+    this.eventSettingsService.validateEventQueryParams(eventRoute, true);
+
+    if (this.eventSettingsService.hasOptions) {
+      return true;
+    }
+
+    const eventPath = eventRoute.pathFromRoot
+      .flatMap((snapshot) => snapshot.url.map((segment) => segment.path))
+      .filter((segment) => segment.length > 0);
+
+    return this.router.createUrlTree(['/', ...eventPath, 'map'], {
+      queryParams: route.queryParams,
+      fragment: route.fragment ?? undefined
+    });
+  }
+}

--- a/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.spec.ts
+++ b/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlSegment, UrlTree } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { EventEntryGuard } from './event-entry.guard';
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+describe('EventEntryGuard', () => {
+  let guard: EventEntryGuard;
+  let router: Router;
+  let eventSettingsService: { validateEventQueryParams: jest.Mock; hasOptions: boolean };
+
+  beforeEach(() => {
+    eventSettingsService = {
+      validateEventQueryParams: jest.fn(),
+      hasOptions: false
+    };
+
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [EventEntryGuard, { provide: EventSettingsService, useValue: eventSettingsService }]
+    });
+
+    guard = TestBed.inject(EventEntryGuard);
+    router = TestBed.inject(Router);
+  });
+
+  it('should redirect intro-only events directly to the map', () => {
+    const route = {
+      pathFromRoot: [
+        { url: [] },
+        { url: [new UrlSegment('parking', {})] },
+        { url: [new UrlSegment('avp-parking', {})] }
+      ],
+      queryParams: { foo: 'bar' },
+      fragment: 'legend'
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = { url: '/parking/avp-parking' } as RouterStateSnapshot;
+
+    const result = guard.canActivate(route, state) as UrlTree;
+
+    expect(eventSettingsService.validateEventQueryParams).toHaveBeenCalledWith(route, true);
+    expect(router.serializeUrl(result)).toBe('/parking/avp-parking/map?foo=bar#legend');
+  });
+
+  it('should redirect configurable events to the builder intro', () => {
+    eventSettingsService.hasOptions = true;
+
+    const route = {
+      pathFromRoot: [
+        { url: [] },
+        { url: [new UrlSegment('parking', {})] },
+        { url: [new UrlSegment('baseball-parking', {})] }
+      ],
+      queryParams: {},
+      fragment: null
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = { url: '/parking/baseball-parking' } as RouterStateSnapshot;
+
+    const result = guard.canActivate(route, state) as UrlTree;
+
+    expect(router.serializeUrl(result)).toBe('/parking/baseball-parking/builder/intro');
+  });
+
+  it('should allow direct child routes to load normally', () => {
+    const route = {
+      pathFromRoot: [
+        { url: [] },
+        { url: [new UrlSegment('parking', {})] },
+        { url: [new UrlSegment('avp-parking', {})] }
+      ],
+      queryParams: {},
+      fragment: null
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = { url: '/parking/avp-parking/map' } as RouterStateSnapshot;
+
+    const result = guard.canActivate(route, state);
+
+    expect(result).toBe(true);
+  });
+});

--- a/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
+++ b/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventEntryGuard implements CanActivate {
+  constructor(
+    private readonly router: Router,
+    private readonly eventSettingsService: EventSettingsService
+  ) {}
+
+  public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
+    this.eventSettingsService.validateEventQueryParams(route, true);
+
+    const eventPath = route.pathFromRoot
+      .flatMap((snapshot) => snapshot.url.map((segment) => segment.path))
+      .filter((segment) => segment.length > 0);
+
+    const requestedPath = this.router.parseUrl(state.url).root.children['primary']?.segments.map((segment) => segment.path) ?? [];
+
+    // Only intercept bare event URLs like /parking/avp-parking. Child routes such as /map and /builder should continue normally.
+    if (requestedPath.length > eventPath.length) {
+      return true;
+    }
+
+    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'intro'] : ['map'];
+
+    return this.router.createUrlTree(['/', ...eventPath, ...targetCommands], {
+      queryParams: route.queryParams,
+      fragment: route.fragment ?? undefined
+    });
+  }
+}

--- a/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.spec.ts
+++ b/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
+
+import { EntryRedirectComponent } from './entry-redirect.component';
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+describe('EntryRedirectComponent', () => {
+  let component: EntryRedirectComponent;
+  let router: { navigate: jest.Mock };
+  let eventSettingsService: { validateEventQueryParams: jest.Mock; hasOptions: boolean };
+  let route: ActivatedRoute;
+
+  beforeEach(() => {
+    router = {
+      navigate: jest.fn()
+    };
+
+    eventSettingsService = {
+      validateEventQueryParams: jest.fn(),
+      hasOptions: false
+    };
+
+    route = {
+      parent: {} as ActivatedRoute,
+      snapshot: {
+        queryParams: { foo: 'bar' },
+        fragment: 'legend'
+      } as unknown as ActivatedRouteSnapshot
+    } as ActivatedRoute;
+
+    TestBed.configureTestingModule({
+      providers: [
+        EntryRedirectComponent,
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+        { provide: EventSettingsService, useValue: eventSettingsService }
+      ]
+    });
+
+    component = TestBed.inject(EntryRedirectComponent);
+  });
+
+  it('should route directly to the map when there are no options', () => {
+    component.ngOnInit();
+
+    expect(eventSettingsService.validateEventQueryParams).toHaveBeenCalledWith(route.snapshot, true);
+    expect(router.navigate).toHaveBeenCalledWith(['map'], {
+      relativeTo: route.parent,
+      queryParams: route.snapshot.queryParams,
+      fragment: 'legend',
+      replaceUrl: true
+    });
+  });
+
+  it('should keep configurable events on the builder intro route', () => {
+    eventSettingsService.hasOptions = true;
+
+    component.ngOnInit();
+
+    expect(router.navigate).toHaveBeenCalledWith(['builder', 'intro'], {
+      relativeTo: route.parent,
+      queryParams: route.snapshot.queryParams,
+      fragment: 'legend',
+      replaceUrl: true
+    });
+  });
+});

--- a/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { EventSettingsService } from '../../services/settings/event-settings.service';
+
+@Component({
+  selector: 'tamu-gisc-entry-redirect',
+  template: ''
+})
+export class EntryRedirectComponent implements OnInit {
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly eventSettingsService: EventSettingsService
+  ) {}
+
+  public ngOnInit(): void {
+    this.eventSettingsService.validateEventQueryParams(this.route.snapshot, true);
+
+    // Maps without configurable options should open directly to the map instead of showing an intro-only builder.
+    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'intro'] : ['map'];
+
+    this.router.navigate(targetCommands, {
+      relativeTo: this.route.parent ?? this.route,
+      queryParams: this.route.snapshot.queryParams,
+      fragment: this.route.snapshot.fragment ?? undefined,
+      replaceUrl: true
+    });
+  }
+}

--- a/libs/ts/events/ngx/src/lib/ts-events-ngx.module.ts
+++ b/libs/ts/events/ngx/src/lib/ts-events-ngx.module.ts
@@ -6,12 +6,14 @@ import { PipesModule } from '@tamu-gisc/common/ngx/pipes';
 
 import { SettingsGuard } from './guards/settings/settings.guard';
 import { BuilderComponent } from './modules/builder/builder.component';
+import { BuilderAccessGuard } from './guards/builder-access/builder-access.guard';
+import { EventEntryGuard } from './guards/event-entry/event-entry.guard';
 import { RouteParamsGuard } from './guards/route-params/route-params.guard';
 
 const routes: Routes = [
   {
     path: ':eventId',
-    canActivate: [RouteParamsGuard],
+    canActivate: [RouteParamsGuard, EventEntryGuard],
     children: [
       {
         path: 'map',
@@ -21,7 +23,7 @@ const routes: Routes = [
       {
         path: 'builder',
         component: BuilderComponent,
-        canActivate: [SettingsGuard],
+        canActivate: [BuilderAccessGuard, SettingsGuard],
         children: [
           {
             path: 'intro',


### PR DESCRIPTION
This PR updates builder routing so maps with no configurable builder options open directly to the map, while maps with actual builder options remain unchanged.

## Changes:

- Added an `EventEntryGuard` to handle bare event routes like `/:eventId`
- If an event has no builder options, the user is sent straight to `/map`
- If an event has configurable options, the user is sent to `/builder/intro`
- Added a `BuilderAccessGuard` so intro-only events cannot be forced back into the builder route
- Kept all existing multi-step builder flows intact for maps that actually require configuration
- Future map configs should be handled automatically by the logic in event-entry.guard.ts, builder-access.guard.ts, and event-settings.service.ts

Closes #662 
