### PR TITLE
fix(aggiemap-angular) Include AVP Parking on Banana Ball map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -32,7 +32,7 @@ export const SavannahBananasParkingDefinitions = {
   ACCESSIBLE_PREPAID_PARKING: {
     id: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
     layerId: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
-    name: 'Accessible/Prepaid Parking',
+    name: 'Accessible/Prepaid/AVP Parking',
     url: `${eventUrl}/4`
   },
   EVENT_PARKING: {


### PR DESCRIPTION
This PR updates the Banana Ball Map to include the AVP Parking layer and makes the layers toggleable like the Physics Fest map.

<img width="1288" height="1143" alt="image" src="https://github.com/user-attachments/assets/7baf90bd-65e7-4657-966f-bf4e23912d8e" />

Closes #732 