### PR TITLE
feat(aggiemap-angular): Update sustainable transportation layers to temporary Portal-hosted services

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -23,6 +23,8 @@ export function LayerSources(
 ): Array<LayerSource> {
   const bikeMapUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/BikeMap/MapServer');
   const evChargeStationsUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/EVChargeStations/MapServer');
+  // If sustainable transportation is re-implemented against a different server/service set later,
+  // update this shared source list alongside `libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts`.
   const sustainableTransportationSources: Array<LayerSource> = [
     {
       type: 'feature',
@@ -39,22 +41,6 @@ export function LayerSources(
           '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
           '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
           '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
-      type: 'feature',
-      id: 'bike-rack-areas-layer',
-      title: 'Bike Rack Areas',
-      url: `${bikeMapUrl}/4`,
-      listMode: 'show',
-      visible: true,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.Type}',
-        description: '<strong>Total Capacity</strong>: {attributes.Total_Capacity}'
       },
       native: {
         ...commonLayerProps

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.spec.ts
@@ -144,6 +144,25 @@ describe('LegendElementComponent', () => {
     ]);
   });
 
+  it('adds a fallback Bike Racks label for single unlabeled bike rack legend entries', async () => {
+    component.groupTitle = 'Bike Racks';
+    component.layer = {
+      id: 'bike-racks-map-layer',
+      url: 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0'
+    } as unknown as __esri.Layer;
+    component.element = {
+      infos: [{ src: 'blue-icon', value: 'coat' }]
+    } as unknown as __esri.LegendElement;
+
+    await component.ngOnInit();
+
+    const infos = await firstValueFrom(component.infos);
+
+    expect(component.useGroupTitleLabel).toBe(false);
+    expect(infos).toHaveLength(1);
+    expect((infos[0] as { label?: string }).label).toBe('Bike Racks');
+  });
+
   it('uses the group title label for non-bike single-entry legend elements', async () => {
     component.groupTitle = 'Baseball Symbols';
     component.layer = {

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -378,7 +378,18 @@ export class LegendElementComponent implements OnInit {
     const flattenedInfos = this._flattenLegendInfos(infos);
 
     if (flattenedInfos.length <= 1) {
-      return flattenedInfos;
+      const fallbackLabel = this.groupTitle?.trim() || 'Bike Racks';
+
+      return flattenedInfos.map((info) => {
+        if (this._hasLegendInfoLabel(info)) {
+          return info;
+        }
+
+        return {
+          ...(info as unknown as Record<string, unknown>),
+          label: fallbackLabel
+        } as LegendInfo;
+      });
     }
 
     const hubCorralInfo = flattenedInfos.find((info) => this._matchesLegendInfoLabel(info, 'Hub Corral'));
@@ -443,6 +454,10 @@ export class LegendElementComponent implements OnInit {
 
   private _matchesLegendInfoLabel(info: LegendInfo, label: string): boolean {
     return ((info as { label?: string }).label ?? '').trim().toLowerCase() === label.toLowerCase();
+  }
+
+  private _hasLegendInfoLabel(info: LegendInfo): boolean {
+    return ((info as { label?: string }).label ?? '').trim().length > 0;
   }
 
   private _isBikeRackSpecialLegendLabel(info: LegendInfo): boolean {

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -7,69 +7,88 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
-  EV_CHARGERS = 'sustainable-transportation-ev-chargers',
+  EV_CHARGERS_MAIN = 'sustainable-transportation-ev-chargers-main',
+  EV_CHARGERS_RELLIS = 'sustainable-transportation-ev-chargers-rellis',
+  HUB_CORRALS = 'sustainable-transportation-hub-corrals',
+  SHARED_MOBILITY_RACKS = 'sustainable-transportation-shared-mobility-racks',
   BIKE_RACKS = 'sustainable-transportation-bike-racks',
-  BIKE_RACK_AREAS = 'sustainable-transportation-bike-rack-areas',
   BIKE_FIX_STATIONS = 'sustainable-transportation-bike-fix-stations',
   BIKE_LANES = 'sustainable-transportation-bike-lanes',
   CITY_BIKE_LANES_ROUTES = 'sustainable-transportation-city-bike-lanes-routes',
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
-const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
-const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+// These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
+const evMainLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_MC_view/FeatureServer';
+const evRellisLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_Rellis/FeatureServer';
+const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
+const fixStationLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Fix_Stations_view/FeatureServer';
+const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Bike_Lanes_view/FeatureServer';
+const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
 
 export const SustainableTransportationDefinitions = {
-  EV_CHARGERS: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
-    name: 'EV Charge Stations (Main + RELLIS)',
-    url: `${evLayersUrl}/0`
+  EV_CHARGERS_MAIN: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
+    name: 'EV Charge Stations (Main Campus)',
+    url: `${evMainLayersUrl}/0`
+  },
+  EV_CHARGERS_RELLIS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
+    name: 'EV Charge Stations (RELLIS)',
+    url: `${evRellisLayersUrl}/0`
+  },
+  HUB_CORRALS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
+    name: 'Hub Corral',
+    url: `${rackLayersUrl}/0`
+  },
+  SHARED_MOBILITY_RACKS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
+    name: 'Shared Mobility Racks',
+    url: `${rackLayersUrl}/1`
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
-    url: `${bikeLayersUrl}/0`
+    url: `${rackLayersUrl}/2`
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     name: 'Bike Fix Stations',
-    url: `${bikeLayersUrl}/1`
+    url: `${fixStationLayersUrl}/0`
   },
   BIKE_LANES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
     name: 'Bike Lanes',
-    url: `${bikeLayersUrl}/2`
+    url: `${bikeLaneLayersUrl}/2`
   },
   CITY_BIKE_LANES_ROUTES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     name: 'City Bike Lanes and Routes',
-    url: `${bikeLayersUrl}/3`
-  },
-  BIKE_RACK_AREAS: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACK_AREAS,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACK_AREAS,
-    name: 'Bike Rack Areas',
-    url: `${bikeLayersUrl}/4`
+    url: `${bikeLaneLayersUrl}/1`
   },
   BIKE_DISMOUNT_ZONES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
     name: 'Bike Dismount Zones',
-    url: `${bikeLayersUrl}/5`
+    url: `${dismountZoneLayersUrl}/0`
   }
 };
 
 export const SustainableTransportationColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS.url,
+    id: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.id,
+    title: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.name,
+    url: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.url,
     visible: true,
     listMode: 'show',
     native: {
@@ -78,9 +97,31 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   },
   {
     type: 'feature',
-    id: SustainableTransportationDefinitions.BIKE_RACK_AREAS.id,
-    title: SustainableTransportationDefinitions.BIKE_RACK_AREAS.name,
-    url: SustainableTransportationDefinitions.BIKE_RACK_AREAS.url,
+    id: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.id,
+    title: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.name,
+    url: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.HUB_CORRALS.id,
+    title: SustainableTransportationDefinitions.HUB_CORRALS.name,
+    url: SustainableTransportationDefinitions.HUB_CORRALS.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.id,
+    title: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.name,
+    url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
     native: {
@@ -173,6 +214,8 @@ export const SustainableTransportationTs: AggiemapCustomMapConfiguration = {
     keywords: [
       'sustainable transportation',
       'bike',
+      'hub corral',
+      'shared mobility',
       'bike racks',
       'bike fix stations',
       'bike lanes',

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -18,6 +18,9 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
+// Temporary bridge until the original TS server/editor workflow is restored.
+// When that server is ready again, swap these URLs and the layer-id mapping in `SustainableTransportationDefinitions`
+// back to the restored source services.
 // These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
 const evMainLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_MC_view/FeatureServer';
 const evRellisLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_Rellis/FeatureServer';
@@ -84,6 +87,7 @@ export const SustainableTransportationDefinitions = {
 };
 
 export const SustainableTransportationColdLayerSources: LayerSource[] = [
+  // Keep this source list aligned with the temporary URL/layer mapping above until the original services are restored.
   {
     type: 'feature',
     id: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.id,


### PR DESCRIPTION
This PR updates sustainable transportation map layers to use the temporary Portal-hosted service views while the original server/editor workflow is unavailable. It also removes Bike Rack Areas from the map and adds comments in the affected files to show where to switch things back once the original server setup is ready again.

Closes #685 