### PR TITLE
fix(aggiemap-angular): Temporary Sustainable Transportation layer/icon workaround

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -247,25 +247,69 @@ export function LayerSources(
       listMode: 'show',
       visible: false,
       sources: [
+        // GroupLayer drawing follows child source order, so keep this array bottom-to-top
+        // while preserving layerIndex values for the desired legend order.
         {
           type: 'feature',
-          id: 'ev-charge-stations-layer',
-          title: 'EV Charge Stations (Main + RELLIS)',
-          url: `${evChargeStationsUrl}/0`,
+          id: 'bike-dismount-zones-layer',
+          title: 'Bike Dismount Zones',
+          url: `${bikeMapUrl}/5`,
           listMode: 'show',
           visible: true,
-          layerIndex: 13,
+          layerIndex: 0,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.EV_ID}',
-            description:
-              '<strong>Network</strong>: {attributes.EV_Network}\n' +
-              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+            name: 'Bike Dismount Zone'
           },
           native: {
             ...commonLayerProps
+          }
+        },
+        {
+          type: 'group',
+          id: 'bike-lanes-group-layer',
+          title: 'Bike Lanes',
+          listMode: 'show',
+          visible: true,
+          layerIndex: 8,
+          sources: [
+            {
+              type: 'feature',
+              id: 'city-bike-lanes-routes-layer',
+              title: 'City Bike Lanes and Routes',
+              url: `${bikeMapUrl}/3`,
+              listMode: 'show',
+              visible: true,
+              layerIndex: 7,
+              popupComponent: Popups.MarkdownPopupComponent,
+              popupData: {
+                name: '{attributes.Use_}',
+                description: '<strong>Location</strong>: {attributes.Location}'
+              },
+              native: {
+                ...commonLayerProps
+              }
+            },
+            {
+              type: 'feature',
+              id: 'bike-lanes-layer',
+              title: 'Campus Bike Lanes',
+              url: `${bikeMapUrl}/2`,
+              listMode: 'show',
+              visible: true,
+              layerIndex: 8,
+              popupComponent: Popups.MarkdownPopupComponent,
+              popupData: {
+                name: '{attributes.Use_}',
+                description: '<strong>Location</strong>: {attributes.Location}'
+              },
+              native: {
+                ...commonLayerProps
+              }
+            }
+          ],
+          native: {
+            listMode: 'hide-children'
           }
         },
         {
@@ -280,40 +324,6 @@ export function LayerSources(
           popupData: {
             name: '{attributes.Bike_Sta_Name}',
             description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-          },
-          native: {
-            ...commonLayerProps
-          }
-        },
-        {
-          type: 'feature',
-          id: 'bike-lanes-layer',
-          title: 'Bike Lanes',
-          url: `${bikeMapUrl}/2`,
-          listMode: 'show',
-          visible: true,
-          layerIndex: 8,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.Use_}',
-            description: '<strong>Location</strong>: {attributes.Location}'
-          },
-          native: {
-            ...commonLayerProps
-          }
-        },
-        {
-          type: 'feature',
-          id: 'city-bike-lanes-routes-layer',
-          title: 'City Bike Lanes and Routes',
-          url: `${bikeMapUrl}/3`,
-          listMode: 'show',
-          visible: true,
-          layerIndex: 7,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.Use_}',
-            description: '<strong>Location</strong>: {attributes.Location}'
           },
           native: {
             ...commonLayerProps
@@ -411,15 +421,20 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-dismount-zones-layer',
-          title: 'Bike Dismount Zones',
-          url: `${bikeMapUrl}/5`,
+          id: 'ev-charge-stations-layer',
+          title: 'EV Charge Stations (Main + RELLIS)',
+          url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 0,
+          layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: 'Bike Dismount Zone'
+            name: '{attributes.EV_ID}',
+            description:
+              '<strong>Network</strong>: {attributes.EV_Network}\n' +
+              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
           },
           native: {
             ...commonLayerProps

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -7,6 +7,25 @@ import { IFactoryExcludeOptions } from '../utils/definitionFactory';
 
 import esri = __esri;
 
+// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
+// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
+// The rack symbol imageData below is copied from the BikeMap layer 0 renderer so the temporary
+// layers use the original source icons instead of the legend swatches. When the FeatureServer
+// icons are corrected upstream, revert the three rack layers back to:
+//   bike-racks-map-layer    → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
+//   shared-mobility-racks-layer → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
+//   hub-corrals-layer       → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
+// Remove definitionExpression, layerIndex, and renderer overrides from the native configs below,
+// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
+// prettier-ignore
+const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
+
+// prettier-ignore
+const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
+
+// prettier-ignore
+const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
+
 export const commonLayerProps = {
   outFields: ['*'],
   minScale: 100000,
@@ -235,6 +254,7 @@ export function LayerSources(
           url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.EV_ID}',
@@ -255,6 +275,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/1`,
           listMode: 'show',
           visible: true,
+          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Bike_Sta_Name}',
@@ -271,6 +292,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/2`,
           listMode: 'show',
           visible: true,
+          layerIndex: 8,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Use_}',
@@ -287,6 +309,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/3`,
           listMode: 'show',
           visible: true,
+          layerIndex: 7,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Use_}',
@@ -300,54 +323,90 @@ export function LayerSources(
           type: 'feature',
           id: 'bike-racks-map-layer',
           title: 'Bike Racks',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 10,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.type}',
+            name: '{attributes.Type}',
             description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×20 px
+                width: 30,
+                height: 22.5
+              }
+            }
           }
         },
         {
           type: 'feature',
           id: 'shared-mobility-racks-layer',
           title: 'Shared Mobility Racks',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 11,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: 'Shared Mobility Racks',
+            name: '{attributes.Type}',
             description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type = 'Shared Mobility HP'",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×20 px
+                width: 30,
+                height: 22.5
+              }
+            }
           }
         },
         {
           type: 'feature',
           id: 'hub-corrals-layer',
           title: 'Hub Corral',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 12,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: 'Hub Corral',
             description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×27 px
+                width: 30,
+                height: 30
+              }
+            }
           }
         },
         {
@@ -357,6 +416,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/5`,
           listMode: 'show',
           visible: true,
+          layerIndex: 0,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: 'Bike Dismount Zone'

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,5 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -7,58 +9,70 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
-  EV_CHARGERS_MAIN = 'sustainable-transportation-ev-chargers-main',
-  EV_CHARGERS_RELLIS = 'sustainable-transportation-ev-chargers-rellis',
+  EV_CHARGERS = 'sustainable-transportation-ev-chargers',
   HUB_CORRALS = 'sustainable-transportation-hub-corrals',
   SHARED_MOBILITY_RACKS = 'sustainable-transportation-shared-mobility-racks',
   BIKE_RACKS = 'sustainable-transportation-bike-racks',
   BIKE_FIX_STATIONS = 'sustainable-transportation-bike-fix-stations',
   BIKE_LANES = 'sustainable-transportation-bike-lanes',
   CITY_BIKE_LANES_ROUTES = 'sustainable-transportation-city-bike-lanes-routes',
-  BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
+  BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones'
 }
 
 // Temporary bridge until the original TS server/editor workflow is restored.
 // When that server is ready again, swap these URLs and the layer-id mapping in `SustainableTransportationDefinitions`
 // back to the restored source services.
 // These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
-const evMainLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_MC_view/FeatureServer';
-const evRellisLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_Rellis/FeatureServer';
-const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
+const evLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_view/FeatureServer';
 const fixStationLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Fix_Stations_view/FeatureServer';
+
+// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
+// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
+// When the FeatureServer icons are corrected upstream, revert the three rack layers back to:
+//   HUB_CORRALS         → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
+//   SHARED_MOBILITY_RACKS → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
+//   BIKE_RACKS          → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
+// Remove the definitionExpression and renderer overrides from their native configs below,
+// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
+const bikeMapRackLayerUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0';
+
+// Base64-encoded PNG symbols sourced from the BikeMap layer 0 renderer imageData.
+// Original renderer symbol sizes: Hub Corral 27×27 px; Shared Mobility and Bike Rack 27×20 px.
+// prettier-ignore
+const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
+
+// prettier-ignore
+const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
+
+// prettier-ignore
+const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
 const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Bike_Lanes_view/FeatureServer';
 const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
 
 export const SustainableTransportationDefinitions = {
-  EV_CHARGERS_MAIN: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
-    name: 'EV Charge Stations (Main Campus)',
-    url: `${evMainLayersUrl}/0`
-  },
-  EV_CHARGERS_RELLIS: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
-    name: 'EV Charge Stations (RELLIS)',
-    url: `${evRellisLayersUrl}/0`
+  EV_CHARGERS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    name: 'EV Charge Stations (Main + RELLIS)',
+    url: evLayersUrl + '/0'
   },
   HUB_CORRALS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     name: 'Hub Corral',
-    url: `${rackLayersUrl}/0`
+    url: bikeMapRackLayerUrl
   },
   SHARED_MOBILITY_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     name: 'Shared Mobility Racks',
-    url: `${rackLayersUrl}/1`
+    url: bikeMapRackLayerUrl
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
-    url: `${rackLayersUrl}/2`
+    url: bikeMapRackLayerUrl
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
@@ -90,22 +104,21 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   // Keep this source list aligned with the temporary URL/layer mapping above until the original services are restored.
   {
     type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.url,
+    id: SustainableTransportationDefinitions.EV_CHARGERS.id,
+    title: SustainableTransportationDefinitions.EV_CHARGERS.name,
+    url: SustainableTransportationDefinitions.EV_CHARGERS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.url,
-    visible: true,
-    listMode: 'show',
+    layerIndex: 13,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'EV Charge Station',
+      description:
+        '<strong>Network</strong>: {attributes.ev_network}<br />' +
+        '<strong>Charging Level</strong>: {attributes.ch_level}<br />' +
+        '<strong>Garage Level</strong>: {attributes.garage_lvl}<br />' +
+        '<strong>Notes</strong>: {attributes.evcs_notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -117,8 +130,27 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.HUB_CORRALS.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 12,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'picture-marker',
+          url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
+          // Original renderer symbol size: 27×27 px
+          width: 30,
+          height: 30
+        }
+      }
     }
   },
   {
@@ -128,8 +160,27 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 11,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: "Type = 'Shared Mobility HP'",
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'picture-marker',
+          url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
+          // Original renderer symbol size: 27×20 px
+          width: 30,
+          height: 22.5
+        }
+      }
     }
   },
   {
@@ -139,8 +190,27 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_RACKS.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 10,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+    },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'picture-marker',
+          url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
+          // Original renderer symbol size: 27×20 px
+          width: 30,
+          height: 22.5
+        }
+      }
     }
   },
   {
@@ -150,6 +220,12 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 9,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.bike_sta_name}',
+      description: '<strong>Amenities</strong>: {attributes.bike_amenities}'
+    },
     native: {
       outFields: ['*']
     }
@@ -161,6 +237,13 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_LANES.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 8,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.use_}',
+      description:
+        '<strong>Street Type</strong>: {attributes.street_use}<br />' + '<strong>Location</strong>: {attributes.location}'
+    },
     native: {
       outFields: ['*']
     }
@@ -172,6 +255,12 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 7,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.type}',
+      description: '<strong>Location</strong>: {attributes.loc}'
+    },
     native: {
       outFields: ['*']
     }
@@ -183,6 +272,12 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.url,
     visible: true,
     listMode: 'show',
+    layerIndex: 0,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.name}',
+      description: '<strong>Notes</strong>: {attributes.bike_notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -194,8 +289,7 @@ export const SustainableTransportationConfiguration: EventConfiguration = {
   name: 'Sustainable Transportation',
   applicationName: 'Sustainable Transportation Map',
   shortApplicationName: 'Sustainable Transportation',
-  introductionText:
-    'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
+  introductionText: 'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
   mapCenter: [-96.34643, 30.61313],
   eventDates: [],
   zoom: 15


### PR DESCRIPTION
This PR applies a temporary workaround to get the Sustainable Transportation map back into a usable state while the upstream/source layer issues are being sorted out.

It is not meant to be the final or optimal long-term solution. The current approach prioritizes getting the map and legend working again while upstream layer/service configuration is still in its transitional state.

### Why this is temporary
- it relies on temporary renderer overrides and draw-order tuning
- it uses local configuration workarounds instead of fixing the underlying source data/service behavior
- some attempted grouping behavior was avoided/reverted because it introduced regressions in layer loading

### Follow-up / long-term cleanup
Once the upstream Sustainable Transportation services are corrected, we should:

- move Hub Corral / Shared Mobility / Bike Racks back to their proper source services
- remove the temporary renderer overrides and symbol sizing overrides
- remove the temporary layer ordering hacks where no longer needed
- revisit Bike Lanes legend grouping in a more durable way if still needed
<img width="2211" height="1213" alt="image" src="https://github.com/user-attachments/assets/3e4f3238-f3b0-480a-b75e-580a88109c21" />

<img width="1752" height="783" alt="image" src="https://github.com/user-attachments/assets/6e85139e-fcab-4846-b1e4-9e30c026cdce" />

Closes #706 
Closes #685 