### PR TITLE
fix(aggiemap-angular): Fix Discover tabs initial render on Discover page

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -54,88 +54,115 @@
       </div>
 
       <div class="discover-tabs-section trailer-3">
-        <tamu-gisc-tabs class="discover-tabs">
-          <tamu-gisc-tab label="Parking Maps">
-            <div class="tab-section">
-              <h2>Parking Maps</h2>
-              <p class="section-description">Browse available parking maps for Texas A&amp;M University campus.</p>
+        <div class="discover-tabs" role="tablist" aria-label="Discover map categories">
+          <button
+            *ngFor="let tab of discoverTabs"
+            type="button"
+            class="discover-tab"
+            role="tab"
+            [class.active]="activeTab === tab.id"
+            [attr.id]="'discover-tab-' + tab.id"
+            [attr.aria-controls]="'discover-panel-' + tab.id"
+            [attr.aria-selected]="activeTab === tab.id"
+            [attr.tabindex]="activeTab === tab.id ? 0 : -1"
+            (click)="setActiveTab(tab.id)"
+          >
+            <span>{{ tab.label }}</span>
+          </button>
+        </div>
 
-              <div class="map-columns" *ngIf="parkingColumns[0].length + parkingColumns[1].length > 0; else noParkingMaps">
-                <ol class="map-links">
-                  <li class="map-link-item" *ngFor="let app of parkingColumns[0]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
+        <div
+          *ngIf="activeTab === 'parking'"
+          class="tab-section discover-tab-panel"
+          role="tabpanel"
+          id="discover-panel-parking"
+          aria-labelledby="discover-tab-parking"
+        >
+          <h2>Parking Maps</h2>
+          <p class="section-description">Browse available parking maps for Texas A&amp;M University campus.</p>
 
-                <ol class="map-links" *ngIf="parkingColumns[1].length > 0" [attr.start]="parkingColumnStart">
-                  <li class="map-link-item" *ngFor="let app of parkingColumns[1]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
-              </div>
+          <div class="map-columns" *ngIf="parkingColumns[0].length + parkingColumns[1].length > 0; else noParkingMaps">
+            <ol class="map-links">
+              <li class="map-link-item" *ngFor="let app of parkingColumns[0]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
 
-              <ng-template #noParkingMaps>
-                <div class="empty-state">
-                  <p>No parking maps are available right now.</p>
-                </div>
-              </ng-template>
+            <ol class="map-links" *ngIf="parkingColumns[1].length > 0" [attr.start]="parkingColumnStart">
+              <li class="map-link-item" *ngFor="let app of parkingColumns[1]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
+          </div>
+
+          <ng-template #noParkingMaps>
+            <div class="empty-state">
+              <p>No parking maps are available right now.</p>
             </div>
-          </tamu-gisc-tab>
+          </ng-template>
+        </div>
 
-          <tamu-gisc-tab label="Campus Events">
-            <div class="tab-section">
-              <h2>Campus Events</h2>
-              <p class="section-description">Browse campus event maps for transportation, parking, and special events.</p>
+        <div
+          *ngIf="activeTab === 'campus'"
+          class="tab-section discover-tab-panel"
+          role="tabpanel"
+          id="discover-panel-campus"
+          aria-labelledby="discover-tab-campus"
+        >
+          <h2>Campus Events</h2>
+          <p class="section-description">Browse campus event maps for transportation, parking, and special events.</p>
 
-              <div class="map-columns" *ngIf="campusColumns[0].length + campusColumns[1].length > 0; else noCampusEvents">
-                <ol class="map-links">
-                  <li class="map-link-item" *ngFor="let app of campusColumns[0]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
+          <div class="map-columns" *ngIf="campusColumns[0].length + campusColumns[1].length > 0; else noCampusEvents">
+            <ol class="map-links">
+              <li class="map-link-item" *ngFor="let app of campusColumns[0]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
 
-                <ol class="map-links" *ngIf="campusColumns[1].length > 0" [attr.start]="campusColumnStart">
-                  <li class="map-link-item" *ngFor="let app of campusColumns[1]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
-              </div>
+            <ol class="map-links" *ngIf="campusColumns[1].length > 0" [attr.start]="campusColumnStart">
+              <li class="map-link-item" *ngFor="let app of campusColumns[1]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
+          </div>
 
-              <ng-template #noCampusEvents>
-                <div class="empty-state">
-                  <p>No campus event maps are available right now.</p>
-                </div>
-              </ng-template>
+          <ng-template #noCampusEvents>
+            <div class="empty-state">
+              <p>No campus event maps are available right now.</p>
             </div>
-          </tamu-gisc-tab>
+          </ng-template>
+        </div>
 
-          <tamu-gisc-tab label="Athletic Events">
-            <div class="tab-section">
-              <h2>Athletic Events</h2>
-              <p class="section-description">Browse athletic event maps for game day parking and transportation information.</p>
+        <div
+          *ngIf="activeTab === 'athletics'"
+          class="tab-section discover-tab-panel"
+          role="tabpanel"
+          id="discover-panel-athletics"
+          aria-labelledby="discover-tab-athletics"
+        >
+          <h2>Athletic Events</h2>
+          <p class="section-description">Browse athletic event maps for game day parking and transportation information.</p>
 
-              <div class="map-columns" *ngIf="athleticColumns[0].length + athleticColumns[1].length > 0; else noAthleticEvents">
-                <ol class="map-links">
-                  <li class="map-link-item" *ngFor="let app of athleticColumns[0]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
+          <div class="map-columns" *ngIf="athleticColumns[0].length + athleticColumns[1].length > 0; else noAthleticEvents">
+            <ol class="map-links">
+              <li class="map-link-item" *ngFor="let app of athleticColumns[0]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
 
-                <ol class="map-links" *ngIf="athleticColumns[1].length > 0" [attr.start]="athleticColumnStart">
-                  <li class="map-link-item" *ngFor="let app of athleticColumns[1]">
-                    <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
-                  </li>
-                </ol>
-              </div>
+            <ol class="map-links" *ngIf="athleticColumns[1].length > 0" [attr.start]="athleticColumnStart">
+              <li class="map-link-item" *ngFor="let app of athleticColumns[1]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
+          </div>
 
-              <ng-template #noAthleticEvents>
-                <div class="empty-state">
-                  <p>No athletic event maps are available right now.</p>
-                </div>
-              </ng-template>
+          <ng-template #noAthleticEvents>
+            <div class="empty-state">
+              <p>No athletic event maps are available right now.</p>
             </div>
-          </tamu-gisc-tab>
-        </tamu-gisc-tabs>
+          </ng-template>
+        </div>
       </div>
 
       <div class="experimental-applications-section" *ngIf="(isDev | async) === true">

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -174,38 +174,44 @@
   margin-top: 2rem;
 }
 
-:host ::ng-deep tamu-gisc-tabs.discover-tabs {
-  display: block;
-  width: 100%;
-}
-
-:host ::ng-deep tamu-gisc-tabs.discover-tabs .tabs {
+.discover-tabs {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
   border-bottom: 1px solid #e1e1e1;
 }
 
-:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab {
+.discover-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 4px solid transparent;
   padding: 0.1rem 1rem;
   cursor: pointer;
   color: #500000;
   text-align: center;
-  border-bottom: 4px solid transparent;
   font-size: 1.05rem;
   font-weight: 600;
+  font-family: inherit;
+  white-space: nowrap;
 }
 
-:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab p {
+.discover-tab span {
+  display: block;
   margin: 0;
 }
 
-:host ::ng-deep tamu-gisc-tabs.discover-tabs .tab.active {
+.discover-tab.active {
   border-bottom-color: #500000;
 }
 
-:host ::ng-deep tamu-gisc-tabs.discover-tabs .content {
-  padding-top: 1.0rem;
+.discover-tab:focus-visible {
+  outline: 2px solid #500000;
+  outline-offset: 2px;
+}
+
+.discover-tab-panel {
+  padding-top: 1rem;
 }
 
 .map-columns {
@@ -286,16 +292,17 @@
     gap: 0.5rem;
   }
 
-  :host ::ng-deep tamu-gisc-tabs.discover-tabs .tabs {
+  .discover-tabs {
     display: flex;
     gap: 0.5rem;
     overflow-x: auto;
     padding-bottom: 0.25rem;
   }
 
-  :host ::ng-deep tamu-gisc-tabs.discover-tabs .tab {
+  .discover-tab {
     min-width: 10rem;
     padding: 0.75rem 1rem;
+    flex: 0 0 auto;
   }
 
   .map-columns,

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
@@ -1,0 +1,110 @@
+import { CommonModule } from '@angular/common';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+
+import { EventConfiguration } from '@tamu-gisc/ts/events/ngx';
+import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
+
+import { DiscoverComponent } from './discover.component';
+import { InternalDiscoverApplication } from '../interfaces/discover-application.interface';
+import { DiscoveryService } from '../services/discovery/discovery.service';
+
+describe('DiscoverComponent', () => {
+  let component: DiscoverComponent;
+  let fixture: ComponentFixture<DiscoverComponent>;
+
+  const internalApplications: InternalDiscoverApplication[] = [
+    createInternalApplication('accessible-parking', 'Accessible Parking', 'parking', 'parking', '2000-04-12'),
+    createInternalApplication('move-in', 'Move In', 'campus', 'event', '2099-03-29'),
+    createInternalApplication('football-parking', 'Football Parking', 'athletics', 'event', '2099-09-05')
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CommonModule, ReactiveFormsModule, RouterTestingModule],
+      declarations: [DiscoverComponent],
+      providers: [
+        {
+          provide: DiscoveryService,
+          useValue: {
+            getInternalDiscoverApplications: jest.fn(() => internalApplications),
+            getExternalDiscoverApplications: jest.fn(() => []),
+            getAllDiscoverApplications: jest.fn(() => internalApplications)
+          }
+        },
+        {
+          provide: TestingService,
+          useValue: {
+            get: jest.fn(() => of(false))
+          }
+        }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DiscoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('renders the parking tab by default and switches the visible panel on click', () => {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    const tabButtons = Array.from(nativeElement.querySelectorAll<HTMLButtonElement>('.discover-tab'));
+
+    expect(tabButtons.map((button) => button.textContent?.trim())).toEqual([
+      'Parking Maps',
+      'Campus Events',
+      'Athletic Events'
+    ]);
+    expect(component.activeTab).toBe('parking');
+    expect(getPanelHeading()).toBe('Parking Maps');
+    expect(getPanelText()).toContain('Accessible Parking');
+
+    tabButtons[1].click();
+    fixture.detectChanges();
+
+    expect(component.activeTab).toBe('campus');
+    expect(getPanelHeading()).toBe('Campus Events');
+    expect(getPanelText()).toContain('Move In');
+    expect(getPanelText()).not.toContain('Accessible Parking');
+  });
+
+  function getPanelHeading() {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    return nativeElement.querySelector('.discover-tab-panel h2')?.textContent?.trim();
+  }
+
+  function getPanelText() {
+    const nativeElement = fixture.nativeElement as HTMLElement;
+    return nativeElement.querySelector('.discover-tab-panel')?.textContent ?? '';
+  }
+});
+
+function createInternalApplication(
+  id: string,
+  name: string,
+  mapType: InternalDiscoverApplication['mapType'],
+  type: InternalDiscoverApplication['type'],
+  eventDate: string
+): InternalDiscoverApplication {
+  const configuration: EventConfiguration = {
+    id,
+    name,
+    applicationName: name,
+    shortApplicationName: name,
+    eventDates: [eventDate]
+  };
+
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    source: 'internal',
+    type,
+    mapType,
+    configuration
+  };
+}

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -14,12 +14,25 @@ import {
 import { DiscoveryService } from '../services/discovery/discovery.service';
 import { TestingService } from '@tamu-gisc/dev-tools/application-testing';
 
+interface DiscoverTab {
+  id: DiscoverMapType;
+  label: string;
+}
+
 @Component({
   selector: 'tamu-gisc-aggiemap-discover',
   templateUrl: './discover.component.html',
   styleUrls: ['./discover.component.scss']
 })
 export class DiscoverComponent implements OnInit {
+  public readonly discoverTabs: ReadonlyArray<DiscoverTab> = [
+    { id: 'parking', label: 'Parking Maps' },
+    { id: 'campus', label: 'Campus Events' },
+    { id: 'athletics', label: 'Athletic Events' }
+  ];
+
+  public activeTab: DiscoverMapType = 'parking';
+
   public externalApplications: ExternalDiscoverApplication[];
   private eventDiscoverApplications: InternalDiscoverApplication[];
   public allApplications: DiscoverApplication[];
@@ -124,7 +137,7 @@ export class DiscoverComponent implements OnInit {
     }
 
     if (!value) {
-      return filtered.slice(0, 10); // Show first 10 when no search
+      return filtered.slice(0, 10);
     }
 
     const filterValue = value.toLowerCase();
@@ -180,6 +193,10 @@ export class DiscoverComponent implements OnInit {
   public getApplicationRoute(app: InternalDiscoverApplication): string[] {
     const routeSegment = app.type === 'event' ? 'events' : app.type;
     return [`/${routeSegment}`, app.id];
+  }
+
+  public setActiveTab(tab: DiscoverMapType): void {
+    this.activeTab = tab;
   }
 
   public getEventDateRange(dates: Array<string | Date | number>): string {


### PR DESCRIPTION
This PR fixes a Discover page UI bug where the category tabs (Parking Maps, Campus Events, Athletic Events) would render at the top of the page until the page was refreshed.

To make the behavior stable on first load, the Discover page now uses local tab state/rendering instead of the shared projected tabs component.

### Changes:

- Added local tab configuration and active tab state in discover.component.ts
- Replaced tamu-gisc-tabs / tamu-gisc-tab usage in discover.component.html with a native button-based tablist and conditionally rendered tab panels
- Updated discover.component.scss to preserve the existing tab styling and responsive behavior with the new implementation
- Added discover.component.spec.ts to cover:
  - default tab selection
  - switching visible tab content on click

The issue appeared to be tied to the shared tab projection/initialization path on the Discover page.
Scoping the tab behavior locally avoids the first-render layout glitch without changing the shared tabs component used elsewhere.

Closes #673 