### PR TITLE
feat(aggiemap-angular): Filter events on Discover page by date 

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -165,6 +165,25 @@
         </div>
       </div>
 
+      <div class="all-events-section trailer-3" *ngIf="(isDev | async) === true">
+        <h2>All Events</h2>
+        <p class="section-description">Complete list of all events (development only).</p>
+
+        <div class="map-columns" *ngIf="allEventsColumns[0].length + allEventsColumns[1].length > 0">
+          <ol class="map-links">
+            <li class="map-link-item" *ngFor="let app of allEventsColumns[0]">
+              <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+            </li>
+          </ol>
+
+          <ol class="map-links" *ngIf="allEventsColumns[1].length > 0" [attr.start]="allEventsColumnStart">
+            <li class="map-link-item" *ngFor="let app of allEventsColumns[1]">
+              <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+            </li>
+          </ol>
+        </div>
+      </div>
+
       <div class="experimental-applications-section" *ngIf="(isDev | async) === true">
         <h2>Experimental Applications</h2>
         <p class="section-description">Explore experimental maps and applications</p>

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -10,6 +10,7 @@
 .search-section,
 .upcoming-events-section,
 .tab-section,
+.all-events-section,
 .experimental-applications-section {
   h2 {
     color: #500000;

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -48,6 +48,9 @@ export class DiscoverComponent implements OnInit {
   public athleticColumns: InternalDiscoverApplication[][] = [[], []];
   public athleticColumnStart = 1;
 
+  public allEventsColumns: InternalDiscoverApplication[][] = [[], []];
+  public allEventsColumnStart = 1;
+
   public searchControl = new FormControl();
   public filteredApplications: Observable<DiscoverApplication[]>;
   public isDev: Observable<boolean>;
@@ -77,12 +80,18 @@ export class DiscoverComponent implements OnInit {
     this.parkingColumnStart = this.getSecondColumnStart(this.parkingColumns);
 
     const campusApplications = this.getApplicationsByMapType('campus');
-    this.campusColumns = this.buildApplicationColumns(campusApplications);
+    const upcomingCampus = this.filterUpcomingEvents(campusApplications);
+    this.campusColumns = this.buildApplicationColumns(upcomingCampus);
     this.campusColumnStart = this.getSecondColumnStart(this.campusColumns);
 
     const athleticApplications = this.getApplicationsByMapType('athletics');
-    this.athleticColumns = this.buildApplicationColumns(athleticApplications);
+    const upcomingAthletic = this.filterUpcomingEvents(athleticApplications);
+    this.athleticColumns = this.buildApplicationColumns(upcomingAthletic);
     this.athleticColumnStart = this.getSecondColumnStart(this.athleticColumns);
+
+    const allEvents = this.sortEventApplications([...campusApplications, ...athleticApplications]);
+    this.allEventsColumns = this.buildApplicationColumns(allEvents);
+    this.allEventsColumnStart = this.getSecondColumnStart(this.allEventsColumns);
   }
 
   private getApplicationsByMapType(mapType: DiscoverMapType): InternalDiscoverApplication[] {
@@ -118,6 +127,18 @@ export class DiscoverComponent implements OnInit {
 
   private getSecondColumnStart(columns: InternalDiscoverApplication[][]): number {
     return columns[0].length + 1;
+  }
+
+  private filterUpcomingEvents(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[] {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayMs = today.getTime();
+
+    return apps.filter((app) => {
+      const dates = app.configuration.eventDates;
+      if (!dates || dates.length === 0) return true;
+      return dates.some((date) => this.parseEventDate(date) >= todayMs);
+    });
   }
 
   private sortEventApplications(apps: InternalDiscoverApplication[]): InternalDiscoverApplication[] {


### PR DESCRIPTION
This PR filters past events from the Campus Events and Athletic Events tabs on the Discover page (keeping only events with at least one date >= today), and adds a dev-only "All Events" section above Experimental Applications that shows the full alphabetical list of all events.

<img width="2498" height="1022" alt="image" src="https://github.com/user-attachments/assets/3adcb1e9-3635-4b78-a744-40d1deb3ece0" />

<img width="2398" height="1081" alt="image" src="https://github.com/user-attachments/assets/89897e40-faf7-4ab6-93ee-1dbfdb29a9e3" />

Closes #688 
