### PR TITLE
fix(aggiemap-angular) Fix issue with upcoming events being sorted by name on Discover Page

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -98,9 +98,17 @@ export class DiscoverComponent implements OnInit {
   private getUpcomingApplications(): InternalDiscoverApplication[] {
     const now = Date.now();
 
-    return this.sortEventApplications(this.eventDiscoverApplications)
-      .filter((app) => this.getEarliestUpcomingDate(app.configuration.eventDates, now) !== Number.POSITIVE_INFINITY)
-      .slice(0, 3);
+    return this.eventDiscoverApplications
+      .map((app) => ({
+        app,
+        earliestUpcomingDate: this.getEarliestUpcomingDate(app.configuration.eventDates, now)
+      }))
+      .filter(({ earliestUpcomingDate }) => earliestUpcomingDate !== Number.POSITIVE_INFINITY)
+      .sort(
+        (a, b) => a.earliestUpcomingDate - b.earliestUpcomingDate || a.app.name.localeCompare(b.app.name)
+      )
+      .slice(0, 3)
+      .map(({ app }) => app);
   }
 
   private buildApplicationColumns(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[][] {


### PR DESCRIPTION
This PR fixes a bug where the "Upcoming Events" section on the Discover Page displayed events in alphabetical order rather than by date.

### Before:
<img width="1303" height="984" alt="image" src="https://github.com/user-attachments/assets/fa17f9c9-290f-4a2f-a6f8-6c680ee73792" />



### After:
<img width="1297" height="1030" alt="image" src="https://github.com/user-attachments/assets/7d4435cc-0ff3-49bc-ba03-3cafc100c603" />
