### PR TITLE
fix(aggiemap-angular): Fix legend icon visibilty for Gate/Road Closures layer on Baseball map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -66,8 +66,7 @@ export const BaseballParkingColdLayerSources: LayerSource[] = [
     url: `${eventUrl}/2`,
     popupComponent: MarkdownPopupComponent,
     native: {
-      outFields: ['*'],
-      definitionExpression: `Baseball = 1`
+      outFields: ['*']
     }
   },
   {


### PR DESCRIPTION
This PR fixes an issue where the Gate/Road Closure layer would not show an icon on the Baseball map legend.

Works on both Baseball and Accessibility maps.

<img width="1419" height="1171" alt="image" src="https://github.com/user-attachments/assets/10ccee5f-218c-4c77-9e54-a3b1403bd6f1" />

Closes #751 