### PR TITLE
fix(aggiemap-angular) Fix broken copied parking lot names on AggieMap

### DIFF
--- a/libs/aggiemap/ngx/popups/src/lib/components/parking-lot/parking-lot.component.spec.ts
+++ b/libs/aggiemap/ngx/popups/src/lib/components/parking-lot/parking-lot.component.spec.ts
@@ -1,0 +1,108 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { Angulartics2 } from 'angulartics2';
+
+import { EsriMapService } from '@tamu-gisc/maps/esri';
+import { TripPlannerService } from '@tamu-gisc/maps/feature/trip-planner';
+import { SearchService } from '@tamu-gisc/ui-kits/ngx/search';
+
+import { ParkingLotPopupComponent } from './parking-lot.component';
+
+describe('ParkingLotPopupComponent', () => {
+  let component: ParkingLotPopupComponent;
+  let fixture: ComponentFixture<ParkingLotPopupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ParkingLotPopupComponent],
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            navigate: jest.fn()
+          }
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {}
+        },
+        {
+          provide: TripPlannerService,
+          useValue: {
+            Stops: of([]),
+            setStops: jest.fn()
+          }
+        },
+        {
+          provide: Angulartics2,
+          useValue: {
+            eventTrack: {
+              next: jest.fn()
+            }
+          }
+        },
+        {
+          provide: EsriMapService,
+          useValue: {
+            clearHitTest: jest.fn()
+          }
+        },
+        {
+          provide: SearchService,
+          useValue: {
+            getSource: jest.fn().mockReturnValue({
+              urlQueryParam: 'lot'
+            })
+          }
+        }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ParkingLotPopupComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    component.data = {
+      attributes: {
+        Name: '100'
+      }
+    } as unknown as __esri.Graphic;
+
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  it('should prefer LotName when Name is null for copied share urls', () => {
+    component.data = {
+      attributes: {
+        Name: null,
+        LotName: 'Post Office Lot'
+      }
+    } as unknown as __esri.Graphic;
+
+    fixture.detectChanges();
+
+    expect(component.shareUrl).toBe('http://localhost/?lot=Post Office Lot');
+  });
+
+  it('should fall back to Name when LotName is unavailable', () => {
+    component.data = {
+      attributes: {
+        Name: '100a',
+        LotName: null
+      }
+    } as unknown as __esri.Graphic;
+
+    fixture.detectChanges();
+
+    expect(component.shareUrl).toBe('http://localhost/?lot=100a');
+  });
+});

--- a/libs/aggiemap/ngx/popups/src/lib/components/parking-lot/parking-lot.component.ts
+++ b/libs/aggiemap/ngx/popups/src/lib/components/parking-lot/parking-lot.component.ts
@@ -14,6 +14,20 @@ import { BaseDirectionsComponent } from '../base-directions/base-directions.comp
   styleUrls: ['../base/base.popup.component.scss']
 })
 export class ParkingLotPopupComponent extends BaseDirectionsComponent {
+  private get lotIdentifier(): string | number | null {
+    const identifiers = [this.data?.attributes?.LotName, this.data?.attributes?.Name];
+
+    const identifier = identifiers.find((value) => {
+      if (typeof value === 'string') {
+        return value.trim().length > 0;
+      }
+
+      return value !== null && value !== undefined;
+    });
+
+    return identifier ?? null;
+  }
+
   constructor(
     private rtr: Router,
     private rt: ActivatedRoute,
@@ -25,10 +39,12 @@ export class ParkingLotPopupComponent extends BaseDirectionsComponent {
   }
 
   protected override _getShareUrlFragment(): string | null {
-    return this._buildShareUrlFragment('parking-lot', this.data.attributes.Name);
+    const identifier = this.lotIdentifier;
+
+    return identifier !== null ? this._buildShareUrlFragment('parking-lot', identifier) : null;
   }
 
   public startDirections() {
-    super.startDirections(`Lot ${this.data.attributes.Name}`);
+    super.startDirections(`Lot ${this.lotIdentifier ?? this.data.attributes.OBJECTID}`);
   }
 }


### PR DESCRIPTION

This PR fixes broken copied parking lot links for lots whose Name attribute is null but LotName is populated.

The parking lot popup now builds its share URL from the first valid lot identifier, preferring LotName and falling back to Name, which prevents copied URLs like ?lot=null for cases such as Post Office Lot and HSC lots.

Also adds a focused regression test covering the null-Name scenario.

Before: https://aggiemap.tamu.edu/?lot=null
<img width="1234" height="817" alt="image" src="https://github.com/user-attachments/assets/ad2efb75-5fcd-42c5-81b2-54cc342cc93b" />


After: http://aggiemap.tamu.edu/map/d?lot=Post%20Office%20Lot

<img width="1075" height="634" alt="image" src="https://github.com/user-attachments/assets/e0d9de37-6736-48b8-967c-7b84c17fa859" />

Closes #755 