### PR TITLE
fix(aggiemap-angular): Update Sustainable Parking Map zoom

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -151,9 +151,9 @@ export const SustainableTransportationConfiguration: EventConfiguration = {
   shortApplicationName: 'Sustainable Transportation',
   introductionText:
     'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
-  mapCenter: [-96.4005, 30.6193],
+  mapCenter: [-96.34643, 30.61313],
   eventDates: [],
-  zoom: 11
+  zoom: 15
 };
 
 export const SustainableTransportationOptions: SpecialEventOptions = [];


### PR DESCRIPTION
This PR changes the default zoom and center of the Sustainable Transportation map.

<img width="2534" height="1220" alt="image" src="https://github.com/user-attachments/assets/bb3a5940-5e6d-4609-8fee-7825e26322fa" />

Closes #670 