### PR TITLE
fix(aggiemap-angular): Alphabetize campus events on Discover Page tab

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -113,18 +113,7 @@ export class DiscoverComponent implements OnInit {
   }
 
   private sortEventApplications(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[] {
-    const now = Date.now();
-
-    return [...apps].sort((a, b) => {
-      const aNextDate = this.getEarliestUpcomingDate(a.configuration.eventDates, now);
-      const bNextDate = this.getEarliestUpcomingDate(b.configuration.eventDates, now);
-
-      if (aNextDate === bNextDate) {
-        return a.name.localeCompare(b.name);
-      }
-
-      return aNextDate - bNextDate;
-    });
+    return apps.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   private _filterApplications(value: string, isDev: boolean): DiscoverApplication[] {


### PR DESCRIPTION
This PR makes the events under the Campus Event tab on the Discover Page sort by alphabetical order rather than by date.

Closes #679 