### PR TITLE
fix(aggiemap-angular): Fix POI Search by separating text queries from exact OBJECTID lookup

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
@@ -1,7 +1,16 @@
-import { ComposedSearchSourcesKeyMap, SearchSources } from './search-sources';
 import { IComposedConnections } from '../connections';
 import { IComposedIDefinitions } from '../definitions';
 import { IFactoryExcludeOptions } from '../utils/definitionFactory';
+
+jest.mock('@tamu-gisc/aggiemap/ngx/popups', () => ({
+  Popups: {
+    BuildingPopupComponent: 'BuildingPopupComponent',
+    ParkingLotPopupComponent: 'ParkingLotPopupComponent',
+    PoiPopupComponent: 'PoiPopupComponent'
+  }
+}));
+
+import { ComposedSearchSourcesKeyMap, SearchSources } from './search-sources';
 
 describe('SearchSources', () => {
   const connections: IComposedConnections = {
@@ -12,7 +21,9 @@ describe('SearchSources', () => {
     bikeLocationsUrl: 'https://example.com/bike-locations',
     constructionUrl: 'https://example.com/construction',
     inforUrl: 'https://example.com/infor',
-    tsMainUrl: 'https://example.com/ts-main'
+    tsMainUrl: 'https://example.com/ts-main',
+    poiUrl: 'https://example.com/poi-service',
+    diningLocationsUrl: 'https://example.com/dining-locations'
   };
 
   const definitions: IComposedIDefinitions = {
@@ -27,12 +38,6 @@ describe('SearchSources', () => {
       layerId: 'poi-layer',
       name: 'Points of Interest',
       url: 'https://example.com/poi'
-    },
-    RESTROOMS: {
-      id: 'restrooms',
-      layerId: 'restrooms-layer',
-      name: 'Restrooms',
-      url: 'https://example.com/restrooms'
     },
     BUILDINGS: {
       id: 'buildings',
@@ -87,12 +92,36 @@ describe('SearchSources', () => {
       layerId: 'bike-locations-layer',
       name: 'Bike Locations',
       url: 'https://example.com/bike-locations'
+    },
+    BONFIRE: {
+      id: 'bonfire',
+      layerId: 'bonfire-layer',
+      name: 'Bonfire Memorial',
+      url: 'https://example.com/bonfire'
+    },
+    DINING_LOCATIONS: {
+      id: 'dining-locations',
+      layerId: 'dining-locations-layer',
+      name: 'Dining Locations',
+      url: 'https://example.com/dining-locations'
+    },
+    AGGIEPRINT_LOCATIONS: {
+      id: 'aggieprint-locations',
+      layerId: 'aggieprint-locations-layer',
+      name: 'AggiePrint Locations',
+      url: 'https://example.com/aggieprint-locations'
+    },
+    SINGLE_OCCUPANCY_RESTROOMS: {
+      id: 'single-occupancy-restroom-locations',
+      layerId: 'single-occupancy-restroom-locations-layer',
+      name: 'Single Occupancy Restroom Locations',
+      url: 'https://example.com/single-occupancy-restrooms'
     }
   };
 
   it('should return all search sources when no options are provided', () => {
     const result = SearchSources(connections, definitions);
-    expect(result.length).toBe(12); // Ensure the number of search sources matches
+    expect(result.length).toBe(13); // Ensure the number of search sources matches
   });
 
   it('should exclude specified search sources', () => {
@@ -100,7 +129,7 @@ describe('SearchSources', () => {
       exclude: ['BUILDING', 'BIKE_RACKS']
     };
     const result = SearchSources(connections, definitions, options);
-    expect(result.length).toBe(10); // Ensure the number of search sources matches after exclusion
+    expect(result.length).toBe(11); // Ensure the number of search sources matches after exclusion
     expect(result.find((source) => source.source === 'building')).toBeUndefined();
     expect(result.find((source) => source.source === 'bike-racks')).toBeUndefined();
   });
@@ -110,7 +139,7 @@ describe('SearchSources', () => {
       exclude: []
     };
     const result = SearchSources(connections, definitions, options);
-    expect(result.length).toBe(12); // Ensure the number of search sources matches
+    expect(result.length).toBe(13); // Ensure the number of search sources matches
   });
 
   it('should return an empty array if all search sources are excluded', () => {
@@ -126,6 +155,7 @@ describe('SearchSources', () => {
         'ONE_PARKING',
         'PARKING_GARAGE',
         'PARKING_LOT',
+        'POINTS_OF_INTEREST_EXACT',
         'POINTS_OF_INTEREST',
         'BIKE_RACKS'
       ]
@@ -133,5 +163,28 @@ describe('SearchSources', () => {
 
     const result = SearchSources(connections, definitions, options);
     expect(result.length).toBe(0); // Ensure the number of search sources matches
+  });
+
+  it('should keep text POI search separate from exact-id POI deep links', () => {
+    const result = SearchSources(connections, definitions);
+    const poiSearch = result.find((source) => source.source === 'points-of-interest');
+    const poiExact = result.find((source) => source.source === 'points-of-interest-exact');
+
+    expect(poiSearch?.searchActive).toBe(true);
+    expect(poiSearch?.queryParams?.where).toEqual({
+      keys: ['name'],
+      operators: ['LIKE'],
+      wildcards: ['includes'],
+      transformations: ['UPPER']
+    });
+    expect(poiSearch?.urlQueryParam).toBeUndefined();
+
+    expect(poiExact?.searchActive).toBe(false);
+    expect(poiExact?.queryParams?.where).toEqual({
+      keys: ['OBJECTID'],
+      operators: ['=']
+    });
+    expect(poiExact?.urlQueryParam).toBe('poi');
+    expect(poiExact?.urlQueryParamAliases).toEqual(['POI']);
   });
 });

--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
@@ -222,6 +222,24 @@ export function SearchSources(
       urlQueryParam: 'lot',
       urlQueryParamAliases: ['Lot']
     },
+    POINTS_OF_INTEREST_EXACT: {
+      source: 'points-of-interest-exact',
+      name: 'Points of Interest',
+      url: definitions.POINTS_OF_INTEREST.url,
+      queryParams: {
+        ...commonQueryParams,
+        where: {
+          keys: ['OBJECTID'],
+          operators: ['=']
+        }
+      },
+      featuresLocation: 'features',
+      displayTemplate: '{attributes.name}',
+      popupComponent: Popups.PoiPopupComponent,
+      searchActive: false,
+      urlQueryParam: 'poi',
+      urlQueryParamAliases: ['POI']
+    },
     POINTS_OF_INTEREST: {
       source: 'points-of-interest',
       name: 'Points of Interest',
@@ -229,18 +247,16 @@ export function SearchSources(
       queryParams: {
         ...commonQueryParams,
         where: {
-          keys: ['name', 'OBJECTID'],
-          operators: ['LIKE', '='],
-          wildcards: ['includes', null],
-          transformations: ['UPPER', null]
+          keys: ['name'],
+          operators: ['LIKE'],
+          wildcards: ['includes'],
+          transformations: ['UPPER']
         }
       },
       featuresLocation: 'features',
       displayTemplate: '{attributes.name}',
       popupComponent: Popups.PoiPopupComponent,
-      searchActive: true,
-      urlQueryParam: 'poi',
-      urlQueryParamAliases: ['POI']
+      searchActive: true
     },
     BIKE_RACKS: {
       source: 'bike-racks',
@@ -290,6 +306,7 @@ export type ComposedSearchSourcesKeyMap = {
   ONE_PARKING: SearchSource;
   PARKING_GARAGE: SearchSource;
   PARKING_LOT: SearchSource;
+  POINTS_OF_INTEREST_EXACT: SearchSource;
   POINTS_OF_INTEREST: SearchSource;
   BIKE_RACKS: SearchSource;
 };

--- a/libs/aggiemap/ngx/popups/src/lib/components/poi/poi.component.ts
+++ b/libs/aggiemap/ngx/popups/src/lib/components/poi/poi.component.ts
@@ -86,7 +86,7 @@ export class PoiPopupComponent extends BaseDirectionsComponent implements OnInit
   }
 
   protected override _getShareUrlFragment(): string | null {
-    return this._buildShareUrlFragment('points-of-interest', this.data.attributes.OBJECTID);
+    return this._buildShareUrlFragment('points-of-interest-exact', this.data.attributes.OBJECTID);
   }
 
   public startDirections() {


### PR DESCRIPTION
## Summary

This PR fixes POI search failures on the Aggie Map home page by separating free-text POI search from exact POI ID lookup.

Previously, the POI search source built a single `where` clause that searched both the POI name field and `OBJECTID`. That worked for numeric input such as `1`, but it caused ArcGIS to reject text queries such as `Wright` because the generated predicate attempted to compare a numeric `OBJECTID` field to a quoted text value. As a result, valid POIs like **Wright Gallery** were missing from search results even though they were present in the underlying feature service response.

This PR removes that invalid mixed query behavior while preserving existing POI deep-link/share URL behavior.

---


## Before: 

<img width="508" height="263" alt="image" src="https://github.com/user-attachments/assets/bfbb378f-da94-40fb-abb5-ff2fdd57f8ff" />

## After:

<img width="524" height="373" alt="image" src="https://github.com/user-attachments/assets/499a00b8-27e2-422d-9ae4-59a509a04810" />

Search works for all POIs.

## Problem

The POI source was configured to search with both of these conditions:

- `name LIKE ...`
- `OBJECTID = ...`

For a text search such as `Wright`, the app generated a `where` clause effectively equivalent to:

```sql
UPPER(name) LIKE '%WRIGHT%' OR OBJECTID = 'WRIGHT'
```

That second predicate is invalid because:

- `OBJECTID` is numeric
- the shared query builder inserts the search term as a quoted string

ArcGIS rejected the entire query with:

```json
{
  "error": {
    "code": 400,
    "message": "Cannot perform query. Invalid query parameters."
  }
}
```

This is why:
- searching `1` could return **Bonfire Memorial** via `OBJECTID`
- searching `Wright` could fail to return **Wright Gallery**

---

## Solution

The fix splits POI handling into two separate search sources:

### 1. `points-of-interest`
This remains the visible, user-facing POI search source.

It now performs **text-only** matching against the POI name field:

- `name LIKE '%term%'`

This avoids sending invalid `OBJECTID` comparisons for text input.

### 2. `points-of-interest-exact`
This is a hidden source used only for exact POI lookup by ID.

It performs:

- `OBJECTID = <id>`

This preserves existing deep-link/share-link behavior such as:

```text
?poi=123
```

---

## Why this approach

This change addresses the actual failure mode reported in the issue: the generated POI query was invalid.

It does **not** switch Aggie Map from the current public POI view service to a direct source layer. During investigation, the current public POI endpoint was confirmed to contain the expected data, including the relevant example, which means the immediate bug was query construction rather than missing data in the current service.

Additionally, the likely direct source service appears to require authentication, while the current POI view is publicly queryable. Repointing to the direct source would therefore be a separate change with additional auth implications, not part of the search-query bug fix.

---

## Files changed

### `libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts`

- Added hidden `points-of-interest-exact` source for exact `OBJECTID` lookup
- Updated visible `points-of-interest` source to search only by `name`
- Added the new source to `ComposedSearchSourcesKeyMap`

### `libs/aggiemap/ngx/popups/src/lib/components/poi/poi.component.ts`

- Updated POI share-link generation to use `points-of-interest-exact`
- Preserves `?poi=<OBJECTID>` deep links

### `libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts`

- Updated source-count expectations
- Added regression coverage ensuring:
  - text POI search uses only `name`
  - exact POI lookup remains available through the hidden source
  - deep-link parameter config remains intact

---

Closes #750
