### PR TITLE
feat(aggiemap-angular): Add event details links to event builders and update Maroon & White Game map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -129,7 +129,7 @@ export const BaseballParkingColdLayerSources: LayerSource[] = [
 
 export const BaseballParkingConfiguration: EventConfiguration = {
   id: 'baseball-parking',
-  name: 'Baseball Parking',
+  name: 'Baseball',
   applicationName: 'Baseball Parking Map',
   shortApplicationName: 'Baseball Parking',
   introductionText: 'Parking and access information for Texas A&M baseball home games.',
@@ -183,6 +183,7 @@ export const BaseballParkingConfiguration: EventConfiguration = {
       value: '/events/baseball-parking'
     }
   },
+  scheduleUrl: 'https://12thman.com/sports/baseball/schedule',
   mapCenter: [-96.34509, 30.60416],
   zoom: 17
 };

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -230,6 +230,7 @@ export const BigEventConfiguration: EventConfiguration = {
   applicationName: 'Big Event Transportation Map',
   shortApplicationName: 'Big Event Map',
   eventDates: ['2026-03-21'],
+  scheduleUrl: 'https://bigevent.tamu.edu/',
   toast: {
     id: 'big-event-notification-2026',
     title: 'Big Event Transportation Map Available',

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -112,6 +112,7 @@ export const CrossCountryParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Cross Country Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M cross country events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/mens-cross-country/schedule',
   zoom: 16,
   mapCenter: [-96.36925, 30.61689]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
@@ -160,6 +160,7 @@ export const FamilyWeekendConfiguration: EventConfiguration = {
   shortApplicationName: 'Family Weekend Map',
   introductionText: 'Get the best parking information for',
   eventDates: ['2026-04-10', '2026-04-11', '2026-04-12'],
+  scheduleUrl: 'https://familyweekend.tamu.edu/',
   mapCenter: [-96.3405, 30.61114],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -378,6 +378,7 @@ export const FootballParkingConfiguration: EventConfiguration = {
     '2025-11-22',
     '2025-12-20'
   ],
+  scheduleUrl: 'https://12thman.com/sports/football/schedule',
   mapCenter: [-96.34344, 30.61011],
   zoom: 16,
   defaultLayerOverrides: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -100,6 +100,7 @@ export const GraduationConfiguration: EventConfiguration = {
   shortApplicationName: 'Fall Commencement Map',
   introductionText: 'Get the best transportation and parking information for the fall commencement ceremonies.',
   eventDates: ['2025-12-17', '2025-12-18'],
+  scheduleUrl: 'https://aggie.tamu.edu/graduation',
   mapCenter: [-96.34458, 30.60629],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -100,6 +100,7 @@ export const GraduationConfiguration: EventConfiguration = {
   shortApplicationName: 'Spring Commencement Map',
   introductionText: 'Get the best transportation and parking information for the spring commencement ceremonies.',
   eventDates: ['2026-05-07', '2026-05-08', '2026-05-09'],
+  scheduleUrl: 'https://aggie.tamu.edu/graduation',
   mapCenter: [-96.34458, 30.60629],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -176,6 +176,7 @@ export const IndoorTrackParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Indoor Track Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M indoor track events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/track-and-field/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -7,37 +7,170 @@ import {
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
 
+import esri = __esri;
+
 export enum MAROON_WHITE_GAME_LAYERS {
-  PARKING_LOTS = 'maroon-white-game-parking-lots'
+  ACCESSIBLE_PREPAID_PARKING = 'maroon-white-game-accessible-prepaid-parking',
+  EVENT_PARKING_LOTS = 'maroon-white-game-event-parking-lots'
 }
 
 const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Maroon_White_Game/MapServer';
 
+type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
+type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;
+
+const ACCESSIBLE_PARKING_IMAGE_DATA =
+  'iVBORw0KGgoAAAANSUhEUgAAACAAAAAoCAYAAACfKfiZAAAACXBIWXMAAAFsAAABbAH7rpytAAAHJUlEQVRYhYzMIRUAIBQEwYlCFCIRhUhEIAoNjodFfTFmxUpSgo6JjRd+BwsDrfRNXAAAAP//IqyAgSGBgYHhATs7+38hfoEXvLy8T9g4Ob+zsLP/R8ZcXJzvBfj5Hwnw8X1jYWEFaQQ5xgGv+f//MwAAAAD//2KEWoIBGBkZDRgYGBZwc3PrMzEzv/z+86c4VoVYABMT0w8uNvaPX75+Ff/z5/dCUKj8//8fFEKogIGBAQAAAP//wuoARkbGBBYW1vm8PNxvPn//LoJNo6GuDgr//OUrGGrADmFl/f/h06dXDAwMAf///wdFHwIwMDAAAAAA///CGuScnJz/+bi5XiMHMb8A///I8LD/O7dt+48LTJ006b+vtzdK1ICwgIDgW2gaMUCx7/9/BgAAAAD//8JqORsn5zdkA0AWP3/2DKfF6ODcmbP/He3tcTkCkUD//2cAAAAA//9CttwAlHiQfQ7y9fIlS4i2eOf27f+nTpoM57c0NqI4QlBA4DUoF8Ed8P8/AwAAAP//QnbABZACZMvxBTc2y/kFBP6zsnP8b21qwukIbm5ukGUNYHv//2cAAAAA//+CBz1IAlkhKT4HATNTE7DlIKytpYkiV1pUDDeXi5MDFA0gLPD//38GAAAAAP//gjngAS8f3wvkOMfnSxBGDmoQAKURkMUgjC29mJoYI9IDH983cCj8/88AAAAA//8Cl3CgQgY56LEZALMcZgnIp34+3ihqQWxciRWUMGF2gNIZyNP///9nAAAAAP//AjlgAqiEI+R7mOUwC6IiwsGOkJOT/b986VKsetABcs4AeZqBgcEAAAAA//9iAoXA739//8DKhYR4UMmLCSJCQxn27NnLICEpCZaUkZYB089fvmaIS0pmmDZ5CsES0tnJCc7m4uJ+z8DAEAAAAAD//wKx/7Mi5XtiQVlxMTzVw6KDEECOBkFBoScMDAwLAAAAAP//AjsAJghKKLgASDMoe6WnpoITICy+nRzswQ5AT5S4AMwuXh6eBwwMDAcAAAAA//8iygGw+EbGIN/D8jvIESCHgTAoZPCVmrDcAHYAA8MBAAAAAP//IugAbJYjY5DPQaGDLAYqE3ABLU1NhAMYGA4AAAAA///C6wBQ1kMuXECpHYZhWREUEiAA8j1yYYQrZ8CjgJf3CQMDwwEAAAAA//8COeADJyfnO2yJEGQozED0YEX2NbJloMSIKxSQE6EQP/8DBgaGCQAAAAD//wJlwwvsbGxfYNlj2uTJmHW/ng48+8HFjI2wZrWGhiYwff7SFYYVy5ahyG3bugXO/v2fQZ6BgeECAAAA//8COWADw///8EbHjp07MQwFGfbi+XMUMXTDkR3m6eoMZvdP6EeR27h5E5z9/ds3BgYGhgMAAAAA//8CEQqgahi5LAAFFbY0AEvpIAwrA2BpgFD0gCo3eF3Az/8IXC3//88AAAAA//+CVUYbBJCKY1CRiR6nuDBy1YsMYPpA2RI59SNVyQn///9nAAAAAP//gje50UMBVI/jy4rI5QA2AEq0IHlQaKSnpCBKQH4+eEX0//9/BgAAAAD//0JukCwAN6mRakZkR4AMAvkGFPwgg4ltoiE3SMDNeUiTHez7////MwAAAAD//0J2gADIZaC2G7IjQI0JcgGyz8F5n4/vKyjrwZtk//8zAAAAAP//Qm+UgtqFH9FbxKACCpYwiQGgBIcc55CEJwBqBaG0B////88AAAAA///C2SxHTg/IiRMUpNgcAxIDySG3fBA+5wfFO0aL+P///wwAAAAA///C1TFZwMvHF/r9508urJkdlud1dRi+fv3GcOvePZxqQJ2Tf7//cPz589vx////oO4aAjAwMAAAAAD//8LlAFB6OCAoICCNq2dELGBlYmL4/v07KDU3YOhhYGAAAAAA///C1zdUAMUZHzf3329//giRYzkPJ+ePDx8+nPz//z+oZ40JGBgYAAAAAP//wukAqCMCWFhY1zOxsvz49+8fBymW83Kwv3n/8RMrNN6xdkwZGBgYAAAAAP//AtUFOMH///83/PnzeyIrExNJlrMxMX78/BUcdaDuOU7LGRgYGAAAAAD//8LrAKgjCr5+/XqRh4PzIzGWMzEyfvvPwMj/58/vQqy9YWTAwMAAAAAA///CGwUwAE2UD3j5+H9///kDb6LkYWf//uHTp13///8PIGgwAwMDAAAA//8iGAIgAA3GgO/fvomAghen5Zxc7z58+nQLOqpCGDAwMAAAAAD//yLKAVBHHPjz53cjKHixyXOxsLz78uULC7ScxxvvcMDAwAAAAAD//yJ6kAqppNwgICCAMkYEKjWhPR14JUMU/v+fAQAAAP//IioNIANoerggKCjEx/D3z6H/TMwCf//+Mfn8+fOa////Ex30YMDAwAAAAAD//yI5BJBqTlDJBgpqUOOSZJ+D8f//DAAAAAD//wMA84KrE77KDHMAAAAASUVORK5CYII=';
+const PARKMOBILE_PREPAID_PARKING_IMAGE_DATA =
+  'iVBORw0KGgoAAAANSUhEUgAAADwAAABJCAYAAABhE0UAAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAACpVJREFUeNrsW2tsHNUVvvbGsZ04yzqmJgkJeHkYWhBZAhXhB/WjAkU8hN3+MSptk1aNiJACRiBhKUoUBEolHiGVACkoMhR+gNQ2RoUIhEicNlJsqZClIhQMyOtgxyR04/X7nXC+u3OdO3funZ2dnTUB+UijWXtn7pzvnu+ce86Zu4wtyIIsyIL8gKQgXwNfeXlVhE61dNTQEbOOiOHyFB1x6zhMR/tXPYnUDwIwAW2g0+/paBD/C5UWsJLVi9jiihArWh6yXT99ZpZNJWfZRO8Mmx0/J3/VRserBLztggRMQDfSaQcdVfg7fEMxC69dzJZeXeQAaRKAH/1img19PMWG/jsp/p2gYycBf+WCAExAQdtWAIUFK2pLWWR9CbdqLgJrpzomWLJ9nDPAAr6JgLd/L4AtH4VFHwa4yjuXsoq60rzEg9MHxljy0Jig/POWxVPzBpjAgrb7EYhA3Ut/u8yzRaPhara0aNnc358kP/Rs8b7XhgXVEdwaCXQi74AJLKLtIUTclb8uc7UqgN2yooZdX7GOjptYZelK7XWj08Ose+gL1vlNO+s8dZidHus3jpk8NM76/z4iInsdgY7nDbAAS9aMXLb5Ih6QdFK5ZCVrqv4Tq199ty8Kf5L8iL3R9bLR+ghsJ/YOwupZgy7IksbHADb6UIQvMzqL/vG6Zt9AdcD3HX+OrN/l+A7LWPeelAB9o1d6F2QRoEDjGMDqLAvqbl273eafMmVBVQAAXWXL4Xr4dTR8Nac96K+OAWvj0FkaoC2frvMSyLwC3o1obPLZe6JNZNlHnNF1vJ8revDrtz1bVfg9XEL2eUzWrv88xifP4NPPE+DmnAFb6+whROPLNocd32+NbXdQGEoB6D+738iJ0gCNQwiove3oFgfoE3uHRPSuy7ROF3p4biuWHCw9OsuqYKFU87/vzxmsoHLzv+6fAwjqP3nrS47rpGWxNdOYIQ/p4sYV95Y5/Jb7bGyHAywskJpMBpZ0YKz3Tuxn6ypvZeXFFfwA7Y99e/S81YoK2LkZ7tOR5ZFIz8BgKu4LMN28n9LFyJpNYYefYaYXh4oz0s20bEXD19B5FXeq0ekR9xz77BQHCDbhmdeUX8+f1zfSc14nMkiqcxJRO0aA92Ttw1bVs18XqFS/BUjQ2C1hQASuX3MXu+WSGkcURnBD5AaFM40hKI17ZLorAazRVGWFXKy7i07XrvlDmFNGts7WtXYqv/bZC2SBDmPU3XLD4zyKwwdhISjZlTrOlV5aVMZpiu/uid43F5G1OTW/fhm3MM6wvHxt8YpF7P/vj+FjCVn5Tc8WttbdAV1kVq0LJTZ/cK8RLCwCMACJQHaw922HFfF9/Zq7eRDM5B4Yc299Gz/j+9+890tTxC7Xrcshg3U3YFX4yR1LbBkVHvLouqds1+77dLc2E5LBcgAdWyhXPqz1VwQm+Ci+h/Vwz+qyKnbk5PtafwZLQG+cMeHy88/NnCPAU/jYSVb+zOuyVCMCgRqZ1fXWlFRg/ZwDS9aCVdOZlP2Q/VlcizOeJSyuClgyp9Mldp0knWt09y4yAI5hXVM7FUj7ZEG6aIrCUBYTImdHujVUAN13fDcPXLj2L/En2O5fvM4n7WDvOw5qY/JwDyZU1Qk6Q3dE62wSj5iuOIBFbIoOdhmtC4HP6qIulEWw4bk1UVIkFIJB+B5WhPXrV99lLCzkXFwWS/esAEd0gNV6FjWsaflQqWfze7LmtqMP8AMBT1wn5+Pw57Qb1eoj9thJG6NkQavJ1CE1ppah0kJHJHUuEye1dBYT47amygIKiwkVygsLqpTVTbaqm1vTsNBQ5GujrnOW+zUsWDVHy1zES8bmR3QWTgQxsKmd4+YCAOmVFX7F4ahYrMnKnhtyqiVFca9jhBCkmIKqoLBIZOQKS1A7aEsvcmuK64BkormgMyYDUVcEHxtgTQsIgUvuagirm9JM2bfVSVF19wI4NZWcjej8SgaJh+omAiDdAKvpJa5RmSImxW2tN60WVuM+lQ3g+ETvTK0uMsozq4vcgpqiOaCrgA5+/Y5rP1q0drFGmzI5OSdQJwsNPqvP5XlZOozGt0oN9I1VxUxNO+TYKN+yDUKYRDQD0+v1c8ZrRFAEWJnS0Nl6Q5EV4LjoCmZKJY35Llkm26UJYyHjwiSCJTp34Ndd0WR7jtrJFEbzDFgUz3iLp667ahCBkm4RWb+mlzlKQ+TOyLQwFnzcZF05quuMIOncnlWUJmmjurIB9JDfG8En5SIACiJ3Nimok5abnzYW+BjHZFlej0vNBzX4QVerFm4z9ajdOh64s6koXMiWRItsSvH3RFKURA0rCgE3Ed+jwyH6YfA/dEv+8dVfeYop96l0lN9w+a/m/k5XYufr64EjE2zkf9zCLbpaOGNfmhKQbkrEq6p3LncEDVBQDVSils2HqM/UvY3o2nEGS1KCrBv127UcJJo0YF7kZoBow8pLAyx226rbubWCbNPK/WjBCkzqsx9ts7PnwJigc7PvNi1uJNAbaV2LLL+t1NbMA4VVagvQfaM9rtTMNnK3/PxpmwugXSRTGb7b2zqE3jSsu8l3I96y8sc00MapU7PsopuKHcuUaJDbQd/BJwKTgh6Ur+KD7m+5+Rmbzwq3USezt3WYTfTNZLSuJ8A0QIJARyZPza5HjSwHMIBBo00FLWgIZctLLiaLJzI22+X7fvfTB3k0ltljihHoRWMfCMkrZN2dmcbP+nXpVY+Xa98NYw01JSEiQmO5QadCzX2RRgKcaZcAQCIiq1kbUsgv/zwgEqXgXpdaoFEz8hfi1U9UaPd0INUE8Gxq4UxiejcMv+3ansz6hXjI64OJ2imi9ufkz03jiWlWvr7EcQ18C11GUF28ZfArSCpgVVMS0vPiICM3w8f7CGyH13H9bGrhL8exTanyziWu1yJlRN9Y91bfVEcjN860sQVL0OkDo/jo6SV4ToAt0PDnWtP2B2OFw98aVjsSFvi0WvUYe13ntzlgP2Zdtrr7BYwg1g1/vqql3PPWwlwFpd+XuwaE30b9bE4r9PNg60GNCBw9e4fYfAmeZdW6jX534vk2jbU+D84Mnd0AJZb9bHFeweK973D6JVkzgfW9nyInLhLoDgIdG0/MXItuv259DkJSnRPs1FujouxrzmWswgD0Qe6a6P/biOglBSoYE2MzazdtruPlDFj2597Xh9VN3jmJMmZjELvkAwmvRO1vsHuG/Llhdvgs3xweiN++OcJGPuV+i33S7wYxZmDriVVKVhEFY2qR4UdQFHyb3q/hqSiYTx+WBQEljoiaiz9zv03vxolbY7ILErDlYwgsqRMvD/nyZ9yDe1n6zcGmoH/dEniKZPnz56R4k65pkElQzI8lpkVR0B60fnnJCdExFE0DtR/m2tWkouDMkXFRFOzJh255+6GWlXMfYy57rA1FQZzA3pgvnQpZfqWR+3N6u76739I1lt825lOhvAK2uhA8KbGsp6+D01v5RXKRyKdOea/rrCKjgJKS2ukzzqSkjzIpK7kI7Ndn35sP65oGABxZnwad6pgUzXNfxfwFaWEhZOW36FSCyD344STDYfWk8EuzLcSEifnQY94sLFm6ilk/yEQFlG+fXZAFWZAfl3wnwAAuoxpI3H/1LQAAAABJRU5ErkJggg==';
+const ACCESSIBLE_PARKING_ICON_WIDTH = 28;
+const ACCESSIBLE_PARKING_ICON_HEIGHT = (ACCESSIBLE_PARKING_ICON_WIDTH * 39) / 32;
+// Preserve the published 33x40 pin aspect ratio instead of forcing the art into a square.
+const PARKMOBILE_PREPAID_PARKING_ICON_WIDTH = 28;
+const PARKMOBILE_PREPAID_PARKING_ICON_HEIGHT = (PARKMOBILE_PREPAID_PARKING_ICON_WIDTH * 40) / 33;
+
+const eventParkingLotSymbol = {
+  type: 'simple-fill',
+  color: [81, 179, 54, 255],
+  outline: {
+    type: 'simple-line',
+    color: [68, 137, 112, 255],
+    width: 1
+  }
+} as unknown as esri.SymbolProperties;
+
+const reservedParkingLotSymbol = {
+  type: 'simple-fill',
+  color: [242, 160, 97, 255],
+  outline: {
+    type: 'simple-line',
+    color: [230, 124, 0, 255],
+    width: 1
+  }
+} as unknown as esri.SymbolProperties;
+
+const roadClosedSymbol = {
+  type: 'simple-fill',
+  style: 'backward-diagonal',
+  color: [230, 0, 0, 255],
+  outline: {
+    type: 'simple-line',
+    color: [230, 0, 0, 255],
+    width: 1
+  }
+} as unknown as esri.SymbolProperties;
+
+const createPictureMarkerSymbol = (url: string, width: number, height: number): esri.SymbolProperties =>
+  ({
+    type: 'picture-marker',
+    url,
+    width,
+    height
+  }) as unknown as esri.SymbolProperties;
+
+const maroonWhiteAccessiblePrepaidParkingRenderer: FeatureRenderer = {
+  type: 'unique-value',
+  field: 'name',
+  uniqueValueInfos: [
+    {
+      value: 'Accessible Parking',
+      label: 'Accessible Parking',
+      // Preserve the published 32x40 pin aspect ratio instead of forcing the art into a square.
+      symbol: createPictureMarkerSymbol(
+        `data:image/png;base64,${ACCESSIBLE_PARKING_IMAGE_DATA}`,
+        ACCESSIBLE_PARKING_ICON_WIDTH,
+        ACCESSIBLE_PARKING_ICON_HEIGHT
+      )
+    },
+    {
+      value: 'ParkMobile Prepaid Parking',
+      label: 'ParkMobile Prepaid Parking',
+      // Use clean local SVG art here because the service PNG produces visible artifacts in AggieMap legend swatches.
+      symbol: createPictureMarkerSymbol(
+        `data:image/png;base64,${PARKMOBILE_PREPAID_PARKING_IMAGE_DATA}`,
+        PARKMOBILE_PREPAID_PARKING_ICON_WIDTH,
+        PARKMOBILE_PREPAID_PARKING_ICON_HEIGHT
+      )
+    }
+  ]
+};
+
+const maroonWhiteEventParkingLotsRenderer: FeatureRenderer = {
+  type: 'unique-value',
+  field: 'Type',
+  uniqueValueInfos: [
+    {
+      value: 'Event Parking',
+      label: 'Event Parking',
+      symbol: eventParkingLotSymbol
+    },
+    {
+      value: 'Reserved',
+      label: 'Reserved',
+      symbol: reservedParkingLotSymbol
+    },
+    {
+      value: 'Lot Specific Permit Only',
+      label: 'Reserved',
+      symbol: reservedParkingLotSymbol
+    },
+    {
+      value: 'Closure',
+      label: 'Road Closed (Pedestrian Zone)',
+      symbol: roadClosedSymbol
+    }
+  ]
+};
+
 export const MaroonWhiteGameDefinitions = {
-  PARKING_LOTS: {
-    id: MAROON_WHITE_GAME_LAYERS.PARKING_LOTS,
-    layerId: MAROON_WHITE_GAME_LAYERS.PARKING_LOTS,
-    name: 'Maroon & White Game Parking Lots',
+  ACCESSIBLE_PREPAID_PARKING: {
+    id: MAROON_WHITE_GAME_LAYERS.ACCESSIBLE_PREPAID_PARKING,
+    layerId: MAROON_WHITE_GAME_LAYERS.ACCESSIBLE_PREPAID_PARKING,
+    name: 'Accessible/PrePaid Parking',
     url: `${eventUrl}/0`
+  },
+  EVENT_PARKING_LOTS: {
+    id: MAROON_WHITE_GAME_LAYERS.EVENT_PARKING_LOTS,
+    layerId: MAROON_WHITE_GAME_LAYERS.EVENT_PARKING_LOTS,
+    name: 'Event Parking Lots',
+    url: `${eventUrl}/1`
   }
 };
 
 export const MaroonWhiteGameColdLayerSources: LayerSource[] = [
   {
     type: 'feature',
-    id: MaroonWhiteGameDefinitions.PARKING_LOTS.id,
-    title: MaroonWhiteGameDefinitions.PARKING_LOTS.name,
-    url: MaroonWhiteGameDefinitions.PARKING_LOTS.url,
+    id: MaroonWhiteGameDefinitions.EVENT_PARKING_LOTS.id,
+    title: MaroonWhiteGameDefinitions.EVENT_PARKING_LOTS.name,
+    url: MaroonWhiteGameDefinitions.EVENT_PARKING_LOTS.url,
     popupComponent: MarkdownWDirectionsPopupComponent,
     popupData: {
-      name: 'attributes.Type',
-      description: '{attributes.description}\n{attributes.Notes}'
+      name: '{attributes.name}',
+      description: '{attributes.description}'
     },
     visible: true,
     listMode: 'show',
     native: {
-      outFields: ['*']
-    }
+      outFields: ['*'],
+      renderer: maroonWhiteEventParkingLotsRenderer
+    } as unknown as FeatureNative
+  },
+  {
+    type: 'feature',
+    id: MaroonWhiteGameDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
+    title: MaroonWhiteGameDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
+    url: MaroonWhiteGameDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: '{attributes.name}',
+      description: '{attributes.description}'
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*'],
+      renderer: maroonWhiteAccessiblePrepaidParkingRenderer
+    } as unknown as FeatureNative
   }
 ];
 
@@ -47,7 +180,8 @@ export const MaroonWhiteGameConfiguration: EventConfiguration = {
   applicationName: 'Maroon & White Game Transportation Map',
   shortApplicationName: 'Maroon & White Game Map',
   introductionText: 'Get the best parking information for',
-  eventDates: ['2026-04-19'],
+  eventDates: ['2026-04-18'],
+  scheduleUrl: 'https://12thman.com/sports/football/schedule',
   mapCenter: [-96.34046, 30.60798],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -150,6 +150,11 @@ export const MaroonWhiteGameColdLayerSources: LayerSource[] = [
     },
     visible: true,
     listMode: 'show',
+    // Service-backed fallback if we want this layer to pull its map symbology and legend entries
+    // directly from the ArcGIS service again, like the simpler event map definitions:
+    // native: {
+    //   outFields: ['*']
+    // }
     native: {
       outFields: ['*'],
       renderer: maroonWhiteEventParkingLotsRenderer
@@ -167,6 +172,11 @@ export const MaroonWhiteGameColdLayerSources: LayerSource[] = [
     },
     visible: true,
     listMode: 'show',
+    // Service-backed fallback if we want this layer to pull its map symbology and legend entries
+    // directly from the ArcGIS service again, like the simpler event map definitions:
+    // native: {
+    //   outFields: ['*']
+    // }
     native: {
       outFields: ['*'],
       renderer: maroonWhiteAccessiblePrepaidParkingRenderer

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -128,6 +128,7 @@ export const MensBasketball_Configuration: EventConfiguration = {
     '2026-02-28',
     '2026-03-03'
   ],
+  scheduleUrl: 'https://12thman.com/sports/mens-basketball/schedule',
   zoom: 16,
   mapCenter: [-96.34467, 30.60585]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -138,6 +138,7 @@ export const MoveInConfiguration: EventConfiguration = {
     "Please review that your selections are correct. In doing so, you'll receive the best parking locations and avoid parking citations on your move-in day.",
   mapCenter: [-96.34358, 30.61035],
   eventDates: [],
+  scheduleUrl: 'https://reslife.tamu.edu/movein/',
   zoom: 16,
   builderStartStep: 'accommodations'
 };

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -127,6 +127,7 @@ export const OutdoorTrackParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Outdoor Track Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M outdoor track events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/track-and-field/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -100,6 +100,7 @@ export const RingDayConfiguration: EventConfiguration = {
   shortApplicationName: 'Ring Day Map',
   introductionText: 'Get the best transportation and logistics information for Ring Day.',
   eventDates: [RingDayDates.DAY1, RingDayDates.DAY2, RingDayDates.DAY3],
+  scheduleUrl: 'https://www.aggienetwork.com/ring/ringday/',
   mapCenter: [-96.33616, 30.60958],
   zoom: 16,
   defaultLayerOverrides: {

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -177,6 +177,7 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Savannah Bananas Parking',
   introductionText: 'Parking and transportation info for Savannah Bananas vs Texas Tailgaters at Kyle Field.',
   eventDates: ['2026-05-02'],
+  scheduleUrl: 'https://app.12thman.com/bananaball',
   mapCenter: [-96.34046, 30.60798],
   zoom: 16
 };

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -162,6 +162,7 @@ export const SoccerParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Soccer Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M soccer events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/womens-soccer/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -124,6 +124,7 @@ export const SoftballParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Softball Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M softball games.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/softball/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -103,6 +103,7 @@ export const SoftballConfiguration: EventConfiguration = {
   shortApplicationName: 'Softball Regionals Map',
   introductionText: 'Get the best transportation and parking information for Softball Regionals.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/softball/schedule',
   mapCenter: [-96.34454, 30.60338],
   zoom: 17
 };

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -159,6 +159,7 @@ export const SwimmingParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Swimming Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M swimming events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/swimdive/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -57,6 +57,7 @@ export const TennisParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Tennis Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M tennis events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/mens-tennis/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -168,6 +168,7 @@ export const VolleyballParkingConfiguration: EventConfiguration = {
   shortApplicationName: 'Volleyball Parking Map',
   introductionText: 'Parking and transportation information for Texas A&M volleyball events.',
   eventDates: [],
+  scheduleUrl: 'https://12thman.com/sports/womens-volleyball/schedule',
   zoom: 16,
   mapCenter: [-96.34454, 30.60338]
 };

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -149,6 +149,7 @@ export const WomensBasketball_Configuration: EventConfiguration = {
     '2026-02-22',
     '2026-02-26'
   ],
+  scheduleUrl: 'https://12thman.com/sports/womens-basketball/schedule',
   zoom: 16,
   mapCenter: [-96.34467, 30.60585]
 };

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -49,6 +49,12 @@ export interface EventConfiguration {
    */
   eventDates: Array<string | Date | number>;
 
+  /**
+   * Optional external URL linking to the event's official schedule page.
+   * When provided, the event date display in the builder is rendered as a clickable link.
+   */
+  scheduleUrl?: string;
+
   mapCenter?: Array<number>;
 
   zoom?: number;

--- a/libs/ts/events/ngx/src/lib/modules/builder/builder.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/builder/builder.component.html
@@ -1,13 +1,6 @@
 <div class="container12">
   <div class="flex flex-column justify-center align-center">
     <h1 id="component-title">{{ config?.applicationName }}</h1>
-
-    <ng-container *ngIf="config?.eventDates as dates">
-      <h4>
-        <a *ngIf="config?.scheduleUrl; else plainDates" [href]="config!.scheduleUrl" target="_blank" rel="noopener noreferrer">Click here for {{ config?.name }} details</a>
-        <ng-template #plainDates>{{ dates | dateRange }}</ng-template>
-      </h4>
-    </ng-container>
   </div>
 
   <router-outlet></router-outlet>

--- a/libs/ts/events/ngx/src/lib/modules/builder/builder.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/builder/builder.component.html
@@ -3,7 +3,10 @@
     <h1 id="component-title">{{ config?.applicationName }}</h1>
 
     <ng-container *ngIf="config?.eventDates as dates">
-      <h4>{{ dates | dateRange}}</h4>
+      <h4>
+        <a *ngIf="config?.scheduleUrl; else plainDates" [href]="config!.scheduleUrl" target="_blank" rel="noopener noreferrer">Click here for {{ config?.name }} details</a>
+        <ng-template #plainDates>{{ dates | dateRange }}</ng-template>
+      </h4>
     </ng-container>
   </div>
 

--- a/libs/ts/events/ngx/src/lib/modules/builder/builder.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/builder/builder.component.scss
@@ -22,6 +22,10 @@
   min-height: 100%;
 }
 
+h4 a {
+  color: #eeeeee;
+}
+
 #component-title {
   font-size: 2.5rem;
   font-weight: 500;

--- a/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.html
@@ -1,6 +1,9 @@
 <div class="container12">
   <ng-container *ngIf="accommodation$ | async as accommodation">
     <p class="center-text component-instructions">{{accommodation.description}}</p>
+    <p class="center-text component-instructions event-details" *ngIf="config?.scheduleUrl">
+      <a [href]="config!.scheduleUrl" target="_blank" rel="noopener noreferrer">Click here for {{ config?.name }} details</a>
+    </p>
 
     <div *ngIf="accommodation.uiType === 'date-card-grid'; else nonDateOptions" class="date-card-container">
       <div

--- a/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.scss
@@ -12,6 +12,17 @@
   flex-wrap: wrap;
 }
 
+.event-details {
+  margin-top: -0.25rem;
+  margin-bottom: 2rem;
+
+  a {
+    color: inherit;
+    font: inherit;
+    text-decoration: underline;
+  }
+}
+
 .button {
   margin: 0.75rem;
   text-transform: none;

--- a/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
@@ -18,6 +18,7 @@ interface AccommodationChoiceGroup {
   styleUrls: ['./accommodations.component.scss', '../builder-module-base/builder-module-base.component.scss']
 })
 export class AccommodationsComponent implements OnInit {
+  public config = this.eventSettingsService.eventConfiguration()?.configuration;
   public savedOptionValue: Observable<string | boolean | number | null>;
 
   public accommodation$: Observable<SpecialEventOption>;

--- a/libs/ts/football/ngx/src/lib/modules/builder/builder.component.html
+++ b/libs/ts/football/ngx/src/lib/modules/builder/builder.component.html
@@ -1,7 +1,6 @@
 <div class="container12">
   <div class="flex flex-column">
     <h1 id="component-title">LONE STAR SHOWDOWN EVENT MAPS</h1>
-    <h4><a href="https://12thman.com/sports/football/schedule" target="_blank" rel="noopener noreferrer">Click here for Football dates.</a></h4>
   </div>
 
   <router-outlet></router-outlet>

--- a/libs/ts/football/ngx/src/lib/modules/builder/builder.component.html
+++ b/libs/ts/football/ngx/src/lib/modules/builder/builder.component.html
@@ -1,6 +1,7 @@
 <div class="container12">
   <div class="flex flex-column">
     <h1 id="component-title">LONE STAR SHOWDOWN EVENT MAPS</h1>
+    <h4><a href="https://12thman.com/sports/football/schedule" target="_blank" rel="noopener noreferrer">Click here for Football dates.</a></h4>
   </div>
 
   <router-outlet></router-outlet>

--- a/libs/ts/football/ngx/src/lib/modules/builder/builder.component.scss
+++ b/libs/ts/football/ngx/src/lib/modules/builder/builder.component.scss
@@ -3,10 +3,6 @@
 :host {
   background: #500000;
   color: #eeeeee;
-
-  h4 a {
-    color: #eeeeee;
-  }
   padding: 2rem 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;

--- a/libs/ts/football/ngx/src/lib/modules/builder/builder.component.scss
+++ b/libs/ts/football/ngx/src/lib/modules/builder/builder.component.scss
@@ -3,6 +3,10 @@
 :host {
   background: #500000;
   color: #eeeeee;
+
+  h4 a {
+    color: #eeeeee;
+  }
   padding: 2rem 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
This PR adds support for event-specific schedule/detail links in the event builder. It also updates the Maroon & White Game map with newly-formatted icons and a new parking map layer.

## Changes
- adds optional `scheduleUrl` to the shared event configuration interface
- update the events builder to show a clickable event details/schedule link when `scheduleUrl` is provided and builder is enabled
- adds matching link styling in the events and football builders
- populate `scheduleUrl` across event definitions forfootball, baseball, basketball, track, soccer, softball, volleyball, swimming, Family Weekend, Ring Day, Move-In, Big Event, graduation, and Savannah Bananas
    -  (May not be necessary for other athletic events that currently do not have builders, but I left these in case we want to reuse them and/or make a builder for these events in the future. Can be removed if desired.)
- updates the Maroon & White Game configuration date to April 18, 2026
- adds custom renderers and marker artwork for Maroon & White Game accessible and prepaid parking legend/map display
- refines Maroon & White Game popup field mappings for the updated service data
- renames the baseball event display name from `Baseball Parking` to `Baseball`


<img width="1672" height="707" alt="image" src="https://github.com/user-attachments/assets/62094658-3e7e-4302-9c5d-dae5797e2748" />
![Recording 2026-04-06 111424](https://github.com/user-attachments/assets/72d36412-05fc-4677-a71e-9dc199a39d14)

![Recording 2026-04-06 111424](https://github.com/user-attachments/assets/9806a62c-340e-4547-bf56-9bebd7020b70)

<img width="2057" height="1071" alt="image" src="https://github.com/user-attachments/assets/ad56731b-9289-4a2d-87a6-2b95ecc31d05" />

Closes #711  
Closes #710