### PR TITLE
fix(aggiemap-angular): Hide bananas 

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -97,7 +97,7 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   RetireeParkingTs,
   MaintenanceParkingTs,
   BaseballParkingTs,
-  SavannahBananasParkingTs,
+  //SavannahBananasParkingTs, // put back when map is ready
   VisitorParkingTs,
   MotorcycleParkingTs,
   AVPParkingTs,

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -15,7 +15,7 @@ export enum SAVANNAH_BANANAS_PARKING_LAYERS {
   PARKING_LOTS = 'savannah-bananas-parking-lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Maroon_White_Game/MapServer';
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Maroon_White_Game/MapServer'; // replace with actual event URL when available
 
 export const SavannahBananasParkingDefinitions = {
   PEDESTRIAN_PATH: {


### PR DESCRIPTION
This PR hides the Savannah Bananas parking map from the discover page. The map configuration file is built out, but we do not have the actual parking map service yet. When we do have it, it can be inserted into the config file.

Closes #678 