### PR TITLE
fix(aggiemap-angular): Update athletic event names

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -141,7 +141,7 @@
           aria-labelledby="discover-tab-athletics"
         >
           <h2>Athletic Events</h2>
-          <p class="section-description">Browse athletic event maps for game day parking and transportation information.</p>
+          <p class="section-description">Browse athletic event maps for gameday parking and transportation information.</p>
 
           <div class="map-columns" *ngIf="athleticColumns[0].length + athleticColumns[1].length > 0; else noAthleticEvents">
             <ol class="map-links">

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -256,7 +256,7 @@ export const BaseballParkingTs: AggiemapCustomMapConfiguration = {
   type: 'general-map',
   discover: {
     id: 'baseball-parking',
-    name: 'Baseball Parking',
+    name: 'Baseball Map',
     description: 'Baseball event parking with optional accessibility-focused view.',
     source: 'internal',
     type: 'parking',

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -107,7 +107,7 @@ export const CrossCountryParkingColdLayerSources: LayerSource[] = [
 
 export const CrossCountryParkingConfiguration: EventConfiguration = {
   id: 'cross-country-parking',
-  name: 'Cross Country Parking',
+  name: 'Cross Country Map',
   applicationName: 'Cross Country Parking Map',
   shortApplicationName: 'Cross Country Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M cross country events.',

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -364,7 +364,7 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
 
 export const FootballParkingConfiguration: EventConfiguration = {
   id: 'gameday-parking',
-  name: 'Gameday Transportation',
+  name: 'Football',
   applicationName: 'Gameday Transportation Map',
   shortApplicationName: 'Gameday Map',
   introductionText: 'Get the best transportation and parking information for game days.',

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -364,7 +364,7 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
 
 export const FootballParkingConfiguration: EventConfiguration = {
   id: 'gameday-parking',
-  name: 'Football',
+  name: 'Football Map',
   applicationName: 'Gameday Transportation Map',
   shortApplicationName: 'Gameday Map',
   introductionText: 'Get the best transportation and parking information for game days.',

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -171,7 +171,7 @@ export const IndoorTrackParkingColdLayerSources: LayerSource[] = [
 
 export const IndoorTrackParkingConfiguration: EventConfiguration = {
   id: 'indoor-track-parking',
-  name: 'Indoor Track Parking',
+  name: 'Indoor Track Map',
   applicationName: 'Indoor Track Parking Map',
   shortApplicationName: 'Indoor Track Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M indoor track events.',

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -105,7 +105,7 @@ export const MensBasketball_ColdLayerSources: LayerSource[] = [
 
 export const MensBasketball_Configuration: EventConfiguration = {
   id: 'mens-basketball',
-  name: "Men's Basketball Parking",
+  name: "Men's Basketball Map",
   applicationName: "Men's Basketball Parking Map",
   shortApplicationName: "Men's Basketball Parking Map",
   eventDates: [

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -122,7 +122,7 @@ export const OutdoorTrackParkingColdLayerSources: LayerSource[] = [
 
 export const OutdoorTrackParkingConfiguration: EventConfiguration = {
   id: 'outdoor-track-parking',
-  name: 'Outdoor Track Parking',
+  name: 'Outdoor Track Map',
   applicationName: 'Outdoor Track Parking Map',
   shortApplicationName: 'Outdoor Track Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M outdoor track events.',

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -157,7 +157,7 @@ export const SoccerParkingColdLayerSources: LayerSource[] = [
 
 export const SoccerParkingConfiguration: EventConfiguration = {
   id: 'soccer-parking',
-  name: 'Soccer Parking',
+  name: 'Soccer Map',
   applicationName: 'Soccer Parking Map',
   shortApplicationName: 'Soccer Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M soccer events.',

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -119,7 +119,7 @@ export const SoftballParkingColdLayerSources: LayerSource[] = [
 
 export const SoftballParkingConfiguration: EventConfiguration = {
   id: 'softball-parking',
-  name: 'Softball Parking',
+  name: 'Softball Map',
   applicationName: 'Softball Parking Map',
   shortApplicationName: 'Softball Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M softball games.',

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -98,7 +98,7 @@ export const SoftballLayerSources: LayerSource[] = [
 
 export const SoftballConfiguration: EventConfiguration = {
   id: 'softball-regionals-2025',
-  name: 'Softball Regionals',
+  name: 'Softball Regionals Map',
   applicationName: 'Softball Regionals Event Map',
   shortApplicationName: 'Softball Regionals Map',
   introductionText: 'Get the best transportation and parking information for Softball Regionals.',

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -154,7 +154,7 @@ export const SwimmingParkingColdLayerSources: LayerSource[] = [
 
 export const SwimmingParkingConfiguration: EventConfiguration = {
   id: 'swimming-parking',
-  name: 'Swimming Parking',
+  name: 'Swimming Map',
   applicationName: 'Swimming Parking Map',
   shortApplicationName: 'Swimming Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M swimming events.',

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -52,7 +52,7 @@ export const TennisParkingColdLayerSources: LayerSource[] = [
 
 export const TennisParkingConfiguration: EventConfiguration = {
   id: 'tennis-parking',
-  name: 'Tennis Parking',
+  name: 'Tennis Map',
   applicationName: 'Tennis Parking Map',
   shortApplicationName: 'Tennis Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M tennis events.',

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -163,7 +163,7 @@ export const VolleyballParkingColdLayerSources: LayerSource[] = [
 
 export const VolleyballParkingConfiguration: EventConfiguration = {
   id: 'volleyball-parking',
-  name: 'Volleyball Parking',
+  name: 'Volleyball Map',
   applicationName: 'Volleyball Parking Map',
   shortApplicationName: 'Volleyball Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M volleyball events.',

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -131,7 +131,7 @@ export const WomensBasketball_ColdLayerSources: LayerSource[] = [
 
 export const WomensBasketball_Configuration: EventConfiguration = {
   id: 'womens-basketball',
-  name: "Women's Basketball Parking",
+  name: "Women's Basketball Map",
   applicationName: "Women's Basketball Parking Map",
   shortApplicationName: "Women's Basketball Parking Map",
   eventDates: [


### PR DESCRIPTION
This PR updates names for athletic events as well as some other text relating to athletic text on the discover page.

### Before:

<img width="1178" height="1028" alt="image" src="https://github.com/user-attachments/assets/21d1edf9-c881-4f76-befb-e2e5475259cb" />

### After:

<img width="1181" height="605" alt="image" src="https://github.com/user-attachments/assets/899fe2b2-ec3f-4605-b10b-4a0ee5d186d5" />

Closes #690 