### PR TITLE
feat(aggiemap-angular): New special Construction Map +  new tab called Operations Maps

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.html
@@ -163,6 +163,31 @@
             </div>
           </ng-template>
         </div>
+
+        <div *ngIf="activeTab === 'operations'" class="tab-section discover-tab-panel" role="tabpanel" id="discover-panel-operations" aria-labelledby="discover-tab-operations">
+          <h2>Operations Maps</h2>
+          <p class="section-description">Browse operations-focused maps for campus construction and future internal-use overlays.</p>
+
+          <div class="map-columns" *ngIf="operationsColumns[0].length + operationsColumns[1].length > 0; else noOperationsMaps">
+            <ol class="map-links">
+              <li class="map-link-item" *ngFor="let app of operationsColumns[0]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
+
+            <ol class="map-links" *ngIf="operationsColumns[1].length > 0" [attr.start]="operationsColumnStart">
+              <li class="map-link-item" *ngFor="let app of operationsColumns[1]">
+                <a class="map-link" [routerLink]="getApplicationRoute(app)">{{ app.name }}</a>
+              </li>
+            </ol>
+          </div>
+
+          <ng-template #noOperationsMaps>
+            <div class="empty-state">
+              <p>No operations maps are available right now.</p>
+            </div>
+          </ng-template>
+        </div>
       </div>
 
       <div class="all-events-section trailer-3" *ngIf="(isDev | async) === true">

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.scss
@@ -177,7 +177,7 @@
 
 .discover-tabs {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
   border-bottom: 1px solid #e1e1e1;
 }

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
@@ -19,7 +19,8 @@ describe('DiscoverComponent', () => {
   const internalApplications: InternalDiscoverApplication[] = [
     createInternalApplication('accessible-parking', 'Accessible Parking', 'parking', 'parking', '2000-04-12'),
     createInternalApplication('move-in', 'Move In', 'campus', 'event', '2099-03-29'),
-    createInternalApplication('football-parking', 'Football Parking', 'athletics', 'event', '2099-09-05')
+    createInternalApplication('football-parking', 'Football Parking', 'athletics', 'event', '2099-09-05'),
+    createInternalApplication('construction-map', 'Construction Map', 'operations', 'parking', '2000-04-12')
   ];
 
   beforeEach(async () => {
@@ -64,18 +65,19 @@ describe('DiscoverComponent', () => {
     expect(tabButtons.map((button) => button.textContent?.trim())).toEqual([
       'Parking Maps',
       'Campus Events',
-      'Athletic Events'
+      'Athletic Events',
+      'Operations Maps'
     ]);
     expect(component.activeTab).toBe('parking');
     expect(getPanelHeading()).toBe('Parking Maps');
     expect(getPanelText()).toContain('Accessible Parking');
 
-    tabButtons[1].click();
+    tabButtons[3].click();
     fixture.detectChanges();
 
-    expect(component.activeTab).toBe('campus');
-    expect(getPanelHeading()).toBe('Campus Events');
-    expect(getPanelText()).toContain('Move In');
+    expect(component.activeTab).toBe('operations');
+    expect(getPanelHeading()).toBe('Operations Maps');
+    expect(getPanelText()).toContain('Construction Map');
     expect(getPanelText()).not.toContain('Accessible Parking');
     expect(window.location.hash).toBe('#discover-tab-campus');
   });

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -28,7 +28,8 @@ export class DiscoverComponent implements OnInit, OnDestroy {
   public readonly discoverTabs: ReadonlyArray<DiscoverTab> = [
     { id: 'parking', label: 'Parking Maps' },
     { id: 'campus', label: 'Campus Events' },
-    { id: 'athletics', label: 'Athletic Events' }
+    { id: 'athletics', label: 'Athletic Events' },
+    { id: 'operations', label: 'Operations Maps' }
   ];
 
   public activeTab: DiscoverMapType = 'parking';
@@ -47,6 +48,9 @@ export class DiscoverComponent implements OnInit, OnDestroy {
 
   public athleticColumns: InternalDiscoverApplication[][] = [[], []];
   public athleticColumnStart = 1;
+
+  public operationsColumns: InternalDiscoverApplication[][] = [[], []];
+  public operationsColumnStart = 1;
 
   public allEventsColumns: InternalDiscoverApplication[][] = [[], []];
   public allEventsColumnStart = 1;
@@ -91,6 +95,10 @@ export class DiscoverComponent implements OnInit, OnDestroy {
     this.athleticColumns = this.buildApplicationColumns(upcomingAthletic);
     this.athleticColumnStart = this.getSecondColumnStart(this.athleticColumns);
 
+    const operationsApplications = this.getApplicationsByMapType('operations');
+    this.operationsColumns = this.buildApplicationColumns(operationsApplications);
+    this.operationsColumnStart = this.getSecondColumnStart(this.operationsColumns);
+
     const allEvents = this.sortEventApplications([...campusApplications, ...athleticApplications]);
     this.allEventsColumns = this.buildApplicationColumns(allEvents);
     this.allEventsColumnStart = this.getSecondColumnStart(this.allEventsColumns);
@@ -122,9 +130,7 @@ export class DiscoverComponent implements OnInit, OnDestroy {
         earliestUpcomingDate: this.getEarliestUpcomingDate(app.configuration.eventDates, now)
       }))
       .filter(({ earliestUpcomingDate }) => earliestUpcomingDate !== Number.POSITIVE_INFINITY)
-      .sort(
-        (a, b) => a.earliestUpcomingDate - b.earliestUpcomingDate || a.app.name.localeCompare(b.app.name)
-      )
+      .sort((a, b) => a.earliestUpcomingDate - b.earliestUpcomingDate || a.app.name.localeCompare(b.app.name))
       .slice(0, 3)
       .map(({ app }) => app);
   }

--- a/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.spec.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.spec.ts
@@ -36,4 +36,11 @@ describe('DiscoveryService', () => {
     expect(football?.mapType).toBe('athletics');
     expect(moveIn?.mapType).toBe('campus');
   });
+
+  it('supports explicit discover tab overrides for operations maps', () => {
+    const applications = service.getInternalDiscoverApplications();
+    const constructionMap = applications.find((app) => app.id === 'construction-map');
+
+    expect(constructionMap?.mapType).toBe('operations');
+  });
 });

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -53,6 +53,7 @@ import { SustainableTransportationTs } from './sustainable-transportation.defini
 import { EvChargersTs } from './ev-chargers.definitions';
 import { TsMainParkingTs } from './main-parking.definitions';
 import { SecGroundsConferenceTs } from './sec-grounds-conference.definitions';
+import { ConstructionMapTs } from './construction-map.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -108,5 +109,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   SustainableTransportationTs,
   EvChargersTs,
   TsMainParkingTs,
-  SecGroundsConferenceTs
+  SecGroundsConferenceTs,
+  ConstructionMapTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/construction-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/construction-map.definitions.ts
@@ -1,0 +1,232 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
+
+import esri = __esri;
+
+export enum CONSTRUCTION_MAP_LAYERS {
+  CONSTRUCTION_DRAW = 'construction-map-draw',
+  CURRENT_CONSTRUCTION_AREA = 'current-construction-area',
+  PLANNED_CONSTRUCTION_AREA = 'planned-construction-area',
+  CONSTRUCTION_POPUP = 'construction-map-popup',
+  PLANNED_CONSTRUCTION_POPUP = 'planned-construction-map-popup'
+}
+
+/**
+ * Two ArcGIS services back this map:
+ *
+ *   eventUrl (TSConstruction/MapServer)
+ *     Sublayer 0 (current) and sublayer 1 (planned). Drives the MapImageLayer that
+ *     produces the visible cross-hatched fills, and the two visible FeatureLayers
+ *     that drive the legend swatches.
+ *     Sublayer 1 field schema: Name, Number, StartDate, EndDate, Owner (no Description).
+ *
+ *   popupEventUrl (FCOR/Construction_2018/MapServer)
+ *     Legacy 2018 service used solely as the popup data source for current construction.
+ *     Sublayer 0 exposes a Description field, which TSConstruction sublayer 0 does not.
+ */
+const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TSConstruction/MapServer';
+const popupEventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/FCOR/Construction_2018/MapServer';
+
+/**
+ * 'cumulative' lets the popup service resolve each entry sequentially, writing each resolved
+ * value back into `attributes` so later template strings like `{attributes.projectName}` can
+ * reference the aliased values.
+ */
+const popupDataResolutionStrategy: NonNullable<LayerSource['popupDataResolutionStrategy']> = 'cumulative';
+
+const plannedConstructionPopupData: NonNullable<LayerSource['popupData']> = {
+  projectName: { field: 'Name', collapsed: true },
+  projectNumber: { field: 'Number', collapsed: true },
+  startDate: { field: 'StartDate', collapsed: true },
+  endDate: { field: 'EndDate', collapsed: true },
+  owner: { field: 'Owner', collapsed: true },
+
+  name: '{attributes.projectName}',
+  description:
+    `<strong>Project Name:</strong> {attributes.projectName}<br>` +
+    `<strong>Project No:</strong> {attributes.projectNumber}<br>` +
+    `<strong>Start Date:</strong> {attributes.startDate}<br>` +
+    `<strong>End Date:</strong> {attributes.endDate}<br><br>` +
+    `<hr>` +
+    `<strong>Note:</strong> {attributes.owner}`
+};
+
+const constructionPopupData: NonNullable<LayerSource['popupData']> = {
+  projectName: { field: 'Name', collapsed: true },
+  projectNumber: { field: 'Number', collapsed: true },
+  projectDescription: { field: 'Description', collapsed: true },
+  startDate: { field: 'StartDate', collapsed: true },
+  endDate: { field: 'EndDate', collapsed: true },
+  owner: { field: 'Owner', collapsed: true },
+
+  name: '{attributes.projectName}',
+  description:
+    `<strong>Project Name:</strong> {attributes.projectName}<br>` +
+    `<strong>Project No:</strong> {attributes.projectNumber}<br>` +
+    `<strong>Project Description:</strong> {attributes.projectDescription}<br><br>` +
+    `<strong>Start Date:</strong> {attributes.startDate}<br>` +
+    `<strong>End Date:</strong> {attributes.endDate}<br><br>` +
+    `<hr>` +
+    `<strong>Note:</strong> {attributes.owner}`
+};
+
+export const ConstructionMapDefinitions = {
+  CONSTRUCTION_DRAW: {
+    id: CONSTRUCTION_MAP_LAYERS.CONSTRUCTION_DRAW,
+    name: 'Construction Map Draw',
+    url: eventUrl
+  },
+  CURRENT_CONSTRUCTION_AREA: {
+    id: CONSTRUCTION_MAP_LAYERS.CURRENT_CONSTRUCTION_AREA,
+    name: 'Current Construction Area',
+    url: `${eventUrl}/0`
+  },
+  PLANNED_CONSTRUCTION_AREA: {
+    id: CONSTRUCTION_MAP_LAYERS.PLANNED_CONSTRUCTION_AREA,
+    name: 'Planned Construction Area',
+    url: `${eventUrl}/1`
+  },
+  CONSTRUCTION_POPUP: {
+    id: CONSTRUCTION_MAP_LAYERS.CONSTRUCTION_POPUP,
+    name: 'Construction Area',
+    url: `${popupEventUrl}/0`
+  },
+  PLANNED_CONSTRUCTION_POPUP: {
+    id: CONSTRUCTION_MAP_LAYERS.PLANNED_CONSTRUCTION_POPUP,
+    name: 'Planned Construction Area Popup',
+    url: `${eventUrl}/1`
+  }
+};
+
+/**
+ * Layer architecture:
+ *
+ *   Two FeatureLayers drive the legend (one per area). The MapImageLayer above them
+ *   covers their default rendering with server-side cross-hatched fills, but the
+ *   FeatureLayers' renderers still populate the legend panel.
+ *
+ *   Two more invisible FeatureLayers (opacity 0) sit above the MapImageLayer purely
+ *   to intercept popup clicks. They are added last so they end up at the top of the
+ *   layers collection — ESRI's Map.add() clamps high `layerIndex` values to the
+ *   current collection size, so relying on `layerIndex` alone is not enough to
+ *   guarantee a layer ends up on top. Order of insertion is what determines the
+ *   final z-position.
+ *
+ *   Current construction uses the legacy 2018 service for its popup layer because
+ *   it is the only source that exposes the Description field.
+ */
+export const ConstructionMapColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_AREA.id,
+    title: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_AREA.name,
+    url: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_AREA.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: ConstructionMapDefinitions.CURRENT_CONSTRUCTION_AREA.id,
+    title: ConstructionMapDefinitions.CURRENT_CONSTRUCTION_AREA.name,
+    url: ConstructionMapDefinitions.CURRENT_CONSTRUCTION_AREA.url,
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'map-image',
+    id: ConstructionMapDefinitions.CONSTRUCTION_DRAW.id,
+    title: ConstructionMapDefinitions.CONSTRUCTION_DRAW.name,
+    url: ConstructionMapDefinitions.CONSTRUCTION_DRAW.url,
+    visible: true,
+    listMode: 'hide',
+    native: {
+      sublayers: [
+        {
+          id: 1,
+          title: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_AREA.name,
+          visible: true,
+          popupEnabled: false
+        },
+        {
+          id: 0,
+          title: ConstructionMapDefinitions.CURRENT_CONSTRUCTION_AREA.name,
+          visible: true,
+          popupEnabled: false
+        }
+      ] as unknown as esri.SublayerProperties[]
+    }
+  },
+  {
+    type: 'feature',
+    id: ConstructionMapDefinitions.CONSTRUCTION_POPUP.id,
+    title: ConstructionMapDefinitions.CONSTRUCTION_POPUP.name,
+    url: ConstructionMapDefinitions.CONSTRUCTION_POPUP.url,
+    popupComponent: MarkdownPopupComponent,
+    popupData: constructionPopupData,
+    popupDataResolutionStrategy,
+    visible: true,
+    listMode: 'hide',
+    native: {
+      opacity: 0,
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_POPUP.id,
+    title: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_POPUP.name,
+    url: ConstructionMapDefinitions.PLANNED_CONSTRUCTION_POPUP.url,
+    popupComponent: MarkdownPopupComponent,
+    popupData: plannedConstructionPopupData,
+    popupDataResolutionStrategy,
+    visible: true,
+    listMode: 'hide',
+    native: {
+      opacity: 0,
+      outFields: ['*']
+    }
+  }
+];
+
+export const ConstructionMapConfiguration: EventConfiguration = {
+  id: 'construction-map',
+  name: 'Construction Map',
+  applicationName: 'Construction Map',
+  shortApplicationName: 'Construction Map',
+  introductionText: 'Current and planned campus construction projects.',
+  eventDates: [],
+  mapCenter: [-96.33799, 30.60974],
+  zoom: 16
+};
+
+export const ConstructionMapOptions: SpecialEventOptions = [];
+
+export const ConstructionMapTs: AggiemapCustomMapConfiguration = {
+  type: 'general-map',
+  configuration: ConstructionMapConfiguration,
+  options: ConstructionMapOptions,
+  sources: ConstructionMapColdLayerSources,
+  references: CONSTRUCTION_MAP_LAYERS,
+  discover: {
+    id: ConstructionMapConfiguration.id,
+    name: ConstructionMapConfiguration.name,
+    description: 'Current and planned campus construction projects.',
+    source: 'internal',
+    type: 'parking',
+    mapType: 'operations',
+    keywords: ['construction', 'planned', 'current', 'operations', 'projects']
+  }
+};

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -318,7 +318,7 @@ export type AggiemapCustomMapConfiguration = ISpecialEventRoot | IGeneralMapRoot
 /**
  * High-level discover grouping used by the tabbed Discover page UI.
  */
-export type DiscoverMapType = 'parking' | 'campus' | 'athletics';
+export type DiscoverMapType = 'parking' | 'campus' | 'athletics' | 'operations';
 
 /**
  * Metadata used to represent a map in the Discover application.


### PR DESCRIPTION
This PR adds a separate tab for Operational Maps and adds the new Construction map.

<img width="2531" height="1589" alt="Screenshot 2026-05-28 084929" src="https://github.com/user-attachments/assets/cc77a1ca-88fb-41f7-8cab-ef24b76c6b09" />
<img width="3291" height="1990" alt="image" src="https://github.com/user-attachments/assets/7695b66c-d023-4844-9a2c-7c7957b28ded" />


### Known issues:
- Popups do not currently appear for Planned Construction Area layers
- Code is honestly just a mess in general

Closes #719 