### PR TITLE
fix(aggiemap-angular): Update Sustainable Transporation layers to only pull from BikeMap server

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -22,7 +22,6 @@ export function LayerSources(
   options?: IFactoryExcludeOptions<IComposedIDefinitions>
 ): Array<LayerSource> {
   const bikeMapUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
-  const evChargeStationsUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
   const all: Array<LayerSource> = [
     {
       type: 'feature',
@@ -231,8 +230,8 @@ export function LayerSources(
         {
           type: 'feature',
           id: 'bike-dismount-zones-layer',
-          title: 'Bike Dismount Zones',
-          url: `${bikeMapUrl}/4`,
+          title: 'Dismount Zones',
+          url: `${bikeMapUrl}/5`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -248,7 +247,7 @@ export function LayerSources(
           type: 'feature',
           id: 'city-bike-lanes-routes-layer',
           title: 'City Bike Lanes and Routes',
-          url: `${bikeMapUrl}/3`,
+          url: `${bikeMapUrl}/4`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -263,8 +262,8 @@ export function LayerSources(
         {
           type: 'feature',
           id: 'bike-lanes-layer',
-          title: 'Bike Lanes',
-          url: `${bikeMapUrl}/2`,
+          title: 'Campus Bike Lanes',
+          url: `${bikeMapUrl}/3`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -280,7 +279,7 @@ export function LayerSources(
           type: 'feature',
           id: 'bike-fix-stations-layer',
           title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/1`,
+          url: `${bikeMapUrl}/2`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -296,7 +295,7 @@ export function LayerSources(
           type: 'feature',
           id: 'bike-racks-map-layer',
           title: 'Bike Racks',
-          url: `${bikeMapUrl}/0`,
+          url: `${bikeMapUrl}/1`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,
@@ -314,7 +313,7 @@ export function LayerSources(
           type: 'feature',
           id: 'ev-charge-stations-layer',
           title: 'EV Charge Stations (Main + RELLIS)',
-          url: `${evChargeStationsUrl}/0`,
+          url: `${bikeMapUrl}/0`,
           listMode: 'show',
           visible: true,
           popupComponent: Popups.MarkdownPopupComponent,

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -16,7 +16,6 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
-const evLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/EVChargeStations/MapServer';
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
 
 export const SustainableTransportationDefinitions = {
@@ -24,37 +23,37 @@ export const SustainableTransportationDefinitions = {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
     name: 'EV Charge Stations (Main + RELLIS)',
-    url: `${evLayersUrl}/0`
+    url: `${bikeLayersUrl}/0`
   },
   BIKE_RACKS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_RACKS,
     name: 'Bike Racks',
-    url: `${bikeLayersUrl}/0`
+    url: `${bikeLayersUrl}/1`
   },
   BIKE_FIX_STATIONS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_FIX_STATIONS,
     name: 'Bike Fix Stations',
-    url: `${bikeLayersUrl}/1`
+    url: `${bikeLayersUrl}/2`
   },
   BIKE_LANES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_LANES,
-    name: 'Bike Lanes',
-    url: `${bikeLayersUrl}/2`
+    name: 'Campus Bike Lanes',
+    url: `${bikeLayersUrl}/3`
   },
   CITY_BIKE_LANES_ROUTES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.CITY_BIKE_LANES_ROUTES,
     name: 'City Bike Lanes and Routes',
-    url: `${bikeLayersUrl}/3`
+    url: `${bikeLayersUrl}/4`
   },
   BIKE_DISMOUNT_ZONES: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
     layerId: SUSTAINABLE_TRANSPORTATION_LAYERS.BIKE_DISMOUNT_ZONES,
-    name: 'Bike Dismount Zones',
-    url: `${bikeLayersUrl}/4`
+    name: 'Dismount Zones',
+    url: `${bikeLayersUrl}/5`
   }
 };
 


### PR DESCRIPTION
This PR updates the Sustainable Transporation map (and the layers toggleable on the homepage) to pull only from https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer, rather than BikeMap and the EV Charge Stations server.

[
<img width="1763" height="1211" alt="Screenshot 2026-04-22 082953" src="https://github.com/user-attachments/assets/34c7648c-8192-4821-9c24-7047fc865e9e" />
](url)

Closes #741 