### PR TITLE
fix(aggiemap-angular): Update Sustainable Transporation map/layers with new source

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -7,25 +7,6 @@ import { IFactoryExcludeOptions } from '../utils/definitionFactory';
 
 import esri = __esri;
 
-// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
-// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
-// The rack symbol imageData below is copied from the BikeMap layer 0 renderer so the temporary
-// layers use the original source icons instead of the legend swatches. When the FeatureServer
-// icons are corrected upstream, revert the three rack layers back to:
-//   bike-racks-map-layer    → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
-//   shared-mobility-racks-layer → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
-//   hub-corrals-layer       → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
-// Remove definitionExpression, layerIndex, and renderer overrides from the native configs below,
-// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
-// prettier-ignore
-const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
-
-// prettier-ignore
-const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
-
-// prettier-ignore
-const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
-
 export const commonLayerProps = {
   outFields: ['*'],
   minScale: 100000,
@@ -345,7 +326,6 @@ export function LayerSources(
           url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
@@ -361,60 +341,36 @@ export function LayerSources(
           type: 'feature',
           id: 'shared-mobility-racks-layer',
           title: 'Shared Mobility Racks',
-          url: `${bikeMapUrl}/0`,
+          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1',
           listMode: 'show',
           visible: true,
-          layerIndex: 11,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.Type}',
+            name: '{attributes.type}',
             description:
-              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-              '<strong>Notes</strong>: {attributes.BR_Notes}'
+              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+              '<strong>Notes</strong>: {attributes.br_notes}'
           },
           native: {
-            ...commonLayerProps,
-            definitionExpression: "Type = 'Shared Mobility HP'",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×20 px
-                width: 30,
-                height: 22.5
-              }
-            }
+            ...commonLayerProps
           }
         },
         {
           type: 'feature',
           id: 'hub-corrals-layer',
           title: 'Hub Corral',
-          url: `${bikeMapUrl}/0`,
+          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0',
           listMode: 'show',
           visible: true,
-          layerIndex: 12,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: 'Hub Corral',
             description:
-              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-              '<strong>Notes</strong>: {attributes.BR_Notes}'
+              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+              '<strong>Notes</strong>: {attributes.br_notes}'
           },
           native: {
-            ...commonLayerProps,
-            definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×27 px
-                width: 30,
-                height: 30
-              }
-            }
+            ...commonLayerProps
           }
         },
         {
@@ -422,20 +378,10 @@ export function LayerSources(
           id: 'ev-charge-stations-layer',
           title: 'EV Charge Stations (Main + RELLIS)',
           url: `${evChargeStationsUrl}/0`,
-          id: 'ev-charge-stations-layer',
-          title: 'EV Charge Stations (Main + RELLIS)',
-          url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.EV_ID}',
-            description:
-              '<strong>Network</strong>: {attributes.EV_Network}\n' +
-              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
             name: '{attributes.EV_ID}',
             description:
               '<strong>Network</strong>: {attributes.EV_Network}\n' +

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -254,6 +254,7 @@ export function LayerSources(
           id: 'bike-dismount-zones-layer',
           title: 'Bike Dismount Zones',
           url: `${bikeMapUrl}/4`,
+<<<<<<< HEAD
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -270,9 +271,32 @@ export function LayerSources(
           id: 'city-bike-lanes-routes-layer',
           title: 'City Bike Lanes and Routes',
           url: `${bikeMapUrl}/3`,
+=======
+>>>>>>> 19e58deb (Updated with new source)
           listMode: 'show',
           visible: true,
           layerIndex: 0,
+          popupComponent: Popups.MarkdownPopupComponent,
+          popupData: {
+<<<<<<< HEAD
+            name: '{attributes.Type}',
+            description: '<strong>Location</strong>: {attributes.Loc}'
+=======
+            name: '{attributes.Name}',
+            description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
+>>>>>>> 19e58deb (Updated with new source)
+          },
+          native: {
+            ...commonLayerProps
+          }
+        },
+        {
+          type: 'feature',
+          id: 'city-bike-lanes-routes-layer',
+          title: 'City Bike Lanes and Routes',
+          url: `${bikeMapUrl}/3`,
+          listMode: 'show',
+          visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
@@ -283,64 +307,16 @@ export function LayerSources(
           }
         },
         {
-          type: 'group',
-          id: 'bike-lanes-group-layer',
-          title: 'Bike Lanes',
-          listMode: 'show',
-          visible: true,
-          layerIndex: 8,
-          sources: [
-            {
-              type: 'feature',
-              id: 'city-bike-lanes-routes-layer',
-              title: 'City Bike Lanes and Routes',
-              url: `${bikeMapUrl}/3`,
-              listMode: 'show',
-              visible: true,
-              layerIndex: 7,
-              popupComponent: Popups.MarkdownPopupComponent,
-              popupData: {
-                name: '{attributes.Use_}',
-                description: '<strong>Location</strong>: {attributes.Location}'
-              },
-              native: {
-                ...commonLayerProps
-              }
-            },
-            {
-              type: 'feature',
-              id: 'bike-lanes-layer',
-              title: 'Campus Bike Lanes',
-              url: `${bikeMapUrl}/2`,
-              listMode: 'show',
-              visible: true,
-              layerIndex: 8,
-              popupComponent: Popups.MarkdownPopupComponent,
-              popupData: {
-                name: '{attributes.Use_}',
-                description: '<strong>Location</strong>: {attributes.Location}'
-              },
-              native: {
-                ...commonLayerProps
-              }
-            }
-          ],
-          native: {
-            listMode: 'hide-children'
-          }
-        },
-        {
           type: 'feature',
-          id: 'bike-fix-stations-layer',
-          title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/1`,
+          id: 'bike-lanes-layer',
+          title: 'Bike Lanes',
+          url: `${bikeMapUrl}/2`,
           listMode: 'show',
           visible: true,
-          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.Bike_Sta_Name}',
-            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+            name: '{attributes.Use_}',
+            description: '<strong>Location</strong>: {attributes.Location}'
           },
           native: {
             ...commonLayerProps
@@ -353,13 +329,30 @@ export function LayerSources(
           url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 10,
+          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
             description:
               '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
               '<strong>Notes</strong>: {attributes.BR_Notes}'
+          },
+          native: {
+            ...commonLayerProps
+          }
+        },
+        {
+          type: 'feature',
+          id: 'bike-fix-stations-layer',
+          title: 'Bike Fix Stations',
+          url: `${bikeMapUrl}/1`,
+          listMode: 'show',
+          visible: true,
+          layerIndex: 10,
+          popupComponent: Popups.MarkdownPopupComponent,
+          popupData: {
+            name: '{attributes.Bike_Sta_Name}',
+            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
           },
           native: {
             ...commonLayerProps,
@@ -441,11 +434,20 @@ export function LayerSources(
           id: 'ev-charge-stations-layer',
           title: 'EV Charge Stations (Main + RELLIS)',
           url: `${evChargeStationsUrl}/0`,
+          id: 'ev-charge-stations-layer',
+          title: 'EV Charge Stations (Main + RELLIS)',
+          url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
           layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
+            name: '{attributes.EV_ID}',
+            description:
+              '<strong>Network</strong>: {attributes.EV_Network}\n' +
+              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
             name: '{attributes.EV_ID}',
             description:
               '<strong>Network</strong>: {attributes.EV_Network}\n' +

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -324,6 +324,22 @@ export function LayerSources(
         },
         {
           type: 'feature',
+          id: 'bike-fix-stations-layer',
+          title: 'Bike Fix Stations',
+          url: `${bikeMapUrl}/1`,
+          listMode: 'show',
+          visible: true,
+          popupComponent: Popups.MarkdownPopupComponent,
+          popupData: {
+            name: '{attributes.Bike_Sta_Name}',
+            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+          },
+          native: {
+            ...commonLayerProps
+          }
+        },
+        {
+          type: 'feature',
           id: 'bike-racks-map-layer',
           title: 'Bike Racks',
           url: `${bikeMapUrl}/0`,
@@ -339,34 +355,6 @@ export function LayerSources(
           },
           native: {
             ...commonLayerProps
-          }
-        },
-        {
-          type: 'feature',
-          id: 'bike-fix-stations-layer',
-          title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/1`,
-          listMode: 'show',
-          visible: true,
-          layerIndex: 10,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.Bike_Sta_Name}',
-            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-          },
-          native: {
-            ...commonLayerProps,
-            definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×20 px
-                width: 30,
-                height: 22.5
-              }
-            }
           }
         },
         {

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -7,6 +7,25 @@ import { IFactoryExcludeOptions } from '../utils/definitionFactory';
 
 import esri = __esri;
 
+// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
+// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
+// The rack symbol imageData below is copied from the BikeMap layer 0 renderer so the temporary
+// layers use the original source icons instead of the legend swatches. When the FeatureServer
+// icons are corrected upstream, revert the three rack layers back to:
+//   bike-racks-map-layer    → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
+//   shared-mobility-racks-layer → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
+//   hub-corrals-layer       → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
+// Remove definitionExpression, layerIndex, and renderer overrides from the native configs below,
+// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
+// prettier-ignore
+const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
+
+// prettier-ignore
+const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
+
+// prettier-ignore
+const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
+
 export const commonLayerProps = {
   outFields: ['*'],
   minScale: 100000,
@@ -235,7 +254,6 @@ export function LayerSources(
           id: 'bike-dismount-zones-layer',
           title: 'Bike Dismount Zones',
           url: `${bikeMapUrl}/4`,
-<<<<<<< HEAD
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -252,34 +270,11 @@ export function LayerSources(
           id: 'city-bike-lanes-routes-layer',
           title: 'City Bike Lanes and Routes',
           url: `${bikeMapUrl}/3`,
-=======
->>>>>>> 19e58deb (Updated with new source)
           listMode: 'show',
           visible: true,
           layerIndex: 0,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-<<<<<<< HEAD
-            name: '{attributes.Type}',
-            description: '<strong>Location</strong>: {attributes.Loc}'
-=======
-            name: '{attributes.Name}',
-            description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
->>>>>>> 19e58deb (Updated with new source)
-          },
-          native: {
-            ...commonLayerProps
-          }
-        },
-        {
-          type: 'feature',
-          id: 'city-bike-lanes-routes-layer',
-          title: 'City Bike Lanes and Routes',
-          url: `${bikeMapUrl}/3`,
-          listMode: 'show',
-          visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
             name: '{attributes.Type}',
             description: '<strong>Location</strong>: {attributes.Loc}'
           },
@@ -288,19 +283,50 @@ export function LayerSources(
           }
         },
         {
-          type: 'feature',
-          id: 'bike-lanes-layer',
+          type: 'group',
+          id: 'bike-lanes-group-layer',
           title: 'Bike Lanes',
-          url: `${bikeMapUrl}/2`,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.Use_}',
-            description: '<strong>Location</strong>: {attributes.Location}'
-          },
+          layerIndex: 8,
+          sources: [
+            {
+              type: 'feature',
+              id: 'city-bike-lanes-routes-layer',
+              title: 'City Bike Lanes and Routes',
+              url: `${bikeMapUrl}/3`,
+              listMode: 'show',
+              visible: true,
+              layerIndex: 7,
+              popupComponent: Popups.MarkdownPopupComponent,
+              popupData: {
+                name: '{attributes.Use_}',
+                description: '<strong>Location</strong>: {attributes.Location}'
+              },
+              native: {
+                ...commonLayerProps
+              }
+            },
+            {
+              type: 'feature',
+              id: 'bike-lanes-layer',
+              title: 'Campus Bike Lanes',
+              url: `${bikeMapUrl}/2`,
+              listMode: 'show',
+              visible: true,
+              layerIndex: 8,
+              popupComponent: Popups.MarkdownPopupComponent,
+              popupData: {
+                name: '{attributes.Use_}',
+                description: '<strong>Location</strong>: {attributes.Location}'
+              },
+              native: {
+                ...commonLayerProps
+              }
+            }
+          ],
           native: {
-            ...commonLayerProps
+            listMode: 'hide-children'
           }
         },
         {
@@ -310,6 +336,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/1`,
           listMode: 'show',
           visible: true,
+          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Bike_Sta_Name}',
@@ -326,6 +353,7 @@ export function LayerSources(
           url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 10,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
@@ -334,43 +362,78 @@ export function LayerSources(
               '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×20 px
+                width: 30,
+                height: 22.5
+              }
+            }
           }
         },
         {
           type: 'feature',
           id: 'shared-mobility-racks-layer',
           title: 'Shared Mobility Racks',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 11,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.type}',
+            name: '{attributes.Type}',
             description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type = 'Shared Mobility HP'",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×20 px
+                width: 30,
+                height: 22.5
+              }
+            }
           }
         },
         {
           type: 'feature',
           id: 'hub-corrals-layer',
           title: 'Hub Corral',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 12,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: 'Hub Corral',
             description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps
+            ...commonLayerProps,
+            definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
+            renderer: {
+              type: 'simple',
+              symbol: {
+                type: 'picture-marker',
+                url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
+                // Original renderer symbol size: 27×27 px
+                width: 30,
+                height: 30
+              }
+            }
           }
         },
         {
@@ -380,6 +443,7 @@ export function LayerSources(
           url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
+          layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.EV_ID}',

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -7,25 +7,6 @@ import { IFactoryExcludeOptions } from '../utils/definitionFactory';
 
 import esri = __esri;
 
-// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
-// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
-// The rack symbol imageData below is copied from the BikeMap layer 0 renderer so the temporary
-// layers use the original source icons instead of the legend swatches. When the FeatureServer
-// icons are corrected upstream, revert the three rack layers back to:
-//   bike-racks-map-layer    → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
-//   shared-mobility-racks-layer → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
-//   hub-corrals-layer       → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
-// Remove definitionExpression, layerIndex, and renderer overrides from the native configs below,
-// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
-// prettier-ignore
-const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
-
-// prettier-ignore
-const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
-
-// prettier-ignore
-const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
-
 export const commonLayerProps = {
   outFields: ['*'],
   minScale: 100000,
@@ -247,8 +228,6 @@ export function LayerSources(
       listMode: 'show',
       visible: false,
       sources: [
-        // GroupLayer drawing follows child source order, so keep this array bottom-to-top
-        // while preserving layerIndex values for the desired legend order.
         {
           type: 'feature',
           id: 'bike-dismount-zones-layer',
@@ -272,7 +251,6 @@ export function LayerSources(
           url: `${bikeMapUrl}/3`,
           listMode: 'show',
           visible: true,
-          layerIndex: 0,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
@@ -283,50 +261,19 @@ export function LayerSources(
           }
         },
         {
-          type: 'group',
-          id: 'bike-lanes-group-layer',
+          type: 'feature',
+          id: 'bike-lanes-layer',
           title: 'Bike Lanes',
+          url: `${bikeMapUrl}/2`,
           listMode: 'show',
           visible: true,
-          layerIndex: 8,
-          sources: [
-            {
-              type: 'feature',
-              id: 'city-bike-lanes-routes-layer',
-              title: 'City Bike Lanes and Routes',
-              url: `${bikeMapUrl}/3`,
-              listMode: 'show',
-              visible: true,
-              layerIndex: 7,
-              popupComponent: Popups.MarkdownPopupComponent,
-              popupData: {
-                name: '{attributes.Use_}',
-                description: '<strong>Location</strong>: {attributes.Location}'
-              },
-              native: {
-                ...commonLayerProps
-              }
-            },
-            {
-              type: 'feature',
-              id: 'bike-lanes-layer',
-              title: 'Campus Bike Lanes',
-              url: `${bikeMapUrl}/2`,
-              listMode: 'show',
-              visible: true,
-              layerIndex: 8,
-              popupComponent: Popups.MarkdownPopupComponent,
-              popupData: {
-                name: '{attributes.Use_}',
-                description: '<strong>Location</strong>: {attributes.Location}'
-              },
-              native: {
-                ...commonLayerProps
-              }
-            }
-          ],
+          popupComponent: Popups.MarkdownPopupComponent,
+          popupData: {
+            name: '{attributes.Use_}',
+            description: '<strong>Location</strong>: {attributes.Location}'
+          },
           native: {
-            listMode: 'hide-children'
+            ...commonLayerProps
           }
         },
         {
@@ -336,7 +283,6 @@ export function LayerSources(
           url: `${bikeMapUrl}/1`,
           listMode: 'show',
           visible: true,
-          layerIndex: 9,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Bike_Sta_Name}',
@@ -353,7 +299,6 @@ export function LayerSources(
           url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 10,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.Type}',
@@ -362,78 +307,43 @@ export function LayerSources(
               '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
-            ...commonLayerProps,
-            definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×20 px
-                width: 30,
-                height: 22.5
-              }
-            }
+            ...commonLayerProps
           }
         },
         {
           type: 'feature',
           id: 'shared-mobility-racks-layer',
           title: 'Shared Mobility Racks',
-          url: `${bikeMapUrl}/0`,
+          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1',
           listMode: 'show',
           visible: true,
-          layerIndex: 11,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.Type}',
+            name: 'Shared Mobility Racks',
             description:
-              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-              '<strong>Notes</strong>: {attributes.BR_Notes}'
+              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+              '<strong>Notes</strong>: {attributes.br_notes}'
           },
           native: {
-            ...commonLayerProps,
-            definitionExpression: "Type = 'Shared Mobility HP'",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×20 px
-                width: 30,
-                height: 22.5
-              }
-            }
+            ...commonLayerProps
           }
         },
         {
           type: 'feature',
           id: 'hub-corrals-layer',
           title: 'Hub Corral',
-          url: `${bikeMapUrl}/0`,
+          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0',
           listMode: 'show',
           visible: true,
-          layerIndex: 12,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: 'Hub Corral',
             description:
-              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-              '<strong>Notes</strong>: {attributes.BR_Notes}'
+              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+              '<strong>Notes</strong>: {attributes.br_notes}'
           },
           native: {
-            ...commonLayerProps,
-            definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
-            renderer: {
-              type: 'simple',
-              symbol: {
-                type: 'picture-marker',
-                url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
-                // Original renderer symbol size: 27×27 px
-                width: 30,
-                height: 30
-              }
-            }
+            ...commonLayerProps
           }
         },
         {
@@ -443,7 +353,6 @@ export function LayerSources(
           url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
-          layerIndex: 13,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
             name: '{attributes.EV_ID}',

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -278,6 +278,22 @@ export function LayerSources(
         },
         {
           type: 'feature',
+          id: 'bike-fix-stations-layer',
+          title: 'Bike Fix Stations',
+          url: `${bikeMapUrl}/1`,
+          listMode: 'show',
+          visible: true,
+          popupComponent: Popups.MarkdownPopupComponent,
+          popupData: {
+            name: '{attributes.Bike_Sta_Name}',
+            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+          },
+          native: {
+            ...commonLayerProps
+          }
+        },
+        {
+          type: 'feature',
           id: 'bike-racks-map-layer',
           title: 'Bike Racks',
           url: `${bikeMapUrl}/0`,
@@ -289,22 +305,6 @@ export function LayerSources(
             description:
               '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
               '<strong>Notes</strong>: {attributes.BR_Notes}'
-          },
-          native: {
-            ...commonLayerProps
-          }
-        },
-        {
-          type: 'feature',
-          id: 'bike-fix-stations-layer',
-          title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/1`,
-          listMode: 'show',
-          visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.Bike_Sta_Name}',
-            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
           },
           native: {
             ...commonLayerProps

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -21,8 +21,8 @@ export function LayerSources(
   definitions: IComposedIDefinitions,
   options?: IFactoryExcludeOptions<IComposedIDefinitions>
 ): Array<LayerSource> {
-  const bikeMapUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/BikeMap/MapServer');
-  const evChargeStationsUrl = connections.tsMainUrl.replace('/TS_Main/MapServer', '/EVChargeStations/MapServer');
+  const bikeMapUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+  const evChargeStationsUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
   const all: Array<LayerSource> = [
     {
       type: 'feature',
@@ -230,19 +230,15 @@ export function LayerSources(
       sources: [
         {
           type: 'feature',
-          id: 'ev-charge-stations-layer',
-          title: 'EV Charge Stations (Main + RELLIS)',
-          url: `${evChargeStationsUrl}/0`,
+          id: 'bike-dismount-zones-layer',
+          title: 'Bike Dismount Zones',
+          url: `${bikeMapUrl}/4`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.EV_ID}',
-            description:
-              '<strong>Network</strong>: {attributes.EV_Network}\n' +
-              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+            name: '{attributes.Name}',
+            description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
           },
           native: {
             ...commonLayerProps
@@ -250,15 +246,15 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-fix-stations-layer',
-          title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/1`,
+          id: 'city-bike-lanes-routes-layer',
+          title: 'City Bike Lanes and Routes',
+          url: `${bikeMapUrl}/3`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.Bike_Sta_Name}',
-            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+            name: '{attributes.Type}',
+            description: '<strong>Location</strong>: {attributes.Loc}'
           },
           native: {
             ...commonLayerProps
@@ -282,15 +278,17 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'city-bike-lanes-routes-layer',
-          title: 'City Bike Lanes and Routes',
-          url: `${bikeMapUrl}/3`,
+          id: 'bike-racks-map-layer',
+          title: 'Bike Racks',
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.Use_}',
-            description: '<strong>Location</strong>: {attributes.Location}'
+            name: '{attributes.Type}',
+            description:
+              '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+              '<strong>Notes</strong>: {attributes.BR_Notes}'
           },
           native: {
             ...commonLayerProps
@@ -298,17 +296,15 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-racks-map-layer',
-          title: 'Bike Racks',
-          url: 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2',
+          id: 'bike-fix-stations-layer',
+          title: 'Bike Fix Stations',
+          url: `${bikeMapUrl}/1`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: '{attributes.type}',
-            description:
-              '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-              '<strong>Notes</strong>: {attributes.br_notes}'
+            name: '{attributes.Bike_Sta_Name}',
+            description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
           },
           native: {
             ...commonLayerProps
@@ -352,14 +348,19 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-dismount-zones-layer',
-          title: 'Bike Dismount Zones',
-          url: `${bikeMapUrl}/5`,
+          id: 'ev-charge-stations-layer',
+          title: 'EV Charge Stations (Main + RELLIS)',
+          url: `${evChargeStationsUrl}/0`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
           popupData: {
-            name: 'Bike Dismount Zone'
+            name: '{attributes.EV_ID}',
+            description:
+              '<strong>Network</strong>: {attributes.EV_Network}\n' +
+              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
           },
           native: {
             ...commonLayerProps

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,8 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
-import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -20,6 +18,7 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones'
 }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 <<<<<<< HEAD
@@ -54,20 +53,26 @@ const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/B
 const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
 =======
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
 const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
 // Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
 const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
 
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     name: 'EV Charge Stations (Main + RELLIS)',
+<<<<<<< HEAD
 <<<<<<< HEAD
     url: `${evLayersUrl}/0`
 =======
@@ -77,23 +82,27 @@ export const SustainableTransportationDefinitions = {
     url: `${evLayersUrl}/0`
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+    url: `${evLayersUrl}/0`
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
   },
   HUB_CORRALS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     name: 'Hub Corral',
-    url: bikeMapRackLayerUrl
+    url: `${rackLayersUrl}/0`
   },
   SHARED_MOBILITY_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     name: 'Shared Mobility Racks',
-    url: bikeMapRackLayerUrl
+    url: `${rackLayersUrl}/1`
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
+<<<<<<< HEAD
 <<<<<<< HEAD
     url: `${bikeLayersUrl}/0`
 =======
@@ -103,6 +112,9 @@ export const SustainableTransportationDefinitions = {
     url: `${bikeLayersUrl}/0`
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+    url: `${bikeLayersUrl}/0`
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
@@ -139,6 +151,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
     layerIndex: 13,
@@ -154,6 +167,8 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Garage Level</strong>: {attributes.garage_lvl}<br />' +
         '<strong>Notes</strong>: {attributes.evcs_notes}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.EV_ID}',
@@ -164,9 +179,12 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
         '<strong>Notes</strong>: {attributes.EVCS_Notes}'
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -179,6 +197,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.HUB_CORRALS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 <<<<<<< HEAD
@@ -195,28 +214,22 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Hub Corral',
       description:
         '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
         '<strong>Notes</strong>: {attributes.br_notes}'
+<<<<<<< HEAD
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
-      outFields: ['*'],
-      definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'picture-marker',
-          url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
-          // Original renderer symbol size: 27×27 px
-          width: 30,
-          height: 30
-        }
-      }
+      outFields: ['*']
     }
   },
   {
@@ -226,6 +239,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 <<<<<<< HEAD
@@ -267,37 +281,27 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Shared Mobility Racks',
       description:
         '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
         '<strong>Notes</strong>: {attributes.br_notes}'
->>>>>>> 6efc1291 (Updated with new source)
     },
     native: {
-      outFields: ['*'],
-      definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'picture-marker',
-          url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
-          // Original renderer symbol size: 27×20 px
-          width: 30,
-          height: 22.5
-        }
-      }
+      outFields: ['*']
     }
   },
   {
     type: 'feature',
-<<<<<<< HEAD
     id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
     title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
     url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
 <<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
@@ -311,6 +315,8 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       name: '{attributes.bike_sta_name}',
       description: '<strong>Amenities</strong>: {attributes.bike_amenities}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Bike_Sta_Name}',
@@ -322,8 +328,6 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   },
   {
     type: 'feature',
-=======
->>>>>>> ca7e13e0 (Put bike fix stations back where they should go)
     id: SustainableTransportationDefinitions.BIKE_RACKS.id,
     title: SustainableTransportationDefinitions.BIKE_RACKS.name,
     url: SustainableTransportationDefinitions.BIKE_RACKS.url,
@@ -335,6 +339,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       description:
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
+<<<<<<< HEAD
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
     },
@@ -353,6 +358,8 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     popupData: {
       name: '{attributes.Bike_Sta_Name}',
       description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -365,6 +372,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_LANES.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
 <<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
@@ -379,12 +387,17 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       description:
         '<strong>Street Type</strong>: {attributes.street_use}<br />' + '<strong>Location</strong>: {attributes.location}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Use_}',
       description: '<strong>Location</strong>: {attributes.Location}'
+<<<<<<< HEAD
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -398,6 +411,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
 <<<<<<< HEAD
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Type}',
@@ -410,12 +424,17 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       name: '{attributes.type}',
       description: '<strong>Location</strong>: {attributes.loc}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Type}',
       description: '<strong>Location</strong>: {attributes.Loc}'
+<<<<<<< HEAD
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -429,6 +448,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
 <<<<<<< HEAD
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Name}',
@@ -441,12 +461,17 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       name: '{attributes.name}',
       description: '<strong>Notes</strong>: {attributes.bike_notes}'
 =======
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Name}',
       description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
+<<<<<<< HEAD
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+=======
+>>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,6 +1,8 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -18,103 +20,35 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones'
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-// Temporary bridge until the original TS server/editor workflow is restored.
-// When that server is ready again, swap these URLs and the layer-id mapping in `SustainableTransportationDefinitions`
-// back to the restored source services.
-// These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
-const evLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_view/FeatureServer';
-const fixStationLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Fix_Stations_view/FeatureServer';
-
-// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
-// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
-// When the FeatureServer icons are corrected upstream, revert the three rack layers back to:
-//   HUB_CORRALS         → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
-//   SHARED_MOBILITY_RACKS → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
-//   BIKE_RACKS          → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
-// Remove the definitionExpression and renderer overrides from their native configs below,
-// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
-const bikeMapRackLayerUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0';
-
-// Base64-encoded PNG symbols sourced from the BikeMap layer 0 renderer imageData.
-// Original renderer symbol sizes: Hub Corral 27×27 px; Shared Mobility and Bike Rack 27×20 px.
-// prettier-ignore
-const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
-
-// prettier-ignore
-const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
-
-// prettier-ignore
-const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
-const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Bike_Lanes_view/FeatureServer';
-const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
-=======
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
 const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
 // Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
 const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
 
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     name: 'EV Charge Stations (Main + RELLIS)',
-<<<<<<< HEAD
-<<<<<<< HEAD
     url: `${evLayersUrl}/0`
-=======
-<<<<<<< HEAD
-    url: evLayersUrl + '/0'
-=======
-    url: `${evLayersUrl}/0`
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
-    url: `${evLayersUrl}/0`
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
   },
   HUB_CORRALS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     name: 'Hub Corral',
-    url: `${rackLayersUrl}/0`
+    url: bikeMapRackLayerUrl
   },
   SHARED_MOBILITY_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     name: 'Shared Mobility Racks',
-    url: `${rackLayersUrl}/1`
+    url: bikeMapRackLayerUrl
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
-<<<<<<< HEAD
-<<<<<<< HEAD
     url: `${bikeLayersUrl}/0`
-=======
-<<<<<<< HEAD
-    url: bikeMapRackLayerUrl
-=======
-    url: `${bikeLayersUrl}/0`
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
-    url: `${bikeLayersUrl}/0`
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
@@ -150,41 +84,14 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.EV_CHARGERS.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-    layerIndex: 13,
->>>>>>> 19e58deb (Updated with new source)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.EV_ID}',
       description:
-<<<<<<< HEAD
-=======
-        '<strong>Network</strong>: {attributes.ev_network}<br />' +
-        '<strong>Charging Level</strong>: {attributes.ch_level}<br />' +
-        '<strong>Garage Level</strong>: {attributes.garage_lvl}<br />' +
-        '<strong>Notes</strong>: {attributes.evcs_notes}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.EV_ID}',
-      description:
->>>>>>> 19e58deb (Updated with new source)
         '<strong>Network</strong>: {attributes.EV_Network}\n' +
         '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
         '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
         '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -197,39 +104,26 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.HUB_CORRALS.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-    layerIndex: 12,
->>>>>>> 19e58deb (Updated with new source)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'Hub Corral',
-      description:
-<<<<<<< HEAD
-        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-        '<strong>Notes</strong>: {attributes.br_notes}'
-=======
-        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
-        '<strong>Notes</strong>: {attributes.BR_Notes}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Hub Corral',
       description:
         '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
         '<strong>Notes</strong>: {attributes.br_notes}'
-<<<<<<< HEAD
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'picture-marker',
+          url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
+          // Original renderer symbol size: 27×27 px
+          width: 30,
+          height: 30
+        }
+      }
     }
   },
   {
@@ -239,12 +133,6 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-    layerIndex: 11,
->>>>>>> 19e58deb (Updated with new source)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Shared Mobility Racks',
@@ -280,71 +168,20 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       description:
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'Shared Mobility Racks',
-      description:
-        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-        '<strong>Notes</strong>: {attributes.br_notes}'
     },
     native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
-    title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
-    url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
-    visible: true,
-    listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Bike_Sta_Name}',
-      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-=======
-<<<<<<< HEAD
-    layerIndex: 9,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.bike_sta_name}',
-      description: '<strong>Amenities</strong>: {attributes.bike_amenities}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Bike_Sta_Name}',
-      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-    },
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.BIKE_RACKS.id,
-    title: SustainableTransportationDefinitions.BIKE_RACKS.name,
-    url: SustainableTransportationDefinitions.BIKE_RACKS.url,
-    visible: true,
-    listMode: 'show',
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Type}',
-      description:
-        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-        '<strong>Notes</strong>: {attributes.BR_Notes}'
-<<<<<<< HEAD
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-    },
-    native: {
-      outFields: ['*']
+      outFields: ['*'],
+      definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'picture-marker',
+          url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
+          // Original renderer symbol size: 27×20 px
+          width: 30,
+          height: 22.5
+        }
+      }
     }
   },
   {
@@ -358,8 +195,6 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     popupData: {
       name: '{attributes.Bike_Sta_Name}',
       description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -372,32 +207,10 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_LANES.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Use_}',
       description: '<strong>Location</strong>: {attributes.Location}'
-=======
-<<<<<<< HEAD
-    layerIndex: 8,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.use_}',
-      description:
-        '<strong>Street Type</strong>: {attributes.street_use}<br />' + '<strong>Location</strong>: {attributes.location}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Use_}',
-      description: '<strong>Location</strong>: {attributes.Location}'
-<<<<<<< HEAD
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -410,31 +223,10 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Type}',
       description: '<strong>Location</strong>: {attributes.Loc}'
-=======
-<<<<<<< HEAD
-    layerIndex: 7,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.type}',
-      description: '<strong>Location</strong>: {attributes.loc}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Type}',
-      description: '<strong>Location</strong>: {attributes.Loc}'
-<<<<<<< HEAD
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']
@@ -447,31 +239,10 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.url,
     visible: true,
     listMode: 'show',
-<<<<<<< HEAD
-<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Name}',
       description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
-=======
-<<<<<<< HEAD
-    layerIndex: 0,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.name}',
-      description: '<strong>Notes</strong>: {attributes.bike_notes}'
-=======
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Name}',
-      description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
-<<<<<<< HEAD
->>>>>>> 6efc1291 (Updated with new source)
->>>>>>> 19e58deb (Updated with new source)
-=======
->>>>>>> 59a81e65 (Fixed horrific merge conflict + cleaned out temp code)
     },
     native: {
       outFields: ['*']

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,8 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
-import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
-
 import {
   AggiemapCustomMapConfiguration,
   EventConfiguration,
@@ -22,8 +20,19 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
 
 const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
-// Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
-const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
+
+// Keep the rack layers pointed at the BikeMap service so all three rack types use the same source schema.
+const bikeMapRackLayerUrl = `${bikeLayersUrl}/0`;
+
+// Base64-encoded PNG symbols sourced from the BikeMap layer 0 renderer imageData.
+// prettier-ignore
+const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
+
+// prettier-ignore
+const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
+
+// prettier-ignore
+const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
 
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
@@ -108,8 +117,8 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     popupData: {
       name: 'Hub Corral',
       description:
-        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-        '<strong>Notes</strong>: {attributes.br_notes}'
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
     },
     native: {
       outFields: ['*'],
@@ -135,10 +144,10 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     listMode: 'show',
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'Shared Mobility Racks',
+      name: '{attributes.Type}',
       description:
-        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
-        '<strong>Notes</strong>: {attributes.br_notes}'
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
     },
     native: {
       outFields: ['*'],

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -20,17 +20,63 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones'
 }
 
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+// Temporary bridge until the original TS server/editor workflow is restored.
+// When that server is ready again, swap these URLs and the layer-id mapping in `SustainableTransportationDefinitions`
+// back to the restored source services.
+// These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
+const evLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_view/FeatureServer';
+const fixStationLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Fix_Stations_view/FeatureServer';
+
+// Temporary fix: BikeMap MapServer layer 0 renders all rack types at a consistent icon size,
+// whereas the hosted Rack_Locations_view FeatureServer sub-layers have inconsistent icon sizes.
+// When the FeatureServer icons are corrected upstream, revert the three rack layers back to:
+//   HUB_CORRALS         → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/0'
+//   SHARED_MOBILITY_RACKS → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/1'
+//   BIKE_RACKS          → 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer/2'
+// Remove the definitionExpression and renderer overrides from their native configs below,
+// and revert popup attribute keys back to lowercase (type, total_capacity, br_notes).
+const bikeMapRackLayerUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer/0';
+
+// Base64-encoded PNG symbols sourced from the BikeMap layer 0 renderer imageData.
+// Original renderer symbol sizes: Hub Corral 27×27 px; Shared Mobility and Bike Rack 27×20 px.
+// prettier-ignore
+const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
+
+// prettier-ignore
+const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
+
+// prettier-ignore
+const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
+const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Bike_Lanes_view/FeatureServer';
+const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
+=======
+>>>>>>> 19e58deb (Updated with new source)
 const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
 // Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
 const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
+<<<<<<< HEAD
+=======
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
 
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     name: 'EV Charge Stations (Main + RELLIS)',
+<<<<<<< HEAD
     url: `${evLayersUrl}/0`
+=======
+<<<<<<< HEAD
+    url: evLayersUrl + '/0'
+=======
+    url: `${evLayersUrl}/0`
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
   },
   HUB_CORRALS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
@@ -48,7 +94,15 @@ export const SustainableTransportationDefinitions = {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
+<<<<<<< HEAD
     url: `${bikeLayersUrl}/0`
+=======
+<<<<<<< HEAD
+    url: bikeMapRackLayerUrl
+=======
+    url: `${bikeLayersUrl}/0`
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
@@ -84,14 +138,35 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.EV_CHARGERS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+    layerIndex: 13,
+>>>>>>> 19e58deb (Updated with new source)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.EV_ID}',
       description:
+<<<<<<< HEAD
+=======
+        '<strong>Network</strong>: {attributes.ev_network}<br />' +
+        '<strong>Charging Level</strong>: {attributes.ch_level}<br />' +
+        '<strong>Garage Level</strong>: {attributes.garage_lvl}<br />' +
+        '<strong>Notes</strong>: {attributes.evcs_notes}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.EV_ID}',
+      description:
+>>>>>>> 19e58deb (Updated with new source)
         '<strong>Network</strong>: {attributes.EV_Network}\n' +
         '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
         '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
         '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+<<<<<<< HEAD
+=======
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*']
@@ -104,12 +179,30 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.HUB_CORRALS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+    layerIndex: 12,
+>>>>>>> 19e58deb (Updated with new source)
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'Hub Corral',
+      description:
+<<<<<<< HEAD
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
+=======
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}<br />' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+=======
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Hub Corral',
       description:
         '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
         '<strong>Notes</strong>: {attributes.br_notes}'
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*'],
@@ -133,6 +226,11 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+    layerIndex: 11,
+>>>>>>> 19e58deb (Updated with new source)
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'Shared Mobility Racks',
@@ -168,6 +266,14 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       description:
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'Shared Mobility Racks',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
+>>>>>>> 6efc1291 (Updated with new source)
     },
     native: {
       outFields: ['*'],
@@ -191,10 +297,43 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Bike_Sta_Name}',
       description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+=======
+<<<<<<< HEAD
+    layerIndex: 9,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.bike_sta_name}',
+      description: '<strong>Amenities</strong>: {attributes.bike_amenities}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Bike_Sta_Name}',
+      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+    },
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_RACKS.id,
+    title: SustainableTransportationDefinitions.BIKE_RACKS.name,
+    url: SustainableTransportationDefinitions.BIKE_RACKS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*']
@@ -207,10 +346,26 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_LANES.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Use_}',
       description: '<strong>Location</strong>: {attributes.Location}'
+=======
+<<<<<<< HEAD
+    layerIndex: 8,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.use_}',
+      description:
+        '<strong>Street Type</strong>: {attributes.street_use}<br />' + '<strong>Location</strong>: {attributes.location}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Use_}',
+      description: '<strong>Location</strong>: {attributes.Location}'
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*']
@@ -223,10 +378,25 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Type}',
       description: '<strong>Location</strong>: {attributes.Loc}'
+=======
+<<<<<<< HEAD
+    layerIndex: 7,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.type}',
+      description: '<strong>Location</strong>: {attributes.loc}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description: '<strong>Location</strong>: {attributes.Loc}'
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*']
@@ -239,10 +409,25 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.url,
     visible: true,
     listMode: 'show',
+<<<<<<< HEAD
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: '{attributes.Name}',
       description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
+=======
+<<<<<<< HEAD
+    layerIndex: 0,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.name}',
+      description: '<strong>Notes</strong>: {attributes.bike_notes}'
+=======
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Name}',
+      description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
+>>>>>>> 6efc1291 (Updated with new source)
+>>>>>>> 19e58deb (Updated with new source)
     },
     native: {
       outFields: ['*']

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -7,8 +8,7 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
-  EV_CHARGERS_MAIN = 'sustainable-transportation-ev-chargers-main',
-  EV_CHARGERS_RELLIS = 'sustainable-transportation-ev-chargers-rellis',
+  EV_CHARGERS = 'sustainable-transportation-ev-chargers',
   HUB_CORRALS = 'sustainable-transportation-hub-corrals',
   SHARED_MOBILITY_RACKS = 'sustainable-transportation-shared-mobility-racks',
   BIKE_RACKS = 'sustainable-transportation-bike-racks',
@@ -18,29 +18,17 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
-// Temporary bridge until the original TS server/editor workflow is restored.
-// When that server is ready again, swap these URLs and the layer-id mapping in `SustainableTransportationDefinitions`
-// back to the restored source services.
-// These hosted view services mirror the secured Portal source layers while remaining queryable by the public app.
-const evMainLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_MC_view/FeatureServer';
-const evRellisLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/EV_Charge_Stations_Rellis/FeatureServer';
+const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
+const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+// Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
 const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
-const fixStationLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Fix_Stations_view/FeatureServer';
-const bikeLaneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Bike_Lanes_view/FeatureServer';
-const dismountZoneLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Dismount_Zones_view/FeatureServer';
 
 export const SustainableTransportationDefinitions = {
-  EV_CHARGERS_MAIN: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_MAIN,
-    name: 'EV Charge Stations (Main Campus)',
-    url: `${evMainLayersUrl}/0`
-  },
-  EV_CHARGERS_RELLIS: {
-    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
-    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS_RELLIS,
-    name: 'EV Charge Stations (RELLIS)',
-    url: `${evRellisLayersUrl}/0`
+  EV_CHARGERS: {
+    id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+    name: 'EV Charge Stations (Main + RELLIS)',
+    url: `${evLayersUrl}/0`
   },
   HUB_CORRALS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
@@ -58,54 +46,51 @@ export const SustainableTransportationDefinitions = {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
-    url: `${rackLayersUrl}/2`
+    url: `${bikeLayersUrl}/0`
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     name: 'Bike Fix Stations',
-    url: `${fixStationLayersUrl}/0`
+    url: `${bikeLayersUrl}/1`
   },
   BIKE_LANES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
     name: 'Bike Lanes',
-    url: `${bikeLaneLayersUrl}/2`
+    url: `${bikeLayersUrl}/2`
   },
   CITY_BIKE_LANES_ROUTES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     name: 'City Bike Lanes and Routes',
-    url: `${bikeLaneLayersUrl}/1`
+    url: `${bikeLayersUrl}/3`
   },
   BIKE_DISMOUNT_ZONES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
     name: 'Bike Dismount Zones',
-    url: `${dismountZoneLayersUrl}/0`
+    url: `${bikeLayersUrl}/4`
   }
 };
 
 export const SustainableTransportationColdLayerSources: LayerSource[] = [
-  // Keep this source list aligned with the temporary URL/layer mapping above until the original services are restored.
   {
     type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS_MAIN.url,
+    id: SustainableTransportationDefinitions.EV_CHARGERS.id,
+    title: SustainableTransportationDefinitions.EV_CHARGERS.name,
+    url: SustainableTransportationDefinitions.EV_CHARGERS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS_RELLIS.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.EV_ID}',
+      description:
+        '<strong>Network</strong>: {attributes.EV_Network}\n' +
+        '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+        '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+        '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -117,6 +102,13 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.HUB_CORRALS.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'Hub Corral',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -128,17 +120,13 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.SHARED_MOBILITY_RACKS.url,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.BIKE_RACKS.id,
-    title: SustainableTransportationDefinitions.BIKE_RACKS.name,
-    url: SustainableTransportationDefinitions.BIKE_RACKS.url,
-    visible: true,
-    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'Shared Mobility Racks',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -150,6 +138,29 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Bike_Sta_Name}',
+      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
+    },
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_RACKS.id,
+    title: SustainableTransportationDefinitions.BIKE_RACKS.name,
+    url: SustainableTransportationDefinitions.BIKE_RACKS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description:
+        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
+        '<strong>Notes</strong>: {attributes.BR_Notes}'
+    },
     native: {
       outFields: ['*']
     }
@@ -161,6 +172,11 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_LANES.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Use_}',
+      description: '<strong>Location</strong>: {attributes.Location}'
+    },
     native: {
       outFields: ['*']
     }
@@ -172,6 +188,11 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.CITY_BIKE_LANES_ROUTES.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Type}',
+      description: '<strong>Location</strong>: {attributes.Loc}'
+    },
     native: {
       outFields: ['*']
     }
@@ -183,6 +204,11 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     url: SustainableTransportationDefinitions.BIKE_DISMOUNT_ZONES.url,
     visible: true,
     listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Name}',
+      description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
+    },
     native: {
       outFields: ['*']
     }

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -15,24 +15,13 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_FIX_STATIONS = 'sustainable-transportation-bike-fix-stations',
   BIKE_LANES = 'sustainable-transportation-bike-lanes',
   CITY_BIKE_LANES_ROUTES = 'sustainable-transportation-city-bike-lanes-routes',
-  BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones'
+  BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
 const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
-
-// Keep the rack layers pointed at the BikeMap service so all three rack types use the same source schema.
-const bikeMapRackLayerUrl = `${bikeLayersUrl}/0`;
-
-// Base64-encoded PNG symbols sourced from the BikeMap layer 0 renderer imageData.
-// prettier-ignore
-const HUB_CORRAL_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAkCAYAAADhAJiYAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADK0lEQVRYheWXz0sVURTHPxfepsxFEGRC4DYiwSAqrVUJWhllkf2ACGpZEEbQwsjQRRD2P1hIGqULn/rCZa9ChAIr2haBtShcFAUSnDjOGbjcfPOGUWKwA8N7c+bec79zfn3PFMiZFMiZFMiZFFiLgAQm9NfB4VwAAnb/vyET2AJ8c7AY6DcArUAjUGO6W8AcMO3gR7Bez6p1sJAZkMBG4BPwQuCQHiLQAPQA54AvwKy3ZTtwAagTGAL6HHw08JNAs8BWB5+zeui7ggH2q0GBEeAOUARaHLwy4F/118Epu98JXAfeCtwATgP7gGfq7cwecvBbPQOUDJRenQ7GquxToGcEjgOjpi4TeXkxMyAVC9ND9ciSArplmRwJxcLU7amGq+1Jm9QNFqZO4Jq5viTQVukAgVpgyl5CPXMPuC9Q1JxaESDgJjCuYVLPWPhaDFS7i/IsBKNrmoHnRGvUy0WzdSkzIImMazXt1Xsz3B6A6gfW2fp2q8BmK4YlMGburgIUuJoUumoeagXmHbyOFeoRDRfw1A7Wco4l/q9g2nzvaaJL1CbU5lhWQI1Bn/FB9QVgfOkPQ2kyazbTAzKijLmpxu8zgaxPeJHHAr+W0au9DoErdj8TEnL+ucx5iAV6gW0OusJ1lsCVQnbSRWUf7nkEvHNwOzWgQOaA8xWqT6upkvQIlJfJo11ETZasgKaBeoGmuNKCPqPVpGX/xNafsF6jz6b85mn8Vmc2swFyUTUNGVGeNTqY8sAslbbAT1uvIMpBn4pBqY2havSRJqn7gDcCx4w6WrwO/Fdpe30qpg4FqdRxBNhR7bA05PrBRoi4d5SDDkwCqJJxn16X1daKAUkUJp1nYhlIw9pGMwPelNAlMLiikEn0fNLeUD0zDDwQGFdu8ikl2NdkOdOhntHZyBvyDibNRNU8VAvssUkvHmEnrJJeCswbHcQdfcRKu14TWHPGQj5oOaXPNik/ZgLkYEFgs46yOj2aTvPgorK2N+QftS3viUBNB8SqL3JAwbgEMGk8RKWvBDtQx9NRicKiut4EOxqmRDCpAP1rWS1AM7kC5Fbhm37Nh2zVJHeA/gB6+wK1LYH5oAAAAABJRU5ErkJggg==';
-
-// prettier-ignore
-const SHARED_MOBILITY_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEuUlEQVRIidWXf2hVZRjHP+855+7+2HbdD7e51Jm6sjm1wlEU5EApMiojMIJEiqJCqkUlWCRC/RMUJNZ/BRX2R4hFBeUfWQSjWVS0ouksc9O5zemd8+7X3b3nnPvG894fujHvlSzSL7z33Pu+zz3P9zzP93ne9zhcZnC4zOBwRRDSHVXASkjPA1UCar4FjQplZQ0cG1WqIKDRMuGlwdfg+jBpwZRCRTQ6nV1zyXwXYw90P/h7Ua19xQnpjjst+CyK5c8j5IZQBLCcKHY4gq1swEKhgDQZOjlPMueaOW0s5HeCtBkxXAZIMWmsZcV5At21CtWcKkioHHsb6JJeWpiDHeZfxhk8PuQ0bfQsg5GbgfaChBR62d1UCplLdp6L2vmowuEp6nmBXs+FFUUJTaGrlhO5oBMfzXeMcTVBPDQBFAsJTrNZxi8cMYkCG8WT1PE2S/LrIsQqHHeI1LnJWQlprVw6SioKFN9XxFnPwfzvRQTpZfU0m8+5zlwnSLOW35ntAStwrCG8hsKEOBCSMFcWILSaUh6mlg84xWPU8Qi1fMoZOpkggkUUmygOfSR5gwG2sYAtzJuNUAB0fRFCVkCSUkg/NQR4j0Ym8HmXIfYxwipKqSNAEIthXPYybPRTjcPzXDXrfcqxLIWq1oUJJSwoIWmyfw5J0saJaGcIl0FSfM+YKf9GwnxBk7Ebw2cD3WymlhZKeZoeyvmBJsLsYjG3Ec3fM2CUpGfymUmoXIt7yX0OfSRZRxd/MmUEKiKeyq5vpJo9xPiIGHdRyR0cZAURE602eoyNxFrSuZ5D/Mb1LCFk5qUgQPlFCElHzUQkh60c4whTvEIDm5hLM53cTzVLCZmUraOC5+hlJ4MmQvdQyX10s4EqjpPkceoYJ81WetnFIDtZnMlFpq0WIaRaJh3d4XvovIh+ZtzoYDsLeJFj5kYnSHKQSUbw+Ilxcx0ixQFW8RaD1BLgHZaykcP0k+JVGnidftoZzbsalR3EbCOFI0QYa8yXIsiiEodW5piYfckIrUSZTwkxPLpJGOGWYfMgc7mJMg6TYDEhI/41RKmnhLN4Jnqnz/MfN1sfUxdByI4lSecJtRI1T307c/iVG/J2WzhquvB+mk0vykHK/mvivMmASbOkTSIlkZXIzSAUL0rIATcnWsEz1LOSTpropI16I9KPOcO3xHmUumlkBNJzhJDoagd9JjI5bKYm3+1H8aTMYkUJ+ehSEWEOCwmyj+WspYtns5VTis3LLGAHC2f+3Qh+N9fwEsdNhQqkP4kG5eEEp3BzHvqLEvLQwZNMOxFwC+Uc4ka6mDQpaaFMtMaFsIkaHqLGEBJRN2Y1lcPJTDFLHzpRlJCLTkiZS9pC5zmVzVTGxUL01UDQjJkQkWetjhYlNIq3u53R7XX8aCJzLWFzZJBqkqYooZYOIgexFNo0y7k4Jo1ymJP0iJ08jGzSsr8N45nWIGehP0jwPqdy7v4qSghCr9mkmiZI37ufuPqGuOeiQ7McbS4R6hPUrRdBSLVM+rIrZOHLh95jw6IK8MrAUuCnIe2Cn8hsN74DnhRgGKwIeBFQEUyDtVPgnQUnVykB8GKoNYP//K1DPSC8hrPjP8UV8hrE/4e/AQQPo7YUUL0rAAAAAElFTkSuQmCC';
-
-// prettier-ignore
-const BIKE_RACK_SYMBOL_DATA = 'iVBORw0KGgoAAAANSUhEUgAAACQAAAAbCAYAAAAULC3gAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAEx0lEQVRIidWXe2xURRTGf3P30d3tg754BUGkhKZSiBGCiAGMKIpRUUyjBmI0EjBE5aEYMCJEEwPRKAE1Chgx+IfRitiI/UNEsTESxQgYRQoiWiqFFvvebrv33jHnzq7bNrBLRCN8m9n7mjvzzTnfOWeun4sMfi4y+LkkCC3VhcA4XIagCKIYZsFoZWF5z138PotspQhoDShsV+NoTdzRRC1FTCki2sVFY7uKuPeW9n42FvUoKnlJ1WUmtFTfYsFHeVk4Q/KIhwIQ8OHPCxGOBFA+CywFSoHrgvBxNQgxuRd3UucK6Iqb1tQJf7RBtAfzkmYha/R41qietIRys1iBJnh8NQwIEeZfxp9ReGcfLP6QUlq5BqhJS0hB6W1jPTIXjKSleqMwAo9MhSeqsOMO5RkJxWwKrxxy7kkcF776FUYWgu167mR4ft8+pc/D0SbjSnHxw1PglbtTz8XlhWHipzoY1X/8foS0ijsE89M46tNamPVG6vryAjj+TN8+VfPNsbMHbngVzrbA/AjWqQ5GpCe0lJCYuSBybkITLoMHJsHb38L8yfDgJNjxA+yvh0gQ8kKm1TXDi5/Dihth0XVnIRQmAAxNT8gmgC+9fgbmwFv3mdVv2QvVh2D8UBicC1l+OBOFygNGP0XZ8Pj1Zx8nNwtLKYp0WkI+k2e67b6dum0ziWjnVDucbIO9vxktjC6GnQtMv/ZumL0F7p8IE4fDo9shdwWUDYYNc2BqL8WI9hIJIA2hLDTdZvVJ1LXAjNfgSKMRaMDyhO+h4ip4bz+8+z3cWgYzX4dysVaOF9ZmjZZxp+ju4JMwqijhDNej46Qn1EycSF8LLa8yEfPsLJg3AcaugznjoaTYuGzGGFi2A9bvMRa6fSzc+SbMLoffm2HBFOjoNuNs+BLW32XGlWSpMxLapKL+ZdqxXVGSwXd1RgerZsLKj81AJ1rgpwZojsK+OnMUV369BDbWwKAc2HwPVGyF+lZ4bha8sBtqjqWmaouZkpOeEBAO0O64/J1ZCiIwvcTklE8OmfNhA0wp+Pk0FEUgJwj3Xg2TRsDh03BFkRH/tBIYmgctXcZ6jR2peVpjnn5imQkFaeq2U4Sml5hV31QKB5an+i2qBFULuxaZXJSEhPxntfDyHuNmcZtYSiw7KLcXoS40itaMhPyKeFK0gsemwbh1ULYWFk8Dn4IPDsIXR+GhyX3JCCTnCCHR1epqY5kkJPqS2b4thoWmKSMhR5MtIkxieD5ULzQZd0kicrKD8PRMWH1z/7eN4LfNhad2mggVSH4SDcriBKc7jASA+oyEbIeshra+964dCYdWwo8NxiWSY8KSZ8+BeRNh7gRDSEQtuUo0lURDe+JEcSIjobhLl4S5uC3U66kUU2nnC6nyIwpM6w8ReQLHMhJqi7Gt5hirBq8ylhkz0GwZpAxIdhVTy8Ys7kKPbRJfcbZxo2zmxD3STxYjRVrq25lOkxpkL1TbCFu/SUxm80tGQkRZ68umrLOHO3YdRu0+4u1bpLr129lcMLazUZ0HoU0q6kBF8tKRvwrtYxD5hMjBQaFxMfvkLq/cdOAnjA9NGIcILhF8RND4cOlB00IQKRaysw540bVenfznXx3vK+F1JtH+U1win0H8f/gLDTWztGgTS7YAAAAASUVORK5CYII=';
+// Hub Corrals and Shared Mobility Racks are not yet in BikeMap; keeping on hosted service until available.
+const rackLayersUrl = 'https://arc.ts.tamu.edu/arcgis/rest/services/Hosted/Rack_Locations_view/FeatureServer';
 
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
@@ -45,13 +34,13 @@ export const SustainableTransportationDefinitions = {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.HUB_CORRALS,
     name: 'Hub Corral',
-    url: bikeMapRackLayerUrl
+    url: `${rackLayersUrl}/0`
   },
   SHARED_MOBILITY_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.SHARED_MOBILITY_RACKS,
     name: 'Shared Mobility Racks',
-    url: bikeMapRackLayerUrl
+    url: `${rackLayersUrl}/1`
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
@@ -117,22 +106,11 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     popupData: {
       name: 'Hub Corral',
       description:
-        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-        '<strong>Notes</strong>: {attributes.BR_Notes}'
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
     },
     native: {
-      outFields: ['*'],
-      definitionExpression: "Type = 'Shared Mobility (Hub Corral)'",
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'picture-marker',
-          url: `data:image/png;base64,${HUB_CORRAL_SYMBOL_DATA}`,
-          // Original renderer symbol size: 27×27 px
-          width: 30,
-          height: 30
-        }
-      }
+      outFields: ['*']
     }
   },
   {
@@ -144,24 +122,13 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
     listMode: 'show',
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: '{attributes.Type}',
+      name: 'Shared Mobility Racks',
       description:
-        '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
-        '<strong>Notes</strong>: {attributes.BR_Notes}'
+        '<strong>Total Capacity</strong>: {attributes.total_capacity}\n' +
+        '<strong>Notes</strong>: {attributes.br_notes}'
     },
     native: {
-      outFields: ['*'],
-      definitionExpression: "Type = 'Shared Mobility HP'",
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'picture-marker',
-          url: `data:image/png;base64,${SHARED_MOBILITY_SYMBOL_DATA}`,
-          // Original renderer symbol size: 27×20 px
-          width: 30,
-          height: 22.5
-        }
-      }
+      outFields: ['*']
     }
   },
   {
@@ -179,18 +146,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Notes</strong>: {attributes.BR_Notes}'
     },
     native: {
-      outFields: ['*'],
-      definitionExpression: "Type NOT IN ('Shared Mobility (Hub Corral)', 'Shared Mobility HP')",
-      renderer: {
-        type: 'simple',
-        symbol: {
-          type: 'picture-marker',
-          url: `data:image/png;base64,${BIKE_RACK_SYMBOL_DATA}`,
-          // Original renderer symbol size: 27×20 px
-          width: 30,
-          height: 22.5
-        }
-      }
+      outFields: ['*']
     }
   },
   {
@@ -264,7 +220,8 @@ export const SustainableTransportationConfiguration: EventConfiguration = {
   name: 'Sustainable Transportation',
   applicationName: 'Sustainable Transportation Map',
   shortApplicationName: 'Sustainable Transportation',
-  introductionText: 'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
+  introductionText:
+    'Explore bike amenities and EV charge stations across Main Campus and the RELLIS Campus in one map.',
   mapCenter: [-96.34643, 30.61313],
   eventDates: [],
   zoom: 15

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -292,6 +292,7 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   },
   {
     type: 'feature',
+<<<<<<< HEAD
     id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
     title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
     url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
@@ -321,6 +322,8 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   },
   {
     type: 'feature',
+=======
+>>>>>>> ca7e13e0 (Put bike fix stations back where they should go)
     id: SustainableTransportationDefinitions.BIKE_RACKS.id,
     title: SustainableTransportationDefinitions.BIKE_RACKS.name,
     url: SustainableTransportationDefinitions.BIKE_RACKS.url,
@@ -334,6 +337,22 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
         '<strong>Notes</strong>: {attributes.BR_Notes}'
 >>>>>>> 6efc1291 (Updated with new source)
 >>>>>>> 19e58deb (Updated with new source)
+    },
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
+    title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
+    url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Bike_Sta_Name}',
+      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
     },
     native: {
       outFields: ['*']

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -133,22 +133,6 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
   },
   {
     type: 'feature',
-    id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
-    title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
-    url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
-    visible: true,
-    listMode: 'show',
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.Bike_Sta_Name}',
-      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
-    },
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
     id: SustainableTransportationDefinitions.BIKE_RACKS.id,
     title: SustainableTransportationDefinitions.BIKE_RACKS.name,
     url: SustainableTransportationDefinitions.BIKE_RACKS.url,
@@ -160,6 +144,22 @@ export const SustainableTransportationColdLayerSources: LayerSource[] = [
       description:
         '<strong>Total Capacity</strong>: {attributes.Total_Capacity}\n' +
         '<strong>Notes</strong>: {attributes.BR_Notes}'
+    },
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.id,
+    title: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.name,
+    url: SustainableTransportationDefinitions.BIKE_FIX_STATIONS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.Bike_Sta_Name}',
+      description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
     },
     native: {
       outFields: ['*']


### PR DESCRIPTION
This PR updates Sustainable Transportation (standalone map + layers on the main map) to this new URL for the data layers: https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer

## Standalone map:
<img width="3054" height="1931" alt="Screenshot 2026-04-10 090405" src="https://github.com/user-attachments/assets/08386b45-0239-4a85-a04f-e0e9cbfa3da8" />

## Main map with sustainable transporation layers on
<img width="3275" height="1955" alt="image" src="https://github.com/user-attachments/assets/841c1b79-b9aa-4710-a69a-f5db93349af9" />

## Popups working on both:

<img width="3064" height="1876" alt="image" src="https://github.com/user-attachments/assets/a3d34671-55c4-4bc1-85fb-eebca3d71c4c" />


Closes #685 