### PR TITLE
fix(aggiemap-angular): Dismiss search results on Escape and click-outside

### DIFF
--- a/libs/ui-kits/ngx/search/src/lib/components/search-mobile/search-mobile.component.html
+++ b/libs/ui-kits/ngx/search/src/lib/components/search-mobile/search-mobile.component.html
@@ -9,7 +9,7 @@
       <div></div>
     </div>
 
-    <input #search type="text" (keyup)="change($event)" (focus)="setFocus()" [value]="value" [placeholder]="placeholder" aria-owns="search-results-container" aria-autocomplete="both" aria-autocomplete="list" role="textbox" [ngClass]="{ 'margin-left': leftActionIcon, 'margin-right': rightActionIcon }" />
+    <input #search type="text" (keyup)="change($event)" (keydown.escape)="loseFocus()" (focus)="setFocus()" (blur)="loseFocus()" [value]="value" [placeholder]="placeholder" aria-owns="search-results-container" aria-autocomplete="both" aria-autocomplete="list" role="textbox" [ngClass]="{ 'margin-left': leftActionIcon, 'margin-right': rightActionIcon }" />
   </div>
 
   <!-- Show search results container only if search results has at least one item OR  canGeolocate is enabled since it will act as the minimum. -->

--- a/libs/ui-kits/ngx/search/src/lib/components/search-mobile/search-mobile.component.ts
+++ b/libs/ui-kits/ngx/search/src/lib/components/search-mobile/search-mobile.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectorRef, ChangeDetectionStrategy, ElementRef } from '@angular/core';
 
 import { Angulartics2 } from 'angulartics2';
 
@@ -21,9 +21,10 @@ export class SearchMobileComponent extends SearchComponent {
     private anltcs: Angulartics2,
     private nss: NotificationService,
     private ss: SearchService,
-    private env: EnvironmentService
+    private env: EnvironmentService,
+    private elRef: ElementRef
   ) {
-    super(cdr, anltcs, nss, ss, env);
+    super(cdr, anltcs, nss, ss, env, elRef);
   }
 
   public emitLeftActionEvent(): void {

--- a/libs/ui-kits/ngx/search/src/lib/components/search/search.component.html
+++ b/libs/ui-kits/ngx/search/src/lib/components/search/search.component.html
@@ -9,7 +9,7 @@
       <div></div>
     </div>
 
-    <input #search type="text" (keyup)="change($event)" (focus)="setFocus()" (blur)="loseFocus()" [value]="value" [placeholder]="placeholder" aria-owns="search-results-container" aria-autocomplete="both" aria-autocomplete="list" role="textbox" [ngClass]="{ 'margin-left': leftActionIcon, 'margin-right': rightActionIcon }" />
+    <input #search type="text" (keyup)="change($event)" (keydown.escape)="loseFocus()" (focus)="setFocus()" (blur)="loseFocus()" [value]="value" [placeholder]="placeholder" aria-owns="search-results-container" aria-autocomplete="both" aria-autocomplete="list" role="textbox" [ngClass]="{ 'margin-left': leftActionIcon, 'margin-right': rightActionIcon }" />
   </div>
 
   <div class="search-results-container" role="listbox" (keydown)="keyControl($event, 'focus', '.focusable')">

--- a/libs/ui-kits/ngx/search/src/lib/components/search/search.component.ts
+++ b/libs/ui-kits/ngx/search/src/lib/components/search/search.component.ts
@@ -8,7 +8,8 @@ import {
   Input,
   OnDestroy,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  HostListener
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { tap, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
@@ -194,7 +195,8 @@ export class SearchComponent implements OnInit, OnDestroy {
     private analytics: Angulartics2,
     private ns: NotificationService,
     private searchService: SearchService,
-    private environment: EnvironmentService
+    private environment: EnvironmentService,
+    protected elementRef: ElementRef
   ) {
     if (this.environment.value('SearchSources')) {
       this._sources = this.environment.value('SearchSources');
@@ -320,6 +322,14 @@ export class SearchComponent implements OnInit, OnDestroy {
     this.blur.emit(true);
   }
 
+  @HostListener('document:click', ['$event'])
+  public onDocumentClick(event: MouseEvent): void {
+    if (this.searchResultsActive && !this.elementRef.nativeElement.contains(event.target as Node)) {
+      this.loseFocus();
+      this.cd.markForCheck();
+    }
+  }
+
   /**
    * Event fired on input keyup that then sets the next Subject value. Also displays the search results
    *
@@ -328,7 +338,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   public change(event: KeyboardEvent): void {
     // Some keyboard keys trigger the change event (e.g. tab).
     // Limit the execution of the process chain only if event key code is not in the not allowed list
-    const keysNotAllowed = [9, 18, 16];
+    const keysNotAllowed = [9, 18, 16, 27];
 
     if (!keysNotAllowed.includes(event.which)) {
       const value = (<HTMLInputElement>event.target).value;


### PR DESCRIPTION
This PR makes it where search results now close when the user presses Escape or clicks anywhere outside the search component. The mobile input also gains the missing blur handler so clicking away behaves consistently with desktop.


https://github.com/user-attachments/assets/09370648-18c2-49e4-89d8-9f9af7694fdc

Closes #769 