### PR TITLE
feat(aggiema-angular): Add titles to maps header on sidebar

### DIFF
--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -1,5 +1,9 @@
 <tamu-gisc-search [placeholder]="'Find Building or Parking'" [leftActionIcon]="'search'" [rightActionIcon]="'close'" (result)="onSearchResult($event)"></tamu-gisc-search>
 
+<div *ngIf="configuration?.applicationName" class="map-title">
+  <h1>{{ configuration?.applicationName }}</h1>
+</div>
+
 <div *ngIf="hasSettings" class="leader-1">
   <div class="sidebar-component-name">
     <p>Share Map</p>

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
@@ -1,3 +1,18 @@
+.map-title {
+  padding: 0.1rem 1rem 0.5rem;
+  text-align: center;
+
+  h1 {
+    margin: 3px 0 0;
+    font-size: 1.75rem;
+    font-weight: 400;
+  }
+
+  + .leader-1 {
+    margin-top: 0.1rem;
+  }
+}
+
 .settings-list {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
This PR adds the title of the map + the type of map to the side bar, right below the search bar and above the layers:

(Names are based on the `applicationName` in each map's definitions file)

<img width="627" height="1079" alt="image" src="https://github.com/user-attachments/assets/f49576e2-41f9-4c6e-a113-eea9f5b4bbc2" />
<img width="651" height="1198" alt="image" src="https://github.com/user-attachments/assets/c9bb6161-a945-46fe-97c6-774bf6bbe80d" />
<img width="649" height="680" alt="image" src="https://github.com/user-attachments/assets/65de5762-e6ce-480e-9203-0a28964f8b19" />

Closes #738 