### PR TITLE
fix(aggiemap-angular): Direct Discover map builder to accommodations page instead of intro page

### DIFF
--- a/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
+++ b/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
@@ -26,7 +26,7 @@ export class EventEntryGuard implements CanActivate {
       return true;
     }
 
-    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'intro'] : ['map'];
+    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'accommodations'] : ['map'];
 
     return this.router.createUrlTree(['/', ...eventPath, ...targetCommands], {
       queryParams: route.queryParams,

--- a/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
@@ -18,7 +18,7 @@ export class EntryRedirectComponent implements OnInit {
     this.eventSettingsService.validateEventQueryParams(this.route.snapshot, true);
 
     // Maps without configurable options should open directly to the map instead of showing an intro-only builder.
-    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'intro'] : ['map'];
+    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'accommodations'] : ['map'];
 
     this.router.navigate(targetCommands, {
       relativeTo: this.route.parent ?? this.route,

--- a/libs/ts/events/ngx/src/lib/ts-events-ngx.module.ts
+++ b/libs/ts/events/ngx/src/lib/ts-events-ngx.module.ts
@@ -43,13 +43,13 @@ const routes: Routes = [
             path: 'review',
             loadChildren: () => import('./modules/builder/modules/review/review.module').then((m) => m.ReviewModule)
           },
-          { path: '', redirectTo: 'intro', pathMatch: 'full' }
+          { path: '', redirectTo: 'accommodations', pathMatch: 'full' }
         ]
       },
       {
         path: '',
         pathMatch: 'full',
-        redirectTo: 'builder/intro'
+        redirectTo: 'builder/accommodations'
       }
     ]
   }


### PR DESCRIPTION
This PR directs the Discover map builder to the accommodations page rather than the intro "Get Started" page. 

Functionality for the Get Started page still exists in the codebase, but it will not be used anymore unless needed.

Closes #675 