### PR TITLE
fix(aggiemap-angular): Add new names to AggieMap about page

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/about/components/about.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/about/components/about.component.html
@@ -35,6 +35,16 @@
           <div class="name">Tim St. Martin</div>
           <div class="title">Assistant Vice President of Web and Digital Experience</div>
         </div>
+
+        <div class="profile">
+          <div class="name">Chelsey Cooke</div>
+          <div class="title">Assistant Director, Enterprise Channels</div>
+        </div>
+
+        <div class="profile">
+          <div class="name">Josh Nuckolls</div>
+          <div class="title">Communications Specialist II</div>
+        </div>
       </div>
 
       <h3>Department of Geography</h3>
@@ -81,6 +91,11 @@
         <div class="profile">
           <div class="name">Megan McMullen</div>
           <div class="title">GIS Specialist I</div>
+        </div>
+
+        <div class="profile">
+          <div class="name">Tad Fifer</div>
+          <div class="title">Communications Manager</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds the following names to the about page on AggieMap:

- Tad Fifer: Communications Manager

- Chelsey Cooke:
Assistant Director, Enterprise Channels

- Josh Nuckolls:
Communications Specialist II

<img width="1295" height="1214" alt="image" src="https://github.com/user-attachments/assets/310b3819-7b43-4f10-8063-28772444d351" />

Closes #720 