### PR TITLE
feat(aggiemap-angular): Link functionality improvements for Discover Page and AggieMap Sharing

### DIFF
--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.spec.ts
@@ -23,6 +23,8 @@ describe('DiscoverComponent', () => {
   ];
 
   beforeEach(async () => {
+    window.history.replaceState(window.history.state, '', '/discover');
+
     await TestBed.configureTestingModule({
       imports: [CommonModule, ReactiveFormsModule, RouterTestingModule],
       declarations: [DiscoverComponent],
@@ -50,6 +52,11 @@ describe('DiscoverComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    fixture.destroy();
+    window.history.replaceState(window.history.state, '', '/discover');
+  });
+
   it('renders the parking tab by default and switches the visible panel on click', () => {
     const nativeElement = fixture.nativeElement as HTMLElement;
     const tabButtons = Array.from(nativeElement.querySelectorAll<HTMLButtonElement>('.discover-tab'));
@@ -70,6 +77,29 @@ describe('DiscoverComponent', () => {
     expect(getPanelHeading()).toBe('Campus Events');
     expect(getPanelText()).toContain('Move In');
     expect(getPanelText()).not.toContain('Accessible Parking');
+    expect(window.location.hash).toBe('#discover-tab-campus');
+  });
+
+  it('opens the requested tab from the discover tab hash', () => {
+    fixture.destroy();
+    window.history.replaceState(window.history.state, '', '/discover#discover-tab-athletics');
+
+    fixture = TestBed.createComponent(DiscoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.activeTab).toBe('athletics');
+    expect(getPanelHeading()).toBe('Athletic Events');
+    expect(getPanelText()).toContain('Football Parking');
+  });
+
+  it('updates the visible panel when the hash changes after load', () => {
+    window.history.replaceState(window.history.state, '', '/discover#discover-tab-athletics');
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    fixture.detectChanges();
+
+    expect(component.activeTab).toBe('athletics');
+    expect(getPanelHeading()).toBe('Athletic Events');
   });
 
   function getPanelHeading() {

--- a/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/components/discover.component.ts
@@ -1,5 +1,5 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { combineLatest, Observable } from 'rxjs';
 import { debounceTime, map, shareReplay, startWith } from 'rxjs/operators';
@@ -24,7 +24,7 @@ interface DiscoverTab {
   templateUrl: './discover.component.html',
   styleUrls: ['./discover.component.scss']
 })
-export class DiscoverComponent implements OnInit {
+export class DiscoverComponent implements OnInit, OnDestroy {
   public readonly discoverTabs: ReadonlyArray<DiscoverTab> = [
     { id: 'parking', label: 'Parking Maps' },
     { id: 'campus', label: 'Campus Events' },
@@ -54,6 +54,8 @@ export class DiscoverComponent implements OnInit {
   public searchControl = new FormControl();
   public filteredApplications: Observable<DiscoverApplication[]>;
   public isDev: Observable<boolean>;
+  private readonly validTabIds = new Set(this.discoverTabs.map((tab) => tab.id));
+  private readonly hashChangeHandler = () => this.syncActiveTabWithHash();
 
   constructor(
     private readonly rt: Router,
@@ -92,6 +94,13 @@ export class DiscoverComponent implements OnInit {
     const allEvents = this.sortEventApplications([...campusApplications, ...athleticApplications]);
     this.allEventsColumns = this.buildApplicationColumns(allEvents);
     this.allEventsColumnStart = this.getSecondColumnStart(this.allEventsColumns);
+
+    this.syncActiveTabWithHash();
+    window.addEventListener('hashchange', this.hashChangeHandler);
+  }
+
+  public ngOnDestroy(): void {
+    window.removeEventListener('hashchange', this.hashChangeHandler);
   }
 
   private getApplicationsByMapType(mapType: DiscoverMapType): InternalDiscoverApplication[] {
@@ -215,6 +224,7 @@ export class DiscoverComponent implements OnInit {
 
   public setActiveTab(tab: DiscoverMapType): void {
     this.activeTab = tab;
+    this.updateHash(tab);
   }
 
   public getEventDateRange(dates: Array<string | Date | number>): string {
@@ -231,5 +241,37 @@ export class DiscoverComponent implements OnInit {
     }
 
     return `${startDate.toLocaleDateString()} - ${endDate.toLocaleDateString()}`;
+  }
+
+  private syncActiveTabWithHash(): void {
+    const tab = this.parseTabFromHash(window.location.hash);
+
+    if (tab) {
+      this.activeTab = tab;
+    }
+  }
+
+  private parseTabFromHash(hash: string): DiscoverMapType | undefined {
+    const normalizedHash = hash.replace(/^#/, '').trim().toLowerCase();
+
+    if (!normalizedHash) {
+      return undefined;
+    }
+
+    const candidate = normalizedHash
+      .replace(/^discover-tab-/, '')
+      .replace(/^discover-panel-/, '') as DiscoverMapType;
+
+    return this.validTabIds.has(candidate) ? candidate : undefined;
+  }
+
+  private updateHash(tab: DiscoverMapType): void {
+    const nextHash = `#discover-tab-${tab}`;
+
+    if (window.location.hash === nextHash) {
+      return;
+    }
+
+    window.history.replaceState(window.history.state, '', `${window.location.pathname}${window.location.search}${nextHash}`);
   }
 }

--- a/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.spec.ts
+++ b/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.spec.ts
@@ -8,12 +8,17 @@ import { EventSettingsService } from '../../services/settings/event-settings.ser
 describe('EventEntryGuard', () => {
   let guard: EventEntryGuard;
   let router: Router;
-  let eventSettingsService: { validateEventQueryParams: jest.Mock; hasOptions: boolean };
+  let eventSettingsService: {
+    validateEventQueryParams: jest.Mock;
+    hasOptions: boolean;
+    hasFeatureSelectionQueryParams: jest.Mock;
+  };
 
   beforeEach(() => {
     eventSettingsService = {
       validateEventQueryParams: jest.fn(),
-      hasOptions: false
+      hasOptions: false,
+      hasFeatureSelectionQueryParams: jest.fn().mockReturnValue(false)
     };
 
     TestBed.configureTestingModule({
@@ -44,7 +49,7 @@ describe('EventEntryGuard', () => {
     expect(router.serializeUrl(result)).toBe('/parking/avp-parking/map?foo=bar#legend');
   });
 
-  it('should redirect configurable events to the builder intro', () => {
+  it('should redirect configurable events to the builder accommodations route', () => {
     eventSettingsService.hasOptions = true;
 
     const route = {
@@ -61,7 +66,29 @@ describe('EventEntryGuard', () => {
 
     const result = guard.canActivate(route, state) as UrlTree;
 
-    expect(router.serializeUrl(result)).toBe('/parking/baseball-parking/builder/intro');
+    expect(router.serializeUrl(result)).toBe('/parking/baseball-parking/builder/accommodations');
+  });
+
+  it('should route configurable events with feature deep links directly to the map', () => {
+    eventSettingsService.hasOptions = true;
+    eventSettingsService.hasFeatureSelectionQueryParams.mockReturnValue(true);
+
+    const route = {
+      pathFromRoot: [
+        { url: [] },
+        { url: [new UrlSegment('events', {})] },
+        { url: [new UrlSegment('gameday-parking', {})] }
+      ],
+      queryParams: { lot: '43' },
+      fragment: null
+    } as unknown as ActivatedRouteSnapshot;
+
+    const state = { url: '/events/gameday-parking' } as RouterStateSnapshot;
+
+    const result = guard.canActivate(route, state) as UrlTree;
+
+    expect(eventSettingsService.hasFeatureSelectionQueryParams).toHaveBeenCalledWith(route.queryParams);
+    expect(router.serializeUrl(result)).toBe('/events/gameday-parking/map?lot=43');
   });
 
   it('should allow direct child routes to load normally', () => {

--- a/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
+++ b/libs/ts/events/ngx/src/lib/guards/event-entry/event-entry.guard.ts
@@ -26,7 +26,10 @@ export class EventEntryGuard implements CanActivate {
       return true;
     }
 
-    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'accommodations'] : ['map'];
+    const targetCommands =
+      this.eventSettingsService.hasOptions && !this.eventSettingsService.hasFeatureSelectionQueryParams(route.queryParams)
+        ? ['builder', 'accommodations']
+        : ['map'];
 
     return this.router.createUrlTree(['/', ...eventPath, ...targetCommands], {
       queryParams: route.queryParams,

--- a/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.spec.ts
+++ b/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.spec.ts
@@ -7,7 +7,11 @@ import { EventSettingsService } from '../../services/settings/event-settings.ser
 describe('EntryRedirectComponent', () => {
   let component: EntryRedirectComponent;
   let router: { navigate: jest.Mock };
-  let eventSettingsService: { validateEventQueryParams: jest.Mock; hasOptions: boolean };
+  let eventSettingsService: {
+    validateEventQueryParams: jest.Mock;
+    hasOptions: boolean;
+    hasFeatureSelectionQueryParams: jest.Mock;
+  };
   let route: ActivatedRoute;
 
   beforeEach(() => {
@@ -17,7 +21,8 @@ describe('EntryRedirectComponent', () => {
 
     eventSettingsService = {
       validateEventQueryParams: jest.fn(),
-      hasOptions: false
+      hasOptions: false,
+      hasFeatureSelectionQueryParams: jest.fn().mockReturnValue(false)
     };
 
     route = {
@@ -52,12 +57,28 @@ describe('EntryRedirectComponent', () => {
     });
   });
 
-  it('should keep configurable events on the builder intro route', () => {
+  it('should keep configurable events on the builder accommodations route', () => {
     eventSettingsService.hasOptions = true;
 
     component.ngOnInit();
 
-    expect(router.navigate).toHaveBeenCalledWith(['builder', 'intro'], {
+    expect(router.navigate).toHaveBeenCalledWith(['builder', 'accommodations'], {
+      relativeTo: route.parent,
+      queryParams: route.snapshot.queryParams,
+      fragment: 'legend',
+      replaceUrl: true
+    });
+  });
+
+  it('should open the map when configurable events include a feature deep link', () => {
+    eventSettingsService.hasOptions = true;
+    eventSettingsService.hasFeatureSelectionQueryParams.mockReturnValue(true);
+    route.snapshot.queryParams = { lot: '43' } as unknown as ActivatedRouteSnapshot['queryParams'];
+
+    component.ngOnInit();
+
+    expect(eventSettingsService.hasFeatureSelectionQueryParams).toHaveBeenCalledWith(route.snapshot.queryParams);
+    expect(router.navigate).toHaveBeenCalledWith(['map'], {
       relativeTo: route.parent,
       queryParams: route.snapshot.queryParams,
       fragment: 'legend',

--- a/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/entry-redirect/entry-redirect.component.ts
@@ -18,7 +18,11 @@ export class EntryRedirectComponent implements OnInit {
     this.eventSettingsService.validateEventQueryParams(this.route.snapshot, true);
 
     // Maps without configurable options should open directly to the map instead of showing an intro-only builder.
-    const targetCommands = this.eventSettingsService.hasOptions ? ['builder', 'accommodations'] : ['map'];
+    const targetCommands =
+      this.eventSettingsService.hasOptions &&
+      !this.eventSettingsService.hasFeatureSelectionQueryParams(this.route.snapshot.queryParams)
+        ? ['builder', 'accommodations']
+        : ['map'];
 
     this.router.navigate(targetCommands, {
       relativeTo: this.route.parent ?? this.route,

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.ts
@@ -76,7 +76,11 @@ export class MapComponent implements OnInit, OnDestroy {
     const root = this.eventsSettingsService.eventConfiguration();
 
     // If the current event has options but none are set, redirect to the builder
-    if (this.hasOptions === true && this.hasSettings === false) {
+    if (
+      this.hasOptions === true &&
+      this.hasSettings === false &&
+      !this.eventsSettingsService.hasFeatureSelectionQueryParams(this.ar.snapshot.queryParams)
+    ) {
       this.rt.navigate(['builder'], { relativeTo: this.ar.parent?.parent });
       return;
     }

--- a/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
@@ -5,6 +5,7 @@ import { Observable, of } from 'rxjs';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 import { LocalStoreService } from '@tamu-gisc/common/ngx/local-store';
 import { LayerSource } from '@tamu-gisc/common/types';
+import { SearchSource } from '@tamu-gisc/ui-kits/ngx/search';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -419,5 +420,41 @@ export class EventSettingsService {
     } else {
       return false;
     }
+  }
+
+  /**
+   * Returns true when the provided query params include a supported feature deep-link
+   * such as `?lot=43`, allowing maps to open directly without builder selections.
+   */
+  public hasFeatureSelectionQueryParams(params?: Params): boolean {
+    const queryParams = params ?? this.at.snapshot.queryParams;
+
+    if (!queryParams) {
+      return false;
+    }
+
+    const searchSources = this.env.value('SearchSources') as SearchSource[] | null | undefined;
+
+    if (!Array.isArray(searchSources)) {
+      return false;
+    }
+
+    return searchSources.some((searchSource) => {
+      if (!searchSource.urlQueryParam) {
+        return false;
+      }
+
+      const parameterKeys = [searchSource.urlQueryParam, ...(searchSource.urlQueryParamAliases || [])];
+
+      return parameterKeys.some((key) => {
+        const value = queryParams[key];
+
+        if (Array.isArray(value)) {
+          return value.some((entry) => `${entry}`.trim().length > 0);
+        }
+
+        return value !== undefined && value !== null && `${value}`.trim().length > 0;
+      });
+    });
   }
 }


### PR DESCRIPTION
This PR adds new link functionality for both the discover page and AggieMap sharing as a whole.

## Details

For Discover:
- the selected tab is now reflected in the URL hash
- loading a Discover URL with a tab hash opens the correct panel
- changing the hash after load updates the visible tab

For sharing:
- the entry guard now checks whether an event actually has configurable options before redirecting
- feature-selection query params can bypass the builder and open the map directly
- existing child routes continue to load normally without being re-routed


## Examples:

https://aggiemap.tamu.edu/discover#discover-tab-campus will open this:

<img width="1338" height="1057" alt="image" src="https://github.com/user-attachments/assets/629d3c1b-59b7-4262-b34b-95660ac3e622" />

instead of just sending the user to the discover page.

https://aggiemap.tamu.edu/events/gameday-parking/map/d?lot=43 goes to this:

<img width="1961" height="1041" alt="image" src="https://github.com/user-attachments/assets/2f56da36-9fb6-4a5c-8736-f2026c1cfb10" />

Instead of opening the gameday builder and then not auto-selecting Lot 43.

Closes #754 
Closes #756