### PR TITLE
fix(aggiemap-angular): Replace RNS labels with actual space ID

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -318,13 +318,13 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
           where: `Anno_Type IS NULL OR Anno_Type NOT IN ('Serv', 'M/C')`,
           labelExpressionInfo: {
             expression: `
-              var label = DefaultValue($feature.Anno_Type, '');
+              var anno = DefaultValue($feature.Anno_Type, '');
 
-              if (label == 'H/C') {
+              if (anno == 'H/C') {
                 return '';
               }
 
-              return label;
+              return DefaultValue(Text($feature.Spc_ID_Num), '');
             `
           },
           labelPlacement: 'center-center',

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -318,13 +318,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
           where: `Anno_Type IS NULL OR Anno_Type NOT IN ('Serv', 'M/C')`,
           labelExpressionInfo: {
             expression: `
-              var anno = DefaultValue($feature.Anno_Type, '');
-
-              if (anno == 'H/C') {
-                return '';
-              }
-
-              return DefaultValue(Text($feature.Spc_ID_Num), '');
+              if ($feature.Anno_Type == 'H/C') { return ''; }
+              return Trim($feature.RNS_Num);
             `
           },
           labelPlacement: 'center-center',


### PR DESCRIPTION
This PR replaces the RNS labels with their actual `RNS_Num` instead of just "RNS."

<img width="1440" height="1131" alt="image" src="https://github.com/user-attachments/assets/a1bb8b09-1193-4a3b-a572-6856ed6df4f4" />

Closes #747