### PR TITLE
fix(aggiemap-angular): Update Family Friendly Bathrooms to Single Occupancy Restrooms

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions.ts
@@ -99,10 +99,10 @@ export function Definitions(Connections: IComposedConnections): IComposedIDefini
       url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/TAMUPrinters/FeatureServer/0',
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     },
-    FAMILY_FRIENDLY_BATHROOMS: {
-      id: 'family-friendly-bathrooms-locations',
-      layerId: 'family-friendly-bathrooms-locations-layer',
-      name: 'Family Friendly Restroom Locations',
+    SINGLE_OCCUPANCY_RESTROOMS: {
+      id: 'single-occupancy-restroom-locations',
+      layerId: 'single-occupancy-restroom-locations-layer',
+      name: 'Single Occupancy Restroom Locations',
       url: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer/1',
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     }
@@ -132,5 +132,5 @@ export interface IComposedIDefinitions {
   BIKE_LOCATIONS: IDefinition;
   DINING_LOCATIONS: IDefinition;
   AGGIEPRINT_LOCATIONS: IDefinition;
-  FAMILY_FRIENDLY_BATHROOMS: IDefinition;
+  SINGLE_OCCUPANCY_RESTROOMS: IDefinition;
 }

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.spec.ts
@@ -117,12 +117,12 @@ describe('LayerSources', () => {
         url: 'aggieprint-locations-url',
         popupComponent: 'aggieprint-popup'
       },
-      FAMILY_FRIENDLY_BATHROOMS: {
-        id: 'family-friendly-bathrooms',
-        layerId: 'family-friendly-bathrooms',
-        name: 'Family Friendly Bathrooms',
-        url: 'family-friendly-bathrooms-url',
-        popupComponent: 'family-friendly-bathrooms-popup'
+      SINGLE_OCCUPANCY_RESTROOMS: {
+        id: 'single-occupancy-restroom-locations',
+        layerId: 'single-occupancy-restroom-locations',
+        name: 'Single Occupancy Restroom Locations',
+        url: 'single-occupancy-restroom-locations-url',
+        popupComponent: 'single-occupancy-restroom-locations-popup'
       }
     };
     options = { exclude: [] };

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -438,10 +438,10 @@ export function LayerSources(
     },
     {
       type: 'feature',
-      id: definitions.FAMILY_FRIENDLY_BATHROOMS.layerId,
-      title: definitions.FAMILY_FRIENDLY_BATHROOMS.name,
-      url: definitions.FAMILY_FRIENDLY_BATHROOMS.url,
-      popupComponent: definitions.FAMILY_FRIENDLY_BATHROOMS.popupComponent,
+      id: definitions.SINGLE_OCCUPANCY_RESTROOMS.layerId,
+      title: definitions.SINGLE_OCCUPANCY_RESTROOMS.name,
+      url: definitions.SINGLE_OCCUPANCY_RESTROOMS.url,
+      popupComponent: definitions.SINGLE_OCCUPANCY_RESTROOMS.popupComponent,
       listMode: 'show',
       visible: false,
       popupData: {

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -355,7 +355,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
     'poi-layer',
     'construction_zone-layer',
     'dining-locations-layer',
-    'family-friendly-bathrooms-locations-layer',
+    'single-occupancy-restroom-locations-layer',
     'emergency-phones-layer'
   ],
   defaultLayerOverrides: {
@@ -366,7 +366,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
     'poi-layer': { listMode: 'hide' },
     'construction_zone-layer': { listMode: 'hide' },
     'dining-locations-layer': { listMode: 'hide' },
-    'family-friendly-bathrooms-locations-layer': { listMode: 'hide' },
+    'single-occupancy-restroom-locations-layer': { listMode: 'hide' },
     'emergency-phones-layer': { listMode: 'hide' },
     'bonfire-layer': { listMode: 'hide' },
     'surface-lots-layer': { listMode: 'hide' },

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
@@ -17,7 +17,7 @@ export class EventLegendComponent implements OnInit {
     'poi-layer',
     'construction_zone-layer',
     'dining-locations-layer',
-    'family-friendly-bathrooms-locations-layer',
+    'single-occupancy-restroom-locations-layer',
     'emergency-phones-layer'
   ];
 


### PR DESCRIPTION
This PR changes all instances of "Family Friendly Bathrooms" to "Single Occupancy Restrooms."

<img width="1205" height="890" alt="image" src="https://github.com/user-attachments/assets/e01111a5-4eec-48b6-bab6-f18fa248d56d" />

Closes #730