### PR TITLE
feat(aggiemap-angular): Legend/Layers tab overhaul + Banana Ball updates

### DIFF
--- a/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.ts
+++ b/libs/maps/feature/layer-list/src/lib/components/layer-list/layer-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { map, Observable } from 'rxjs';
 
@@ -14,6 +14,8 @@ import esri = __esri;
   styleUrls: ['./layer-list.component.scss']
 })
 export class LayerListComponent implements OnInit {
+  @Input() public allowedLayerIds: string[] = [];
+
   public layers: Observable<Array<esri.ListItem>>;
 
   public responsive: ResponsiveSnapshot;
@@ -28,10 +30,14 @@ export class LayerListComponent implements OnInit {
   public ngOnInit() {
     this.responsive = this.responsiveService.snapshot;
     this.layers = this.layerListService.layers().pipe(
-      // Order layers by title
-      // TODO: This is potentially problematic because layer lists are inherently supposed to be ordered by the order of the layers in the map.
-      // However, we can't apply the order of the layers in the map because certain layers need to be at the top of the list due to rendering conflicts (occlusion, etc.)
-      map((layers) => layers.sort((a, b) => a.title.localeCompare(b.title)))
+      map((layers) => {
+        const filtered =
+          this.allowedLayerIds.length > 0 ? layers.filter((l) => this.allowedLayerIds.includes(l.layer.id)) : layers;
+        // Order layers by title
+        // TODO: This is potentially problematic because layer lists are inherently supposed to be ordered by the order of the layers in the map.
+        // However, we can't apply the order of the layers in the map because certain layers need to be at the top of the list due to rendering conflicts (occlusion, etc.)
+        return filtered.sort((a, b) => a.title.localeCompare(b.title));
+      })
     );
   }
 

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.html
@@ -12,7 +12,7 @@
     <span class="collection-group-title-text">{{ group.title }}</span>
   </div>
 
-  <div class="collection-group-content" *ngIf="!hasChildren || isExpanded">
+  <div class="collection-group-content" *ngIf="isExpanded">
     <tamu-gisc-legend-element
       *ngFor="let element of legendElements; trackBy: trackByLegendElement"
       [element]="element"
@@ -20,7 +20,7 @@
       [groupTitle]="group.title"
       [deduplicateChildren]="deduplicate"
       [respectDefinitionExpression]="respectDefinitionExpression"
-      [hideGroupHeader]="hideElementGroupHeaders"
+      [hideGroupHeader]="hideElementGroupHeaders || hideLeafElementGroupHeaders"
     ></tamu-gisc-legend-element>
 
     <tamu-gisc-legend-collection

--- a/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-collection/legend-collection.component.ts
@@ -96,8 +96,17 @@ export class LegendCollectionComponent {
     return this.hideElementGroupHeaders;
   }
 
+  /**
+   * When a leaf collection (no child groups) already displays its own title as a
+   * visibility-toggle header, the legend-element group header would repeat that same
+   * label. Suppress it so each label appears only once.
+   */
+  public get hideLeafElementGroupHeaders(): boolean {
+    return this.showGroupTitle && !this.hasChildren;
+  }
+
   public toggleExpanded(): void {
-    if (!this.hasChildren) {
+    if (!this.hasChildren && !this.allowVisibilityToggle) {
       return;
     }
 
@@ -113,7 +122,7 @@ export class LegendCollectionComponent {
   }
 
   public get isExpanded(): boolean {
-    if (this.allowVisibilityToggle && this.hasChildren) {
+    if (this.allowVisibilityToggle && this.group?.layer) {
       return this.isLayerVisible;
     }
 
@@ -163,7 +172,17 @@ export class LegendCollectionComponent {
   }
 
   public get showGroupTitle(): boolean {
-    return this.hasChildren && !this._sportsSafetyFirstLayerIds.has(this.group?.layer?.id);
+    if (this._sportsSafetyFirstLayerIds.has(this.group?.layer?.id)) {
+      return false;
+    }
+
+    if (this.hasChildren) {
+      return true;
+    }
+
+    // Also show a clickable title for leaf layers when visibility toggling is enabled
+    // and child headers are not suppressed (e.g. Physics Fest combine-under-primary mode)
+    return this.allowVisibilityToggle && !this.hideElementGroupHeaders && !!this.group?.layer;
   }
 
   private _shouldHideSportsSafetyFirstChildGroups(): boolean {

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -63,7 +63,8 @@ export class LegendComponent implements OnInit, OnDestroy {
     }
 
     this.legend = this.legendService.legend({
-      excludedLayerIds: this.excludedLayerIds
+      excludedLayerIds: this.excludedLayerIds,
+      showAllLayers: this.allowVisibilityToggle
     });
 
     this.responsive = this.responsiveService.snapshot;

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -34,6 +34,9 @@ export class LegendComponent implements OnInit, OnDestroy {
   public excludedLayerIds: string[] = [];
 
   @Input()
+  public allowedLayerIds: string[] = [];
+
+  @Input()
   public combineChildrenUnderPrimary = false;
 
   public legend: Observable<Array<esri.ActiveLayerInfo>>;
@@ -58,13 +61,14 @@ export class LegendComponent implements OnInit, OnDestroy {
       this.respectDefinitionExpression = routeData['respectDefinitionExpression'] ?? this.respectDefinitionExpression;
       this.allowVisibilityToggle = routeData['allowVisibilityToggle'] ?? this.allowVisibilityToggle;
       this.excludedLayerIds = routeData['excludedLayerIds'] ?? this.excludedLayerIds;
+      this.allowedLayerIds = routeData['allowedLayerIds'] ?? this.allowedLayerIds;
       this.combineChildrenUnderPrimary =
         routeData['combineChildrenUnderPrimary'] ?? this.combineChildrenUnderPrimary;
     }
 
     this.legend = this.legendService.legend({
       excludedLayerIds: this.excludedLayerIds,
-      showAllLayers: this.allowVisibilityToggle
+      allowedLayerIds: this.allowedLayerIds
     });
 
     this.responsive = this.responsiveService.snapshot;

--- a/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend/legend.component.ts
@@ -63,7 +63,6 @@ export class LegendComponent implements OnInit, OnDestroy {
     }
 
     this.legend = this.legendService.legend({
-      respectLayerVisibility: !this.allowVisibilityToggle,
       excludedLayerIds: this.excludedLayerIds
     });
 

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -20,6 +20,7 @@ export class LegendService {
 
   public legend(options?: LegendOptions) {
     const excludedLayerIds = new Set(options?.excludedLayerIds ?? []);
+    const showAllLayers = options?.showAllLayers ?? false;
 
     return combineLatest([this.moduleProvider.require(['LegendViewModel']), this.mapService.store]).pipe(
       switchMap(([[LegendViewModel], instances]: [[esri.LegendViewModelConstructor], MapServiceInstance]) => {
@@ -60,7 +61,7 @@ export class LegendService {
               items: esri.ActiveLayerInfo[]
             ) => {
               const allowedIds = new Set(acc.allowedIds);
-              items.filter((l) => l.layer.visible).forEach((l) => allowedIds.add(l.layer.id));
+              (showAllLayers ? items : items.filter((l) => l.layer.visible)).forEach((l) => allowedIds.add(l.layer.id));
               return { allowedIds, result: items.filter((l) => allowedIds.has(l.layer.id)) };
             },
             { allowedIds: new Set<string>(), result: [] as esri.ActiveLayerInfo[] }
@@ -74,6 +75,7 @@ export class LegendService {
 
 interface LegendOptions {
   excludedLayerIds?: string[];
+  showAllLayers?: boolean;
 }
 
 export interface IActiveLayerInfosChangeEvent {

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -20,7 +20,7 @@ export class LegendService {
 
   public legend(options?: LegendOptions) {
     const excludedLayerIds = new Set(options?.excludedLayerIds ?? []);
-    const showAllLayers = options?.showAllLayers ?? false;
+    const allowedLayerIds = options?.allowedLayerIds ?? [];
 
     return combineLatest([this.moduleProvider.require(['LegendViewModel']), this.mapService.store]).pipe(
       switchMap(([[LegendViewModel], instances]: [[esri.LegendViewModelConstructor], MapServiceInstance]) => {
@@ -48,6 +48,7 @@ export class LegendService {
             return event.target
               .filter((l) => l.layer.listMode !== 'hide')
               .filter((l) => !excludedLayerIds.has(l.layer.id))
+              .filter((l) => allowedLayerIds.length === 0 || allowedLayerIds.includes(l.layer.id))
               .toArray();
           }),
           // Track layers that have ever been visible. Initially-hidden layers (e.g. alternate
@@ -61,7 +62,7 @@ export class LegendService {
               items: esri.ActiveLayerInfo[]
             ) => {
               const allowedIds = new Set(acc.allowedIds);
-              (showAllLayers ? items : items.filter((l) => l.layer.visible)).forEach((l) => allowedIds.add(l.layer.id));
+              items.filter((l) => l.layer.visible).forEach((l) => allowedIds.add(l.layer.id));
               return { allowedIds, result: items.filter((l) => allowedIds.has(l.layer.id)) };
             },
             { allowedIds: new Set<string>(), result: [] as esri.ActiveLayerInfo[] }
@@ -75,7 +76,7 @@ export class LegendService {
 
 interface LegendOptions {
   excludedLayerIds?: string[];
-  showAllLayers?: boolean;
+  allowedLayerIds?: string[];
 }
 
 export interface IActiveLayerInfosChangeEvent {

--- a/libs/maps/feature/legend/src/lib/services/legend.service.ts
+++ b/libs/maps/feature/legend/src/lib/services/legend.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { combineLatest, fromEventPattern, Observable, ReplaySubject } from 'rxjs';
-import { map, startWith, switchMap } from 'rxjs/operators';
+import { map, scan, startWith, switchMap } from 'rxjs/operators';
 
 import { EsriMapService, EsriModuleProviderService, MapServiceInstance } from '@tamu-gisc/maps/esri';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
@@ -19,18 +19,18 @@ export class LegendService {
   ) {}
 
   public legend(options?: LegendOptions) {
-    const respectLayerVisibility = options?.respectLayerVisibility ?? true;
     const excludedLayerIds = new Set(options?.excludedLayerIds ?? []);
 
     return combineLatest([this.moduleProvider.require(['LegendViewModel']), this.mapService.store]).pipe(
       switchMap(([[LegendViewModel], instances]: [[esri.LegendViewModelConstructor], MapServiceInstance]) => {
+        // Use respectLayerVisibility: false so that ESRI never removes a layer from
+        // activeLayerInfos when its visibility changes. This keeps toggled-off layers
+        // in the list so the legend-collection component can collapse (not destroy) them.
         const model = new LegendViewModel({
           view: instances.view,
-          respectLayerVisibility
+          respectLayerVisibility: false
         });
 
-        // Create add/remove watch handlers for the activeLayerInfos property of the view model.
-        // These are used to create a subscribable event stream.
         let handle;
 
         const add = (handler) => {
@@ -41,7 +41,6 @@ export class LegendService {
           handle.remove();
         };
 
-        // For every item, attempt to create a layer
         return fromEventPattern(add, remove).pipe(
           startWith({ target: model.activeLayerInfos }),
           map((event: IActiveLayerInfosChangeEvent) => {
@@ -49,7 +48,24 @@ export class LegendService {
               .filter((l) => l.layer.listMode !== 'hide')
               .filter((l) => !excludedLayerIds.has(l.layer.id))
               .toArray();
-          })
+          }),
+          // Track layers that have ever been visible. Initially-hidden layers (e.g. alternate
+          // map-mode layers, base-map layers that are off by default) are never added to the
+          // allowed set and therefore never appear in the legend. Once a layer has been seen
+          // as visible it stays in the legend permanently so that toggling it off collapses
+          // the entry instead of removing it.
+          scan(
+            (
+              acc: { allowedIds: Set<string>; result: esri.ActiveLayerInfo[] },
+              items: esri.ActiveLayerInfo[]
+            ) => {
+              const allowedIds = new Set(acc.allowedIds);
+              items.filter((l) => l.layer.visible).forEach((l) => allowedIds.add(l.layer.id));
+              return { allowedIds, result: items.filter((l) => allowedIds.has(l.layer.id)) };
+            },
+            { allowedIds: new Set<string>(), result: [] as esri.ActiveLayerInfo[] }
+          ),
+          map((acc) => acc.result)
         );
       })
     );
@@ -57,7 +73,6 @@ export class LegendService {
 }
 
 interface LegendOptions {
-  respectLayerVisibility?: boolean;
   excludedLayerIds?: string[];
 }
 

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -347,17 +347,6 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   zoom: 17,
   legendAllowVisibilityToggle: true,
   legendCombineChildrenUnderPrimary: true,
-  legendExcludedLayerIds: [
-    'aggieprint-locations-layer',
-    'accessible-entrances-layer',
-    'visitor-parking-layer',
-    'lactation-rooms-layer',
-    'poi-layer',
-    'construction_zone-layer',
-    'dining-locations-layer',
-    'single-occupancy-restroom-locations-layer',
-    'emergency-phones-layer'
-  ],
   defaultLayerOverrides: {
     'aggieprint-locations-layer': { listMode: 'hide' },
     'accessible-entrances-layer': { listMode: 'hide' },

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -346,25 +346,7 @@ export const PhysicsAndEngineeringFestivalConfiguration: EventConfiguration = {
   mapCenter: [-96.33771, 30.62143],
   zoom: 17,
   legendAllowVisibilityToggle: true,
-  legendCombineChildrenUnderPrimary: true,
-  defaultLayerOverrides: {
-    'aggieprint-locations-layer': { listMode: 'hide' },
-    'accessible-entrances-layer': { listMode: 'hide' },
-    'visitor-parking-layer': { listMode: 'hide' },
-    'lactation-rooms-layer': { listMode: 'hide' },
-    'poi-layer': { listMode: 'hide' },
-    'construction_zone-layer': { listMode: 'hide' },
-    'dining-locations-layer': { listMode: 'hide' },
-    'single-occupancy-restroom-locations-layer': { listMode: 'hide' },
-    'emergency-phones-layer': { listMode: 'hide' },
-    'bonfire-layer': { listMode: 'hide' },
-    'surface-lots-layer': { listMode: 'hide' },
-    'bike-locations-layer': { listMode: 'hide' },
-    'sustainable-transportation-group-layer': {
-      listMode: 'hide',
-      native: { listMode: 'hide' }
-    }
-  }
+  legendCombineChildrenUnderPrimary: true
 };
 
 export const PhysicsAndEngineeringFestivalOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -8,8 +8,10 @@ import {
 } from '../interfaces/special-event.interface';
 
 export enum SAVANNAH_BANANAS_PARKING_LAYERS {
+  SHUTTLE_GROUP = 'savannah-bananas-shuttle-group',
   SHUTTLE_STOPS = 'savannah-bananas-shuttle-stops',
   SHUTTLE_ROUTES = 'savannah-bananas-shuttle-routes',
+  PARKING_GROUP = 'savannah-bananas-parking-group',
   ACCESSIBLE_PREPAID_PARKING = 'savannah-bananas-accessible-prepaid-parking',
   EVENT_PARKING = 'savannah-bananas-event-parking'
 }
@@ -17,10 +19,16 @@ export enum SAVANNAH_BANANAS_PARKING_LAYERS {
 const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SavannahBananas/MapServer';
 
 export const SavannahBananasParkingDefinitions = {
+  SHUTTLE_GROUP: {
+    id: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_GROUP,
+    layerId: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_GROUP,
+    name: 'Event Shuttles',
+    url: `${eventUrl}/0`
+  },
   SHUTTLE_STOPS: {
     id: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_STOPS,
     layerId: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_STOPS,
-    name: 'Shuttle Stops',
+    name: 'Campus Shuttle Stops',
     url: `${eventUrl}/1`
   },
   SHUTTLE_ROUTES: {
@@ -28,6 +36,12 @@ export const SavannahBananasParkingDefinitions = {
     layerId: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_ROUTES,
     name: 'Shuttle Routes',
     url: `${eventUrl}/2`
+  },
+  PARKING_GROUP: {
+    id: SAVANNAH_BANANAS_PARKING_LAYERS.PARKING_GROUP,
+    layerId: SAVANNAH_BANANAS_PARKING_LAYERS.PARKING_GROUP,
+    name: 'Event Parking',
+    url: `${eventUrl}/3`
   },
   ACCESSIBLE_PREPAID_PARKING: {
     id: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
@@ -44,99 +58,121 @@ export const SavannahBananasParkingDefinitions = {
 };
 
 const SavannahBananasLayerReferences: Record<string, string> = {
-  SHUTTLE_STOPS: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_STOPS,
-  SHUTTLE_ROUTES: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_ROUTES,
-  ACCESSIBLE_PREPAID_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
-  EVENT_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.EVENT_PARKING
+  SHUTTLE_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_GROUP,
+  PARKING_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.PARKING_GROUP
 };
 
 export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
   {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
-    title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
-    url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
-      },
-      description: {
-        field: 'description'
-      }
-    },
+    type: 'group',
+    id: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.id,
+    title: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.name,
     visible: true,
     listMode: 'show',
+    sources: [
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
+        title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
+        url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
+        title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
+        url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupDataResolutionStrategy: 'cumulative',
+        popupData: {
+          name: {
+            field: 'StopName'
+          },
+          routeName: {
+            field: 'RouteName'
+          },
+          route: {
+            field: 'Route'
+          },
+          stopNumber: {
+            field: 'StopNum'
+          },
+          description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      }
+    ],
     native: {
-      outFields: ['*']
+      listMode: 'hide-children'
     }
   },
   {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
-    title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
-    url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
+    type: 'group',
+    id: SavannahBananasParkingDefinitions.PARKING_GROUP.id,
+    title: SavannahBananasParkingDefinitions.PARKING_GROUP.name,
+    visible: true,
+    listMode: 'show',
+    sources: [
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
+        title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
+        url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       },
-      description: {
-        field: 'description'
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
+        title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
+        url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       }
-    },
-    visible: true,
-    listMode: 'show',
+    ],
     native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
-    title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
-    url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
-      },
-      description: {
-        field: 'description'
-      }
-    },
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
-    title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
-    url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupDataResolutionStrategy: 'cumulative',
-    popupData: {
-      name: {
-        field: 'StopName'
-      },
-      routeName: {
-        field: 'RouteName'
-      },
-      route: {
-        field: 'Route'
-      },
-      stopNumber: {
-        field: 'StopNum'
-      },
-      description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
-    },
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
+      listMode: 'hide-children'
     }
   }
 ];
@@ -150,7 +186,37 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
   eventDates: ['2026-05-02'],
   scheduleUrl: 'https://app.12thman.com/bananaball',
   mapCenter: [-96.34046, 30.60798],
-  zoom: 16
+  zoom: 16,
+  legendAllowVisibilityToggle: true,
+  legendExcludedLayerIds: [
+    'aggieprint-locations-layer',
+    'accessible-entrances-layer',
+    'visitor-parking-layer',
+    'lactation-rooms-layer',
+    'poi-layer',
+    'construction_zone-layer',
+    'dining-locations-layer',
+    'single-occupancy-restroom-locations-layer',
+    'emergency-phones-layer'
+  ],
+  defaultLayerOverrides: {
+    'aggieprint-locations-layer': { listMode: 'hide' },
+    'accessible-entrances-layer': { listMode: 'hide' },
+    'visitor-parking-layer': { listMode: 'hide' },
+    'lactation-rooms-layer': { listMode: 'hide' },
+    'poi-layer': { listMode: 'hide' },
+    'construction_zone-layer': { listMode: 'hide' },
+    'dining-locations-layer': { listMode: 'hide' },
+    'single-occupancy-restroom-locations-layer': { listMode: 'hide' },
+    'emergency-phones-layer': { listMode: 'hide' },
+    'bonfire-layer': { listMode: 'hide' },
+    'surface-lots-layer': { listMode: 'hide' },
+    'bike-locations-layer': { listMode: 'hide' },
+    'sustainable-transportation-group-layer': {
+      listMode: 'hide',
+      native: { listMode: 'hide' }
+    }
+  }
 };
 
 export const SavannahBananasParkingOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -58,121 +58,99 @@ export const SavannahBananasParkingDefinitions = {
 };
 
 const SavannahBananasLayerReferences: Record<string, string> = {
-  SHUTTLE_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_GROUP,
-  PARKING_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.PARKING_GROUP
+  SHUTTLE_STOPS: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_STOPS,
+  SHUTTLE_ROUTES: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_ROUTES,
+  ACCESSIBLE_PREPAID_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
+  EVENT_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.EVENT_PARKING
 };
 
 export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
   {
-    type: 'group',
-    id: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.id,
-    title: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.name,
+    type: 'feature',
+    id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
+    title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
+    url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'name'
+      },
+      description: {
+        field: 'description'
+      }
+    },
     visible: true,
     listMode: 'show',
-    sources: [
-      {
-        type: 'feature',
-        id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
-        title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
-        url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        popupData: {
-          name: {
-            field: 'name'
-          },
-          description: {
-            field: 'description'
-          }
-        },
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      },
-      {
-        type: 'feature',
-        id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
-        title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
-        url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        popupDataResolutionStrategy: 'cumulative',
-        popupData: {
-          name: {
-            field: 'StopName'
-          },
-          routeName: {
-            field: 'RouteName'
-          },
-          route: {
-            field: 'Route'
-          },
-          stopNumber: {
-            field: 'StopNum'
-          },
-          description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
-        },
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      }
-    ],
     native: {
-      listMode: 'hide-children'
+      outFields: ['*']
     }
   },
   {
-    type: 'group',
-    id: SavannahBananasParkingDefinitions.PARKING_GROUP.id,
-    title: SavannahBananasParkingDefinitions.PARKING_GROUP.name,
+    type: 'feature',
+    id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
+    title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
+    url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'name'
+      },
+      description: {
+        field: 'description'
+      }
+    },
     visible: true,
     listMode: 'show',
-    sources: [
-      {
-        type: 'feature',
-        id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
-        title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
-        url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        popupData: {
-          name: {
-            field: 'name'
-          },
-          description: {
-            field: 'description'
-          }
-        },
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      },
-      {
-        type: 'feature',
-        id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
-        title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
-        url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        popupData: {
-          name: {
-            field: 'name'
-          },
-          description: {
-            field: 'description'
-          }
-        },
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
-      }
-    ],
     native: {
-      listMode: 'hide-children'
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
+    title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
+    url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupData: {
+      name: {
+        field: 'name'
+      },
+      description: {
+        field: 'description'
+      }
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
+    }
+  },
+  {
+    type: 'feature',
+    id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
+    title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
+    url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
+    popupComponent: MarkdownWDirectionsPopupComponent,
+    popupDataResolutionStrategy: 'cumulative',
+    popupData: {
+      name: {
+        field: 'StopName'
+      },
+      routeName: {
+        field: 'RouteName'
+      },
+      route: {
+        field: 'Route'
+      },
+      stopNumber: {
+        field: 'StopNum'
+      },
+      description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
+    },
+    visible: true,
+    listMode: 'show',
+    native: {
+      outFields: ['*']
     }
   }
 ];
@@ -188,17 +166,6 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
   mapCenter: [-96.34046, 30.60798],
   zoom: 16,
   legendAllowVisibilityToggle: true,
-  legendExcludedLayerIds: [
-    'aggieprint-locations-layer',
-    'accessible-entrances-layer',
-    'visitor-parking-layer',
-    'lactation-rooms-layer',
-    'poi-layer',
-    'construction_zone-layer',
-    'dining-locations-layer',
-    'single-occupancy-restroom-locations-layer',
-    'emergency-phones-layer'
-  ],
   defaultLayerOverrides: {
     'aggieprint-locations-layer': { listMode: 'hide' },
     'accessible-entrances-layer': { listMode: 'hide' },
@@ -215,7 +182,8 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
     'sustainable-transportation-group-layer': {
       listMode: 'hide',
       native: { listMode: 'hide' }
-    }
+    },
+    'three-d-buildings-scene-layer': { listMode: 'hide' }
   }
 };
 

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -165,26 +165,7 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
   scheduleUrl: 'https://app.12thman.com/bananaball',
   mapCenter: [-96.34046, 30.60798],
   zoom: 16,
-  legendAllowVisibilityToggle: true,
-  defaultLayerOverrides: {
-    'aggieprint-locations-layer': { listMode: 'hide' },
-    'accessible-entrances-layer': { listMode: 'hide' },
-    'visitor-parking-layer': { listMode: 'hide' },
-    'lactation-rooms-layer': { listMode: 'hide' },
-    'poi-layer': { listMode: 'hide' },
-    'construction_zone-layer': { listMode: 'hide' },
-    'dining-locations-layer': { listMode: 'hide' },
-    'single-occupancy-restroom-locations-layer': { listMode: 'hide' },
-    'emergency-phones-layer': { listMode: 'hide' },
-    'bonfire-layer': { listMode: 'hide' },
-    'surface-lots-layer': { listMode: 'hide' },
-    'bike-locations-layer': { listMode: 'hide' },
-    'sustainable-transportation-group-layer': {
-      listMode: 'hide',
-      native: { listMode: 'hide' }
-    },
-    'three-d-buildings-scene-layer': { listMode: 'hide' }
-  }
+  legendAllowVisibilityToggle: true
 };
 
 export const SavannahBananasParkingOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -81,13 +81,6 @@ export interface EventConfiguration {
   legendCombineChildrenUnderPrimary?: boolean;
 
   /**
-   * Omits specific layer ids from the legend when supported by the consuming UI.
-   *
-   * Defaults to an empty array when omitted.
-   */
-  legendExcludedLayerIds?: Array<string>;
-
-  /**
    * Events can have exceptions for default map layers. This property allows for the ability to
    * define a set of default layer overrides that apply to a specific event.
    *

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
@@ -3,5 +3,4 @@
   [respectDefinitionExpression]="respectDefinitionExpression"
   [allowVisibilityToggle]="allowVisibilityToggle"
   [combineChildrenUnderPrimary]="combineChildrenUnderPrimary"
-  [excludedLayerIds]="excludedLayerIds"
 ></tamu-gisc-legend>

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
@@ -11,7 +11,6 @@ export class EventLegendComponent implements OnInit {
   public respectDefinitionExpression = true;
   public allowVisibilityToggle = true;
   public combineChildrenUnderPrimary = false;
-  public excludedLayerIds: string[] = [];
 
   constructor(private readonly eventSettingsService: EventSettingsService) {}
 
@@ -20,6 +19,5 @@ export class EventLegendComponent implements OnInit {
 
     this.allowVisibilityToggle = config?.legendAllowVisibilityToggle ?? true;
     this.combineChildrenUnderPrimary = config?.legendCombineChildrenUnderPrimary ?? false;
-    this.excludedLayerIds = config?.legendExcludedLayerIds ?? [];
   }
 }

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
@@ -7,34 +7,19 @@ import { EventSettingsService } from '../../../../services/settings/event-settin
   templateUrl: './event-legend.component.html'
 })
 export class EventLegendComponent implements OnInit {
-  private readonly _physicsEventId = 'phys-eng-fest';
-
-  private readonly _physicsExcludedLayerIds = [
-    'aggieprint-locations-layer',
-    'accessible-entrances-layer',
-    'visitor-parking-layer',
-    'lactation-rooms-layer',
-    'poi-layer',
-    'construction_zone-layer',
-    'dining-locations-layer',
-    'single-occupancy-restroom-locations-layer',
-    'emergency-phones-layer'
-  ];
-
   public deduplicate = true;
   public respectDefinitionExpression = true;
-  public allowVisibilityToggle = false;
+  public allowVisibilityToggle = true;
   public combineChildrenUnderPrimary = false;
   public excludedLayerIds: string[] = [];
 
   constructor(private readonly eventSettingsService: EventSettingsService) {}
 
   public ngOnInit(): void {
-    const eventId = this.eventSettingsService.eventConfiguration()?.configuration?.id;
-    const isPhysicsMap = eventId === this._physicsEventId;
+    const config = this.eventSettingsService.eventConfiguration()?.configuration;
 
-    this.allowVisibilityToggle = isPhysicsMap;
-    this.combineChildrenUnderPrimary = isPhysicsMap;
-    this.excludedLayerIds = isPhysicsMap ? this._physicsExcludedLayerIds : [];
+    this.allowVisibilityToggle = config?.legendAllowVisibilityToggle ?? true;
+    this.combineChildrenUnderPrimary = config?.legendCombineChildrenUnderPrimary ?? false;
+    this.excludedLayerIds = config?.legendExcludedLayerIds ?? [];
   }
 }

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -21,6 +21,8 @@
   </div>
 </div>
 
+<tamu-gisc-layer-list></tamu-gisc-layer-list>
+
 <tamu-gisc-legend
   [deduplicate]="true"
   [respectDefinitionExpression]="true"
@@ -28,5 +30,3 @@
   [combineChildrenUnderPrimary]="legendCombineChildrenUnderPrimary"
   [excludedLayerIds]="legendExcludedLayerIds"
 ></tamu-gisc-legend>
-
-<tamu-gisc-layer-list></tamu-gisc-layer-list>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -21,12 +21,12 @@
   </div>
 </div>
 
-<tamu-gisc-layer-list></tamu-gisc-layer-list>
+<tamu-gisc-layer-list [allowedLayerIds]="eventLayerIds"></tamu-gisc-layer-list>
 
 <tamu-gisc-legend
   [deduplicate]="true"
   [respectDefinitionExpression]="true"
   [allowVisibilityToggle]="legendAllowVisibilityToggle"
   [combineChildrenUnderPrimary]="legendCombineChildrenUnderPrimary"
-  [excludedLayerIds]="legendExcludedLayerIds"
+  [allowedLayerIds]="eventLayerIds"
 ></tamu-gisc-legend>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -38,7 +38,7 @@ export class SidebarReferenceComponent implements OnInit {
     this.hasSettings = this.eventSettingsService.queryParamsFromSettings !== null;
     this.configuration = this.eventSettingsService.eventConfiguration()?.configuration;
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
-    this.legendAllowVisibilityToggle = this.configuration?.legendAllowVisibilityToggle ?? false;
+    this.legendAllowVisibilityToggle = this.configuration?.legendAllowVisibilityToggle ?? true;
     this.legendCombineChildrenUnderPrimary = this.configuration?.legendCombineChildrenUnderPrimary ?? false;
     this.legendExcludedLayerIds = this.configuration?.legendExcludedLayerIds ?? [];
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -23,7 +23,7 @@ export class SidebarReferenceComponent implements OnInit {
   public configuration: EventConfiguration | null;
   public legendAllowVisibilityToggle = false;
   public legendCombineChildrenUnderPrimary = false;
-  public legendExcludedLayerIds: string[] = [];
+  public eventLayerIds: string[] = [];
   public showResolvedSettingNotes = false;
 
   constructor(
@@ -40,7 +40,7 @@ export class SidebarReferenceComponent implements OnInit {
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
     this.legendAllowVisibilityToggle = this.configuration?.legendAllowVisibilityToggle ?? true;
     this.legendCombineChildrenUnderPrimary = this.configuration?.legendCombineChildrenUnderPrimary ?? false;
-    this.legendExcludedLayerIds = this.configuration?.legendExcludedLayerIds ?? [];
+    this.eventLayerIds = this.eventSettingsService.eventLayerSources().map((s) => s.id);
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
   }

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.ts
@@ -40,7 +40,23 @@ export class SidebarReferenceComponent implements OnInit {
     this.showResolvedSettingNotes = this.configuration?.enableResolvedSettingNotes ?? false;
     this.legendAllowVisibilityToggle = this.configuration?.legendAllowVisibilityToggle ?? true;
     this.legendCombineChildrenUnderPrimary = this.configuration?.legendCombineChildrenUnderPrimary ?? false;
-    this.eventLayerIds = this.eventSettingsService.eventLayerSources().map((s) => s.id);
+    const settings = this.eventSettingsService.settings();
+    const options = this.eventSettingsService.eventOptions();
+    this.eventLayerIds = this.eventSettingsService
+      .eventLayerSources()
+      .filter((source) => {
+        for (const option of options) {
+          const layerEffect = option.effects.layers?.find((l) => l.layerId === source.id);
+          if (layerEffect?.conversions && settings) {
+            const conversion = layerEffect.conversions.find((c) => c.input === settings[option.value]);
+            if (conversion?.propOverrides?.visible === false) {
+              return false;
+            }
+          }
+        }
+        return true;
+      })
+      .map((s) => s.id);
     this.shareUrl = `${window.location.origin}${window.location.pathname}?${this.eventSettingsService.queryParamsFromSettings}`;
     this.mergedSettings = this.eventSettingsService.getMergedSettings();
   }


### PR DESCRIPTION
This PR updates the legend functionality to allow for all grouped layers to be toggleable.

## Summary

Adds configurable toggleable legend behavior for event maps and tightens event sidebar controls so the layer list and legend can focus on event-specific layers. This also removes the previous Physics Engineering Festival hardcoding and applies toggleable legend behavior to the Savannah Bananas map.

## Changes

- Enables event map legends to support visibility toggles by default.
- Removes the hardcoded Physics Engineering Festival logic from `EventLegendComponent`.
- Keeps event legend behavior driven by event configuration:
  - `legendAllowVisibilityToggle`
  - `legendCombineChildrenUnderPrimary`
- Removes `legendExcludedLayerIds` from the event configuration interface and event legend wiring.
- Updates the shared legend service so ESRI does not remove layers from legend data when visibility changes.
- Tracks layers that have been visible so toggled-off layers stay available as collapsed legend entries instead of disappearing.
- Adds `allowedLayerIds` support to the shared legend component/service.
- Adds `allowedLayerIds` support to the shared layer list component.
- Updates the event sidebar reference to derive event layer IDs from `eventLayerSources()` and pass them to both:
  - `<tamu-gisc-layer-list>`
  - `<tamu-gisc-legend>`
- Moves the sidebar layer list above the legend so layer visibility controls appear before legend details.
- Allows leaf legend entries to show clickable toggle headers when visibility toggling is enabled.
- Hides duplicate leaf legend labels when the layer title is already shown as the toggle header.
- Collapses legend content when a toggled layer is not visible.

## Event Map Updates

- Keeps Physics Engineering Festival toggleable legend behavior through config, but removes its explicit legend exclusions and default layer overrides.
- Enables toggleable legend behavior for the Savannah Bananas map.
- Adds Savannah Bananas layer definitions for:
  - `Event Shuttles`
  - `Event Parking`
- Renames `Shuttle Stops` to `Campus Shuttle Stops`.


## Groups can now toggle:
<img width="800" height="426" alt="Screen Recording 2026-04-17 175433" src="https://github.com/user-attachments/assets/9e9670cc-7090-41d9-8528-663b9bad9662" />

## Subgroups within groups can also toggle:
<img width="800" height="426" alt="Screen Recording 2026-04-17 175404" src="https://github.com/user-attachments/assets/386ce1d5-fdca-4549-a5fc-e25bff0cc936" />

## Layers are now above legend:

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/e9c4dac4-5bce-4fff-b511-802d6fff2367" />

## Only relevant layers are shown on each map:
<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/7905e1ab-f389-4261-b72b-a1e4ebb9131f" />

Closes #733 
Closes #734 
Closes #735 
Closes #736 