### PR TITLE
feat(aggiemap-angular): Group concurrent event toasts into single stacked notification

### DIFF
--- a/apps/aggiemap-angular/src/app/app.component.html
+++ b/apps/aggiemap-angular/src/app/app.component.html
@@ -1,3 +1,3 @@
 <router-outlet></router-outlet>
 
-<tamu-gisc-notification-container></tamu-gisc-notification-container>
+<tamu-gisc-notification-container [grouped]="true"></tamu-gisc-notification-container>

--- a/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.html
+++ b/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.html
@@ -1,8 +1,37 @@
-<tamu-gisc-notification-item 
-  *ngFor="let item of notifications | async" 
-  [notification]="item" 
-  (closeNotification)="close($event)" 
-  (acknowledgeNotification)="acknowledge($event)"
-  (actionNotification)="action($event)" 
-  [position]="position">
-</tamu-gisc-notification-item>
+<ng-container *ngIf="!grouped">
+  <tamu-gisc-notification-item
+    *ngFor="let item of notifications | async"
+    [notification]="item"
+    (closeNotification)="close($event)"
+    (acknowledgeNotification)="acknowledge($event)"
+    (actionNotification)="action($event)"
+    [position]="position">
+  </tamu-gisc-notification-item>
+</ng-container>
+
+<div
+  *ngIf="grouped && groupVisible"
+  class="notification-grouped-wrapper"
+  [ngClass]="[position, groupShowing ? 'show' : '']"
+  (mouseover)="pauseGroup()"
+  (mouseleave)="resumeGroup()">
+  <div class="status" [style.width.%]="groupTimerPercent"></div>
+  <div class="close material-icons" tabindex="0" (click)="closeGroup()" title="Close">close</div>
+  <ng-container *ngFor="let item of groupedItems; let last = last">
+    <div class="grouped-item" (click)="actionGroupItem(item)" [class.actionable]="item.action">
+      <div class="grouped-image" *ngIf="item.imgUrl">
+        <img [src]="item.imgUrl" [title]="item.imgAltText" [alt]="item.imgAltText" />
+      </div>
+      <div class="grouped-text">
+        <div class="grouped-title">{{ item.title }}</div>
+        <div class="grouped-description" [innerHTML]="item.message"></div>
+        <div class="grouped-ack" *ngIf="item.acknowledge">
+          <a href="#" class="dont-show-again"
+            (click)="acknowledgeGroupItem(item); $event.preventDefault(); $event.stopPropagation();"
+            title="Don't show this notification again">[ Don't show again ]</a>
+        </div>
+      </div>
+    </div>
+    <hr *ngIf="!last" class="grouped-separator" />
+  </ng-container>
+</div>

--- a/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.scss
+++ b/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.scss
@@ -1,0 +1,159 @@
+.notification-grouped-wrapper {
+  position: fixed;
+  bottom: 0;
+  z-index: 999;
+  background: #ffffff;
+  box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.15);
+  border-radius: 5px;
+  overflow: hidden;
+  transform: translateY(110%);
+  transition: transform 250ms cubic-bezier(0.25, 0, 0.25, 1);
+
+  &.show {
+    transform: translateY(0);
+  }
+
+  &.center {
+    left: 50%;
+    transform: translateX(-50%) translateY(110%);
+
+    &.show {
+      transform: translateX(-50%) translateY(0);
+    }
+  }
+
+  &.left {
+    left: 2.5rem;
+  }
+
+  &.right {
+    right: 2.5rem;
+  }
+
+  .status {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 2px;
+    background: #500000;
+  }
+
+  .close {
+    position: absolute;
+    right: 0.25rem;
+    top: 0.25rem;
+    font-size: 0.9rem;
+    border-radius: 99rem;
+    padding: 0.25rem;
+    cursor: pointer;
+
+    &:hover {
+      background: #e0e0e0;
+    }
+  }
+
+  .grouped-item {
+    display: flex;
+    flex-direction: row;
+    padding: 1.25rem 2rem 1.25rem 1.25rem;
+    box-sizing: border-box;
+
+    &.actionable {
+      cursor: pointer;
+    }
+  }
+
+  .grouped-image {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-right: 1rem;
+
+    img {
+      width: 2rem;
+      height: auto;
+    }
+  }
+
+  .grouped-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  .grouped-title {
+    font-size: 0.9rem;
+    margin-bottom: 0.1rem;
+  }
+
+  .grouped-description {
+    font-size: 0.85rem;
+    max-width: 30rem;
+    color: #616161;
+  }
+
+  .grouped-ack {
+    margin-top: 0.5rem;
+    text-align: center;
+
+    .dont-show-again {
+      font-size: 0.75rem;
+      color: #888;
+      text-decoration: none;
+      cursor: pointer;
+      border-bottom: 1px solid transparent;
+      transition: all 0.2s ease;
+
+      &:hover {
+        color: #500000;
+        border-bottom-color: #500000;
+      }
+
+      &:focus {
+        outline: 1px solid #500000;
+        outline-offset: 2px;
+      }
+    }
+  }
+
+  .grouped-separator {
+    border: none;
+    border-top: 1px solid #e0e0e0;
+    margin: 0;
+  }
+}
+
+@media only screen and (max-width: 960px) {
+  .notification-grouped-wrapper {
+    width: 50%;
+  }
+}
+
+@media only screen and (max-width: 800px) {
+  .notification-grouped-wrapper {
+    width: 60%;
+
+    .grouped-title,
+    .grouped-description {
+      font-size: 0.8rem;
+    }
+
+    .grouped-image img {
+      width: 3rem;
+    }
+  }
+}
+
+@media only screen and (max-width: 700px) {
+  .notification-grouped-wrapper {
+    width: 95%;
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) translateY(110%);
+
+    &.show {
+      transform: translateX(-50%) translateY(0);
+    }
+  }
+}

--- a/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.ts
+++ b/libs/common/ngx/ui/notification/src/lib/components/notification-container/notification-container.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, OnInit, Optional } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Component, Input, OnInit, OnDestroy, Optional } from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+import { Router } from '@angular/router';
 
 import { v4 as guid } from 'uuid';
 import { Angulartics2 } from 'angulartics2';
@@ -12,32 +13,69 @@ import { Notification } from '../../helpers/notification.helper';
   templateUrl: './notification-container.component.html',
   styleUrls: ['./notification-container.component.scss']
 })
-export class NotificationContainerComponent implements OnInit {
+export class NotificationContainerComponent implements OnInit, OnDestroy {
   @Input()
   public position: 'left' | 'center' | 'right' = 'center';
 
+  /**
+   * When true, multiple active notifications are merged into a single stacked toast
+   * instead of overlapping individual toasts. Does not affect existing behavior when false.
+   */
+  @Input()
+  public grouped = false;
+
   public notifications: Observable<Notification[]>;
 
-  constructor(@Optional() private analytics: Angulartics2, private service: NotificationService) {}
+  // Grouped mode state
+  public groupedItems: Notification[] = [];
+  public groupVisible = false;
+  public groupShowing = false;
+  public groupTimerPercent = 0;
+
+  private _groupTimerStep = 50;
+  private _groupTimerCurrent = 0;
+  private _groupTimerLimit = 10000;
+  private _groupTimerInterval: ReturnType<typeof setInterval> | undefined;
+  private _groupSubscription: Subscription | undefined;
+
+  constructor(
+    @Optional() private readonly analytics: Angulartics2,
+    @Optional() private readonly router: Router,
+    private readonly service: NotificationService
+  ) {}
 
   public ngOnInit() {
     this.notifications = this.service.notifications;
+
+    if (this.grouped) {
+      this._groupSubscription = this.service.notifications.subscribe((items) => {
+        const hadItems = this.groupedItems.length > 0;
+        this.groupedItems = [...items];
+
+        if (items.length > 0 && !this.groupVisible) {
+          this.groupVisible = true;
+          setTimeout(() => {
+            this.groupShowing = true;
+          });
+          this._startGroupTimer();
+        } else if (items.length === 0 && hadItems) {
+          this._triggerGroupHide();
+        }
+      });
+    }
   }
 
-  /**
-   * Invoke notification service method to remove the emitted Notification object
-   *
-   * @param event Notification object
-   */
+  public ngOnDestroy() {
+    this._stopGroupTimer();
+    this._groupSubscription?.unsubscribe();
+  }
+
+  // --- Non-grouped methods (unchanged behavior) ---
+
   public close(event: Notification): void {
     this.service.remove(event);
   }
 
-  /**
-   * Invoke notification service method to acknowledge the emitted Notification object
-   *
-   * @param event Notification object
-   */
   public acknowledge(event: Notification): void {
     this.service.acknowledge(event);
   }
@@ -57,6 +95,77 @@ export class NotificationContainerComponent implements OnInit {
           gstCustom: label
         }
       });
+    }
+  }
+
+  // --- Grouped mode methods ---
+
+  public pauseGroup(): void {
+    this._stopGroupTimer();
+  }
+
+  public resumeGroup(): void {
+    this._startGroupTimer();
+  }
+
+  public closeGroup(): void {
+    this._stopGroupTimer();
+    const toRemove = [...this.groupedItems];
+    this._triggerGroupHide();
+    setTimeout(() => {
+      toRemove.forEach((item) => this.service.remove(item));
+    }, 300);
+  }
+
+  public acknowledgeGroupItem(item: Notification): void {
+    this.service.acknowledge(item);
+  }
+
+  public closeGroupItem(item: Notification): void {
+    this.service.remove(item);
+  }
+
+  public actionGroupItem(item: Notification): void {
+    if (!item.action) {
+      return;
+    }
+
+    this.action(item);
+    this.service.remove(item);
+
+    if (this.router) {
+      this.router.navigate([item.action.value]);
+    }
+  }
+
+  private _triggerGroupHide(): void {
+    if (!this.groupVisible) {
+      return;
+    }
+    this.groupShowing = false;
+    setTimeout(() => {
+      this.groupVisible = false;
+      this._groupTimerCurrent = 0;
+      this.groupTimerPercent = 0;
+    }, 300);
+  }
+
+  private _startGroupTimer(): void {
+    this._stopGroupTimer();
+    this._groupTimerCurrent = 0;
+    this._groupTimerInterval = setInterval(() => {
+      this._groupTimerCurrent += this._groupTimerStep;
+      this.groupTimerPercent = (this._groupTimerCurrent / this._groupTimerLimit) * 100;
+      if (this._groupTimerCurrent >= this._groupTimerLimit) {
+        this.closeGroup();
+      }
+    }, this._groupTimerStep);
+  }
+
+  private _stopGroupTimer(): void {
+    if (this._groupTimerInterval) {
+      clearInterval(this._groupTimerInterval);
+      this._groupTimerInterval = undefined;
     }
   }
 }


### PR DESCRIPTION
This PR fixes the issue where multiple active event notifications would render as overlapping toasts, making them unreadable on mobile.

### Changes

- Adds an optional `[grouped]` input to `tamu-gisc-notification-container`. When enabled, all active notifications are combined into a single stacked toast with separators between entries and individual "Don't show again" links. The grouped toast shares the same 10-second auto-dismiss timer, hover-to-pause behavior, and slide animation as individual toasts.
- The grouped flag defaults to false, so no other apps using the notification container are affected. AggieMap opts in via `[grouped]="true"` in `app.component.html`, covering both the main map and Discover pages.

### Before:
<img width="2280" height="1088" alt="image" src="https://github.com/user-attachments/assets/7ef938ec-566d-422a-968a-34cfe2a15e1d" />


### After:
<img width="1483" height="807" alt="image" src="https://github.com/user-attachments/assets/44cb0571-c457-4999-b70a-c6de1640cb9e" />

Closes #687
