### PR TITLE
fix(aggiemap-angular): Add map controls to all event maps

### DIFF
--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -24,7 +24,10 @@
 <ng-container *ngIf="(config | async) as c">
   <tamu-gisc-esri-map [config]="c" (loaded)="continue($event)" [ngClass]="{ mobile: isMobile }">
     <div class="map-overlay-ui">
-      <div class="overlay-zone top left"></div>
+      <div class="overlay-zone top left">
+        <a class="all-maps-button esri-component esri-widget" routerLink="/discover" aria-label="Open All Maps">ALL MAPS</a>
+        <tamu-gisc-perspective-toggle [threeDLayers]="threeDLayers"></tamu-gisc-perspective-toggle>
+      </div>
 
       <div class="overlay-zone bottom right">
         <div *ngIf="hasSettings" class="esri-component esri-track esri-widget--button esri-widget" role="button" alt="URL Share" clipboard-copy [text]="shareUrl"><span class="material-icons" (click)="notifyUrlCopy()">share</span></div>

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,50 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+::ng-deep .map-overlay-ui {
+  z-index: 2;
+}
+
+.map-overlay-ui .overlay-zone.top.left {
+  @include flexbox();
+  @include align-items(flex-start);
+  gap: 0.5rem;
+}
+
+.all-maps-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 0.85rem;
+  border: 1px solid rgb(50 50 50 / 25%);
+  border-radius: 3px;
+  background: #500000;
+  color: #fff;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 30%);
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.all-maps-button:hover,
+.all-maps-button:focus {
+  background: #3d0000;
+  color: #fff;
+  text-decoration: none;
+}
+
+.all-maps-button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+@media only screen and (max-width: 768px) {
+  .map-overlay-ui .overlay-zone.top.left {
+    left: 1rem;
+    top: 4.25rem;
+  }
+}

--- a/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.module.ts
@@ -43,6 +43,7 @@ import { MapPopupModule, PopupMobileComponent } from '@tamu-gisc/maps/feature/po
 import { UIClipboardModule } from '@tamu-gisc/ui-kits/ngx/interactions/clipboard';
 import { MapsFeatureCoordinatesModule } from '@tamu-gisc/maps/feature/coordinates';
 import { MapsFeatureAccessibilityModule } from '@tamu-gisc/maps/feature/accessibility';
+import { MapsFeaturePerspectiveModule } from '@tamu-gisc/maps/feature/perspective';
 import { BasemapGalleryComponent } from '@tamu-gisc/maps/feature/basemap';
 
 import { MoveInOutSidebarModule } from '../sidebar/sidebar.module';
@@ -129,6 +130,7 @@ const routes: Routes = [
     EsriMapModule,
     MapsFeatureCoordinatesModule,
     MapsFeatureAccessibilityModule,
+    MapsFeaturePerspectiveModule,
     SearchModule,
     AggiemapNgxSharedUiStructuralModule,
     AggiemapFormsModule,


### PR DESCRIPTION
This PR adds the "All Maps" button and 2D/3D toggle to all maps, not just the main homepage map.

<img width="2526" height="1223" alt="image" src="https://github.com/user-attachments/assets/fdd1e1c6-3336-4667-b783-a1b6be0cf47f" />

Closes #746 