### PR TITLE
fix(aggiemap-angular): Remove forbidden static import of lazy-loaded

### DIFF
--- a/apps/aggiemap-angular/src/app/app.module.ts
+++ b/apps/aggiemap-angular/src/app/app.module.ts
@@ -6,8 +6,9 @@ import { HttpClientModule } from '@angular/common/http';
 import { Angulartics2Module } from 'angulartics2';
 
 import { env, EnvironmentModule } from '@tamu-gisc/common/ngx/environment';
-import { AggiemapNgxCoreModule } from '@tamu-gisc/aggiemap/ngx/core';
+import { AggiemapNgxCoreModule, EVENT_NOTIFICATION_DEFINITIONS } from '@tamu-gisc/aggiemap/ngx/core';
 import { NotificationModule, notificationStorage } from '@tamu-gisc/common/ngx/ui/notification';
+import { EventDefinitions } from '@tamu-gisc/ts/events/ngx';
 
 import * as environment from '../environments/environment';
 import { AppComponent } from './app.component';
@@ -34,7 +35,8 @@ WebFont.load({
   bootstrap: [AppComponent],
   providers: [
     { provide: env, useValue: environment },
-    { provide: notificationStorage, useValue: 'aggiemap-notifications' }
+    { provide: notificationStorage, useValue: 'aggiemap-notifications' },
+    { provide: EVENT_NOTIFICATION_DEFINITIONS, useValue: EventDefinitions }
   ]
 })
 export class AppModule {}

--- a/libs/aggiemap/ngx/core/src/lib/services/event-notifications/event-notifications.service.ts
+++ b/libs/aggiemap/ngx/core/src/lib/services/event-notifications/event-notifications.service.ts
@@ -22,18 +22,23 @@ export class EventNotificationsService {
     @Optional() @Inject(EVENT_NOTIFICATION_DEFINITIONS) private readonly definitions: EventNotificationEntry[] | null
   ) {}
 
+  /**
+   * Checks all event definitions for active events and triggers toast notifications
+   * for any that have toast configuration and are currently active/upcoming.
+   */
   public checkAndTriggerEventNotifications(): void {
     if (!this.definitions) {
       return;
     }
 
     const now = Date.now();
-    const oneDay = 24 * 60 * 60 * 1000;
+    const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
     const sevenDays = 7 * oneDay;
 
     this.definitions.forEach((eventDefinition) => {
       const config = eventDefinition.configuration;
 
+      // Skip if no configuration or no toast config
       if (!config || !config.toast || !config.eventDates) {
         return;
       }
@@ -48,14 +53,15 @@ export class EventNotificationsService {
         }
       });
 
+      // Check if any event date is within the next 7 days (upcoming) or is today (ongoing)
       const isOngoing = eventDates.some((eventDate) => {
         const timeDiff = Math.abs(now - eventDate);
-        return timeDiff < oneDay;
+        return timeDiff < oneDay; // Event is today (within 24 hours)
       });
 
       const isUpcoming = eventDates.some((eventDate) => {
         const timeDiff = eventDate - now;
-        return timeDiff > 0 && timeDiff <= sevenDays;
+        return timeDiff > 0 && timeDiff <= sevenDays; // Event is within next 7 days
       });
 
       if (isOngoing || isUpcoming) {
@@ -64,13 +70,22 @@ export class EventNotificationsService {
     });
   }
 
+  /**
+   * Triggers a toast notification for an event.
+   *
+   * @param toastConfig The notification properties for the toast
+   * @param eventId The event ID to ensure unique notification IDs
+   */
   private triggerEventToast(toastConfig: NotificationProperties, eventId: string): void {
+    // Create a copy of the toast config to avoid modifying the original
     const notificationProps = { ...toastConfig };
 
+    // Add a unique ID if not provided to prevent duplicate notifications
     if (!notificationProps.id) {
       notificationProps.id = `event-${eventId}-toast`;
     }
 
+    // Trigger the notification
     this.notificationService.toast(notificationProps);
   }
 }

--- a/libs/aggiemap/ngx/core/src/lib/services/event-notifications/event-notifications.service.ts
+++ b/libs/aggiemap/ngx/core/src/lib/services/event-notifications/event-notifications.service.ts
@@ -1,26 +1,39 @@
-import { Injectable } from '@angular/core';
+import { Injectable, InjectionToken, Optional, Inject } from '@angular/core';
 import { NotificationService, NotificationProperties } from '@tamu-gisc/common/ngx/ui/notification';
-import { EventDefinitions } from '@tamu-gisc/ts/events/ngx';
+
+interface EventToastConfig {
+  id: string;
+  eventDates: Array<string | Date | number>;
+  toast?: NotificationProperties;
+}
+
+interface EventNotificationEntry {
+  configuration?: EventToastConfig | null;
+}
+
+export const EVENT_NOTIFICATION_DEFINITIONS = new InjectionToken<EventNotificationEntry[]>('EVENT_NOTIFICATION_DEFINITIONS');
 
 @Injectable({
   providedIn: 'root'
 })
 export class EventNotificationsService {
-  constructor(private readonly notificationService: NotificationService) {}
+  constructor(
+    private readonly notificationService: NotificationService,
+    @Optional() @Inject(EVENT_NOTIFICATION_DEFINITIONS) private readonly definitions: EventNotificationEntry[] | null
+  ) {}
 
-  /**
-   * Checks all event definitions for active events and triggers toast notifications
-   * for any that have toast configuration and are currently active/upcoming.
-   */
   public checkAndTriggerEventNotifications(): void {
+    if (!this.definitions) {
+      return;
+    }
+
     const now = Date.now();
-    const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
+    const oneDay = 24 * 60 * 60 * 1000;
     const sevenDays = 7 * oneDay;
 
-    EventDefinitions.forEach((eventDefinition) => {
+    this.definitions.forEach((eventDefinition) => {
       const config = eventDefinition.configuration;
 
-      // Skip if no configuration or no toast config
       if (!config || !config.toast || !config.eventDates) {
         return;
       }
@@ -35,15 +48,14 @@ export class EventNotificationsService {
         }
       });
 
-      // Check if any event date is within the next 7 days (upcoming) or is today (ongoing)
       const isOngoing = eventDates.some((eventDate) => {
         const timeDiff = Math.abs(now - eventDate);
-        return timeDiff < oneDay; // Event is today (within 24 hours)
+        return timeDiff < oneDay;
       });
 
       const isUpcoming = eventDates.some((eventDate) => {
         const timeDiff = eventDate - now;
-        return timeDiff > 0 && timeDiff <= sevenDays; // Event is within next 7 days
+        return timeDiff > 0 && timeDiff <= sevenDays;
       });
 
       if (isOngoing || isUpcoming) {
@@ -52,22 +64,13 @@ export class EventNotificationsService {
     });
   }
 
-  /**
-   * Triggers a toast notification for an event.
-   *
-   * @param toastConfig The notification properties for the toast
-   * @param eventId The event ID to ensure unique notification IDs
-   */
   private triggerEventToast(toastConfig: NotificationProperties, eventId: string): void {
-    // Create a copy of the toast config to avoid modifying the original
     const notificationProps = { ...toastConfig };
 
-    // Add a unique ID if not provided to prevent duplicate notifications
     if (!notificationProps.id) {
       notificationProps.id = `event-${eventId}-toast`;
     }
 
-    // Trigger the notification
     this.notificationService.toast(notificationProps);
   }
 }


### PR DESCRIPTION
This PR replaces direct EventDefinitions import in EventNotificationsService with an InjectionToken, providing the definitions from app.module.ts where the ts-events-ngx import is permitted.

`event-notifications.service.ts` was statically importing `EventDefinitions` directly from `@tamu-gisc/ts/events/ngx.` Because `aggiemap-ngx-core` already lazy-loads that same library via the Angular router (`loadChildren`), NX's `@nx/enforce-module-boundaries` rule treats it as a lazy-loaded library and forbids any static imports of it from within the same project, causing a lint error in CI whenever `aggiemap-ngx-core` appears in the affected set.

The fix replaces the static import with an `InjectionToken (EVENT_NOTIFICATION_DEFINITIONS)`. The service now declares a minimal local interface for the data it needs and injects the token as an optional dependency. The actual `EventDefinitions` array is provided in `app.module.ts` inside the aggiemap-angular app, which is an application entry point and is permitted to import from `@tamu-gisc/ts/events/ngx` without restriction. Runtime behavior is unchanged.

Required for #772 and #773
Closes #774 