### PR TITLE
fix(aggiemap-angular): Update names on AggieMap About section

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/about/components/about.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/about/components/about.component.html
@@ -49,6 +49,11 @@
           <div class="name">Edgar Hernandez</div>
           <div class="title">GIS Systems Coordinator I</div>
         </div>
+
+        <div class="profile">
+          <div class="name">Slone Early</div>
+          <div class="title">GIS Student Technician</div>
+        </div>
       </div>
 
       <h3>Facilities Analytics and Mapping</h3>
@@ -61,7 +66,7 @@
 
         <div class="profile">
           <div class="name">Rusty Carter</div>
-          <div class="title">Assistant Director</div>
+          <div class="title">Associate Director</div>
         </div>
       </div>
 
@@ -71,6 +76,11 @@
         <div class="profile">
           <div class="name">Eric Irwin</div>
           <div class="title">GIS Manager</div>
+        </div>
+
+        <div class="profile">
+          <div class="name">Megan McMullen</div>
+          <div class="title">GIS Specialist I</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR updates the names and job titles on the About section on Aggiemap.

<img width="2249" height="1711" alt="image" src="https://github.com/user-attachments/assets/0a86a828-58cb-4aae-912d-f9fbb37b4345" />

Closes #720 