### PR TITLE
feat(aggiemap-angular) Add maintenance message for routing system in AggieMap

### DIFF
--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component.html
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component.html
@@ -1,14 +1,19 @@
 <div>
+  <p class="maintenance-message">The Aggie Map routing services are currently undergoing maintenance and are unavailable. We apologize for the inconvenience while this work is underway.</p>
+  <a class="back-link" [routerLink]="['../']">&#8592; Back to map</a>
+
+  <!--
   <div>
-    <!-- Trip from and to input components. By default, two blanks are automatically generated given that a trip has a minimum of two points -->
+    <!- - Trip from and to input components. By default, two blanks are automatically generated given that a trip has a minimum of two points - ->
     <tamu-gisc-search *ngFor="let stop of stops | async" (result)="setSearchResultAsTripStop($event)" (dirty)="eventClearRoute($event)" (empty)="eventClearStop($event)" [placeholder]="'Choose point or click on the map'" [canGeolocate]="true" [value]="stop?.attributes?.name" [index]="stop.index" [rightActionIcon]="'close'"></tamu-gisc-search>
   </div>
 
-  <!-- Trip planner connection service dropdown select element. Used in localhost and dev testing modes -->
+  <!- - Trip planner connection service dropdown select element. Used in localhost and dev testing modes - ->
   <tamu-gisc-trip-planner-connection-select *ngIf="dev | async"></tamu-gisc-trip-planner-connection-select>
 
-  <!-- Trip planner mode picker element. Sets the routing mode for the trip planner service.-->
+  <!- - Trip planner mode picker element. Sets the routing mode for the trip planner service.- ->
   <tamu-gisc-trip-planner-mode-picker></tamu-gisc-trip-planner-mode-picker>
 
   <tamu-gisc-trip-planner-directions></tamu-gisc-trip-planner-directions>
+  -->
 </div>

--- a/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component.scss
+++ b/libs/aggiemap/ngx/ui/desktop/src/lib/modules/sidebar/components/sidebar-trip-planner/sidebar-trip-planner.component.scss
@@ -1,0 +1,19 @@
+.maintenance-message {
+  padding: 1rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: #424242;
+}
+
+.back-link {
+  display: inline-block;
+  padding: 0 1rem 1rem;
+  font-size: 0.875rem;
+  color: #500000;
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/trip-planner-top/trip-planner-top.component.html
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/trip-planner-top/trip-planner-top.component.html
@@ -4,13 +4,13 @@
       <i class="material-icons" (click)="returnBaseRoute()">arrow_back</i>
     </div>
     <div class="points">
-      <div *ngFor="let stop of (stops | async); let i = index">
-        <input type="text" [placeholder]="'Search location'" [value]="stop?.attributes?.name" (click)="summonOmnisearch(i)" />
-      </div>
+      <p class="maintenance-message">The Aggie Map routing services are currently undergoing maintenance and are unavailable. We apologize for the inconvenience while this work is underway.</p>
     </div>
   </div>
 
+  <!--
   <div id="bottom">
     <tamu-gisc-trip-planner-mode-picker-mobile></tamu-gisc-trip-planner-mode-picker-mobile>
   </div>
+  -->
 </div>

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/trip-planner-top/trip-planner-top.component.scss
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/trip-planner-top/trip-planner-top.component.scss
@@ -69,3 +69,10 @@ input {
   border: 1px solid #e0e0e0;
   width: 100%;
 }
+
+.maintenance-message {
+  padding: 0.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  color: #424242;
+}


### PR DESCRIPTION
This PR removes the old routing system and replaces it with a new maintenance message:

> The Aggie Map routing services are currently undergoing maintenance and are unavailable. We apologize for the inconvenience while this work is underway.

<img width="439" height="347" alt="image" src="https://github.com/user-attachments/assets/101be92c-000b-43de-b544-ad115d0a7145" />

The back button takes the user back to the default sidebar page.
![maintanence_desktop](https://github.com/user-attachments/assets/f0b5b510-ec6e-4ce4-8fd7-522d9d6a50b7)

Also functional on mobile:

![maintanence_mobile](https://github.com/user-attachments/assets/a5de52ad-958e-41e8-a868-db08009231b4)

Closes #668 