### PR TITLE
feat(aggiemap-angular): Re-added EV Charger layers to other maps, made standalone EV map

### DIFF
--- a/libs/aggiemap/ngx/common/src/index.ts
+++ b/libs/aggiemap/ngx/common/src/index.ts
@@ -1,5 +1,5 @@
-// // Web GIS resource endpoints
-// export * from './lib/connections';
+// Web GIS resource endpoints
+export * from './lib/connections';
 
 // // Dictionary of map layer definitions
 // export * from './lib/definitions';

--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -7,6 +7,7 @@ export function Connections(gisHost: string) {
     departmentUrl: `https://${gisHost}/arcgis/rest/services/FCOR/DepartmentSearch/MapServer/1`,
     tsMainUrl: `https://${gisHost}/arcgis/rest/services/TS/TS_Main/MapServer`,
     bikeRacksUrl: `https://${gisHost}/arcgis/rest/services/TS/TS_Bicycles/MapServer/3`,
+    bikeMapUrl: `https://${gisHost}/arcgis/rest/services/TS/BikeMap/MapServer`,
     bikeLocationsUrl: `https://veoride.geoservices.tamu.edu/api/vehicles/basic/geojson`,
     routingBaseUrl: `https://${gisHost}/arcgis/rest/services/Routing`,
     poiUrl: 'https://services1.arcgis.com/oxXAea6csqnDZ6WT/arcgis/rest/services/Points_of_Interest_view/FeatureServer',
@@ -22,6 +23,7 @@ export interface IComposedConnections {
   departmentUrl: string;
   tsMainUrl: string;
   bikeRacksUrl: string;
+  bikeMapUrl: string;
   bikeLocationsUrl: string;
   poiUrl: string;
   diningLocationsUrl: string;

--- a/libs/aggiemap/ngx/common/src/lib/definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions.ts
@@ -105,6 +105,48 @@ export function Definitions(Connections: IComposedConnections): IComposedIDefini
       name: 'Single Occupancy Restroom Locations',
       url: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer/1',
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
+    },
+    BIKE_DISMOUNT_ZONES: {
+      id: 'bike-dismount-zones',
+      layerId: 'bike-dismount-zones-layer',
+      name: 'Dismount Zones',
+      url: `${Connections.bikeMapUrl}/5`,
+      popupComponent: Popups.MarkdownPopupComponent
+    },
+    CITY_BIKE_LANES_ROUTES: {
+      id: 'city-bike-lanes-routes',
+      layerId: 'city-bike-lanes-routes-layer',
+      name: 'City Bike Lanes and Routes',
+      url: `${Connections.bikeMapUrl}/4`,
+      popupComponent: Popups.MarkdownPopupComponent
+    },
+    CAMPUS_BIKE_LANES: {
+      id: 'campus-bike-lanes',
+      layerId: 'bike-lanes-layer',
+      name: 'Campus Bike Lanes',
+      url: `${Connections.bikeMapUrl}/3`,
+      popupComponent: Popups.MarkdownPopupComponent
+    },
+    BIKE_FIX_STATIONS: {
+      id: 'bike-fix-stations',
+      layerId: 'bike-fix-stations-layer',
+      name: 'Bike Fix Stations',
+      url: `${Connections.bikeMapUrl}/2`,
+      popupComponent: Popups.MarkdownPopupComponent
+    },
+    BIKE_RACKS_MAP: {
+      id: 'bike-racks-map',
+      layerId: 'bike-racks-map-layer',
+      name: 'Bike Racks',
+      url: `${Connections.bikeMapUrl}/1`,
+      popupComponent: Popups.MarkdownPopupComponent
+    },
+    EV_CHARGE_STATIONS: {
+      id: 'ev-charge-stations',
+      layerId: 'ev-charge-stations-layer',
+      name: 'EV Charge Stations (Main + RELLIS)',
+      url: `${Connections.bikeMapUrl}/0`,
+      popupComponent: Popups.MarkdownPopupComponent
     }
   };
 }
@@ -133,4 +175,10 @@ export interface IComposedIDefinitions {
   DINING_LOCATIONS: IDefinition;
   AGGIEPRINT_LOCATIONS: IDefinition;
   SINGLE_OCCUPANCY_RESTROOMS: IDefinition;
+  BIKE_DISMOUNT_ZONES: IDefinition;
+  CITY_BIKE_LANES_ROUTES: IDefinition;
+  CAMPUS_BIKE_LANES: IDefinition;
+  BIKE_FIX_STATIONS: IDefinition;
+  BIKE_RACKS_MAP: IDefinition;
+  EV_CHARGE_STATIONS: IDefinition;
 }

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -22,6 +22,26 @@ export function LayerSources(
   options?: IFactoryExcludeOptions<IComposedIDefinitions>
 ): Array<LayerSource> {
   const bikeMapUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+  const bikeMapEvChargeStationsLayerSource: LayerSource = {
+    type: 'feature',
+    id: 'ev-charge-stations-layer',
+    title: 'EV Charge Stations (Main + RELLIS)',
+    url: `${bikeMapUrl}/0`,
+    listMode: 'show',
+    visible: true,
+    popupComponent: Popups.MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.EV_ID}',
+      description:
+        '<strong>Network</strong>: {attributes.EV_Network}\n' +
+        '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+        '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+        '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+    },
+    native: {
+      ...commonLayerProps
+    }
+  };
   const all: Array<LayerSource> = [
     {
       type: 'feature',
@@ -309,26 +329,7 @@ export function LayerSources(
             ...commonLayerProps
           }
         },
-        {
-          type: 'feature',
-          id: 'ev-charge-stations-layer',
-          title: 'EV Charge Stations (Main + RELLIS)',
-          url: `${bikeMapUrl}/0`,
-          listMode: 'show',
-          visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
-          popupData: {
-            name: '{attributes.EV_ID}',
-            description:
-              '<strong>Network</strong>: {attributes.EV_Network}\n' +
-              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-          },
-          native: {
-            ...commonLayerProps
-          }
-        }
+        bikeMapEvChargeStationsLayerSource
       ],
       native: {
         listMode: 'hide-children'

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -1,5 +1,4 @@
 import { LayerSource } from '@tamu-gisc/common/types';
-import { Popups } from '@tamu-gisc/aggiemap/ngx/popups';
 
 import { IComposedIDefinitions } from '../definitions';
 import { IComposedConnections } from '../connections';
@@ -21,27 +20,6 @@ export function LayerSources(
   definitions: IComposedIDefinitions,
   options?: IFactoryExcludeOptions<IComposedIDefinitions>
 ): Array<LayerSource> {
-  const bikeMapUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
-  const bikeMapEvChargeStationsLayerSource: LayerSource = {
-    type: 'feature',
-    id: 'sustainable-transportation-ev-charge-stations-layer',
-    title: 'EV Charge Stations (Main + RELLIS)',
-    url: `${bikeMapUrl}/0`,
-    listMode: 'show',
-    visible: true,
-    popupComponent: Popups.MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.EV_ID}',
-      description:
-        '<strong>Network</strong>: {attributes.EV_Network}\n' +
-        '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-        '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-        '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-    },
-    native: {
-      ...commonLayerProps
-    }
-  };
   const all: Array<LayerSource> = [
     {
       type: 'feature',
@@ -241,26 +219,6 @@ export function LayerSources(
       }
     },
     {
-      type: 'feature',
-      id: 'ev-charge-stations-layer',
-      title: 'EV Charge Stations (Main + RELLIS)',
-      url: `${bikeMapUrl}/0`,
-      listMode: 'show',
-      visible: false,
-      popupComponent: Popups.MarkdownPopupComponent,
-      popupData: {
-        name: '{attributes.EV_ID}',
-        description:
-          '<strong>Network</strong>: {attributes.EV_Network}\n' +
-          '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-          '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-          '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-      },
-      native: {
-        ...commonLayerProps
-      }
-    },
-    {
       type: 'group',
       id: 'sustainable-transportation-group-layer',
       title: 'Sustainable Transportation',
@@ -269,12 +227,12 @@ export function LayerSources(
       sources: [
         {
           type: 'feature',
-          id: 'bike-dismount-zones-layer',
-          title: 'Dismount Zones',
-          url: `${bikeMapUrl}/5`,
+          id: definitions.BIKE_DISMOUNT_ZONES.layerId,
+          title: definitions.BIKE_DISMOUNT_ZONES.name,
+          url: definitions.BIKE_DISMOUNT_ZONES.url,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
+          popupComponent: definitions.BIKE_DISMOUNT_ZONES.popupComponent,
           popupData: {
             name: '{attributes.Name}',
             description: '<strong>Notes</strong>: {attributes.Bike_Notes}'
@@ -285,12 +243,12 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'city-bike-lanes-routes-layer',
-          title: 'City Bike Lanes and Routes',
-          url: `${bikeMapUrl}/4`,
+          id: definitions.CITY_BIKE_LANES_ROUTES.layerId,
+          title: definitions.CITY_BIKE_LANES_ROUTES.name,
+          url: definitions.CITY_BIKE_LANES_ROUTES.url,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
+          popupComponent: definitions.CITY_BIKE_LANES_ROUTES.popupComponent,
           popupData: {
             name: '{attributes.Type}',
             description: '<strong>Location</strong>: {attributes.Loc}'
@@ -301,12 +259,12 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-lanes-layer',
-          title: 'Campus Bike Lanes',
-          url: `${bikeMapUrl}/3`,
+          id: definitions.CAMPUS_BIKE_LANES.layerId,
+          title: definitions.CAMPUS_BIKE_LANES.name,
+          url: definitions.CAMPUS_BIKE_LANES.url,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
+          popupComponent: definitions.CAMPUS_BIKE_LANES.popupComponent,
           popupData: {
             name: '{attributes.Use_}',
             description: '<strong>Location</strong>: {attributes.Location}'
@@ -317,12 +275,12 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-fix-stations-layer',
-          title: 'Bike Fix Stations',
-          url: `${bikeMapUrl}/2`,
+          id: definitions.BIKE_FIX_STATIONS.layerId,
+          title: definitions.BIKE_FIX_STATIONS.name,
+          url: definitions.BIKE_FIX_STATIONS.url,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
+          popupComponent: definitions.BIKE_FIX_STATIONS.popupComponent,
           popupData: {
             name: '{attributes.Bike_Sta_Name}',
             description: '<strong>Amenities</strong>: {attributes.Bike_Amenities}'
@@ -333,12 +291,12 @@ export function LayerSources(
         },
         {
           type: 'feature',
-          id: 'bike-racks-map-layer',
-          title: 'Bike Racks',
-          url: `${bikeMapUrl}/1`,
+          id: definitions.BIKE_RACKS_MAP.layerId,
+          title: definitions.BIKE_RACKS_MAP.name,
+          url: definitions.BIKE_RACKS_MAP.url,
           listMode: 'show',
           visible: true,
-          popupComponent: Popups.MarkdownPopupComponent,
+          popupComponent: definitions.BIKE_RACKS_MAP.popupComponent,
           popupData: {
             name: '{attributes.Type}',
             description:
@@ -349,7 +307,26 @@ export function LayerSources(
             ...commonLayerProps
           }
         },
-        bikeMapEvChargeStationsLayerSource
+        {
+          type: 'feature',
+          id: definitions.EV_CHARGE_STATIONS.layerId,
+          title: definitions.EV_CHARGE_STATIONS.name,
+          url: definitions.EV_CHARGE_STATIONS.url,
+          listMode: 'show',
+          visible: true,
+          popupComponent: definitions.EV_CHARGE_STATIONS.popupComponent,
+          popupData: {
+            name: '{attributes.EV_ID}',
+            description:
+              '<strong>Network</strong>: {attributes.EV_Network}\n' +
+              '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+              '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+              '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+          },
+          native: {
+            ...commonLayerProps
+          }
+        }
       ],
       native: {
         listMode: 'hide-children'

--- a/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/layer-sources/layer-sources.ts
@@ -24,7 +24,7 @@ export function LayerSources(
   const bikeMapUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
   const bikeMapEvChargeStationsLayerSource: LayerSource = {
     type: 'feature',
-    id: 'ev-charge-stations-layer',
+    id: 'sustainable-transportation-ev-charge-stations-layer',
     title: 'EV Charge Stations (Main + RELLIS)',
     url: `${bikeMapUrl}/0`,
     listMode: 'show',
@@ -238,6 +238,26 @@ export function LayerSources(
             color: '#03C4A6'
           }
         }
+      }
+    },
+    {
+      type: 'feature',
+      id: 'ev-charge-stations-layer',
+      title: 'EV Charge Stations (Main + RELLIS)',
+      url: `${bikeMapUrl}/0`,
+      listMode: 'show',
+      visible: false,
+      popupComponent: Popups.MarkdownPopupComponent,
+      popupData: {
+        name: '{attributes.EV_ID}',
+        description:
+          '<strong>Network</strong>: {attributes.EV_Network}\n' +
+          '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+          '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+          '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+      },
+      native: {
+        ...commonLayerProps
       }
     },
     {

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -50,6 +50,7 @@ import { AVPParkingTs } from './avp-parking.definitions';
 import { NscParkingTs } from './nsc-parking.definitions';
 import { BreakSummerParkingTs } from './break-summer.definitions';
 import { SustainableTransportationTs } from './sustainable-transportation.definitions';
+import { EvChargersTs } from './ev-chargers.definitions';
 import { TsMainParkingTs } from './main-parking.definitions';
 import { SecGroundsConferenceTs } from './sec-grounds-conference.definitions';
 
@@ -105,6 +106,7 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   NscParkingTs,
   BreakSummerParkingTs,
   SustainableTransportationTs,
+  EvChargersTs,
   TsMainParkingTs,
   SecGroundsConferenceTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
@@ -1,0 +1,75 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
+
+export enum EV_CHARGERS_LAYERS {
+  EV_CHARGERS = 'ev-chargers'
+}
+
+const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+
+export const EvChargersDefinitions = {
+  EV_CHARGERS: {
+    id: EV_CHARGERS_LAYERS.EV_CHARGERS,
+    layerId: EV_CHARGERS_LAYERS.EV_CHARGERS,
+    name: 'EV Charge Stations (Main + RELLIS)',
+    url: `${bikeLayersUrl}/0`
+  }
+};
+
+export const EvChargersColdLayerSources: LayerSource[] = [
+  {
+    type: 'feature',
+    id: EvChargersDefinitions.EV_CHARGERS.id,
+    title: EvChargersDefinitions.EV_CHARGERS.name,
+    url: EvChargersDefinitions.EV_CHARGERS.url,
+    visible: true,
+    listMode: 'show',
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.EV_ID}',
+      description:
+        '<strong>Network</strong>: {attributes.EV_Network}\n' +
+        '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+        '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+        '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+    },
+    native: {
+      outFields: ['*']
+    }
+  }
+];
+
+export const EvChargersConfiguration: EventConfiguration = {
+  id: 'ev-chargers',
+  name: 'EV Chargers',
+  applicationName: 'EV Chargers Map',
+  shortApplicationName: 'EV Chargers',
+  introductionText: 'Locate EV charge stations across Main Campus and the RELLIS Campus.',
+  mapCenter: [-96.34643, 30.61313],
+  eventDates: [],
+  zoom: 15
+};
+
+export const EvChargersOptions: SpecialEventOptions = [];
+
+export const EvChargersTs: AggiemapCustomMapConfiguration = {
+  configuration: EvChargersConfiguration,
+  options: EvChargersOptions,
+  sources: EvChargersColdLayerSources,
+  references: EV_CHARGERS_LAYERS,
+  type: 'general-map',
+  discover: {
+    id: EvChargersConfiguration.id,
+    name: EvChargersConfiguration.name,
+    description: 'EV charging locations for Main Campus and the RELLIS Campus.',
+    source: 'internal',
+    type: 'parking',
+    keywords: ['ev', 'ev chargers', 'electric vehicle', 'charging', 'sustainable transportation', 'rellis']
+  }
+};

--- a/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -11,7 +12,7 @@ export enum EV_CHARGERS_LAYERS {
   EV_CHARGERS = 'ev-chargers'
 }
 
-const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+const bikeLayersUrl = Connections('gis.it.tamu.edu').bikeMapUrl;
 
 export const EvChargersDefinitions = {
   EV_CHARGERS: {

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -1,4 +1,6 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
+
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
 import {
@@ -16,7 +18,7 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
-const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
+const bikeLayersUrl = Connections('gis.it.tamu.edu').bikeMapUrl;
 
 export const SustainableTransportationEvChargersLayerSource: LayerSource = {
   type: 'feature',

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -18,6 +18,27 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
 
 const bikeLayersUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
 
+export const SustainableTransportationEvChargersLayerSource: LayerSource = {
+  type: 'feature',
+  id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
+  title: 'EV Charge Stations (Main + RELLIS)',
+  url: `${bikeLayersUrl}/0`,
+  visible: true,
+  listMode: 'show',
+  popupComponent: MarkdownPopupComponent,
+  popupData: {
+    name: '{attributes.EV_ID}',
+    description:
+      '<strong>Network</strong>: {attributes.EV_Network}\n' +
+      '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
+      '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
+      '<strong>Notes</strong>: {attributes.EVCS_Notes}'
+  },
+  native: {
+    outFields: ['*']
+  }
+};
+
 export const SustainableTransportationDefinitions = {
   EV_CHARGERS: {
     id: SUSTAINABLE_TRANSPORTATION_LAYERS.EV_CHARGERS,
@@ -58,26 +79,7 @@ export const SustainableTransportationDefinitions = {
 };
 
 export const SustainableTransportationColdLayerSources: LayerSource[] = [
-  {
-    type: 'feature',
-    id: SustainableTransportationDefinitions.EV_CHARGERS.id,
-    title: SustainableTransportationDefinitions.EV_CHARGERS.name,
-    url: SustainableTransportationDefinitions.EV_CHARGERS.url,
-    visible: true,
-    listMode: 'show',
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.EV_ID}',
-      description:
-        '<strong>Network</strong>: {attributes.EV_Network}\n' +
-        '<strong>Charging Level</strong>: {attributes.Ch_Level}\n' +
-        '<strong>Garage Level</strong>: {attributes.Garage_Lvl}\n' +
-        '<strong>Notes</strong>: {attributes.EVCS_Notes}'
-    },
-    native: {
-      outFields: ['*']
-    }
-  },
+  SustainableTransportationEvChargersLayerSource,
   {
     type: 'feature',
     id: SustainableTransportationDefinitions.BIKE_RACKS.id,


### PR DESCRIPTION
This PR re-adds the EV Charger layer to the Sustainable Transporation map and the main layers on the homepage. This PR also creates an independent EV Chargers map.

<img width="1771" height="1111" alt="image" src="https://github.com/user-attachments/assets/8de04296-3ef5-4a8b-a220-525f1e591cd0" />


<img width="1809" height="971" alt="image" src="https://github.com/user-attachments/assets/c484062e-e5d8-4c86-94b2-fcfcab235339" />


<img width="1275" height="972" alt="image" src="https://github.com/user-attachments/assets/f755cc73-cfba-43a8-a3d1-3939ebee64db" />


Closes #752 