### PR TITLE
fix(aggiemap-angular): Make back button work on Aggiemap builder page

### DIFF
--- a/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
@@ -53,7 +53,8 @@ export class AccommodationsComponent implements OnInit {
           const firstAccommodation = Object.values(options)[0];
 
           return this.router.navigate([firstAccommodation.value], {
-            relativeTo: this.route
+            relativeTo: this.route,
+            replaceUrl: true
           });
         }
       }),


### PR DESCRIPTION
This PR adds `replaceUrl: true` to the automatic redirect in the builder so the intermediate URL (`builder/accommodations`) doesn't create a history entry that traps back navigation in a loop.

![lower](https://github.com/user-attachments/assets/2301ac0b-b947-44a3-b98c-52b5d7c82913)

Closes #689