### PR TITLE
feat(aggiemap-angular): Centralize shared layer source URLs for event maps

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -1,4 +1,4 @@
-export function Connections(gisHost: string) {
+function createConnections(gisHost: string): IComposedConnections {
   return {
     basemapUrl: `https://${gisHost}/arcgis/rest/services/FCOR/TAMU_BaseMap/MapServer`,
     inforUrl: `https://${gisHost}/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer`,
@@ -67,6 +67,19 @@ export function Connections(gisHost: string) {
   };
 }
 
+function getDefaultGisHost() {
+  const hostname = globalThis.location?.hostname;
+
+  return hostname?.includes('dev') ? 'gis-dev.it.tamu.edu' : 'gis.it.tamu.edu';
+}
+
+export type IConnectionsFactory = ((gisHost: string) => IComposedConnections) & IComposedConnections;
+
+export const Connections: IConnectionsFactory = Object.assign(
+  ((gisHost: string) => createConnections(gisHost)) as IConnectionsFactory,
+  createConnections(getDefaultGisHost())
+);
+
 export interface IComposedConnections {
   basemapUrl: string;
   inforUrl: string;
@@ -77,6 +90,7 @@ export interface IComposedConnections {
   bikeRacksUrl: string;
   bikeMapUrl: string;
   bikeLocationsUrl: string;
+  routingBaseUrl: string;
   poiUrl: string;
   diningLocationsUrl: string;
   aggiePrintUrl: string;

--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -11,7 +11,59 @@ export function Connections(gisHost: string) {
     bikeLocationsUrl: `https://veoride.geoservices.tamu.edu/api/vehicles/basic/geojson`,
     routingBaseUrl: `https://${gisHost}/arcgis/rest/services/Routing`,
     poiUrl: 'https://services1.arcgis.com/oxXAea6csqnDZ6WT/arcgis/rest/services/Points_of_Interest_view/FeatureServer',
-    diningLocationsUrl: `https://api.aggiemap.tamu.edu/dining/locations/geojson`
+    diningLocationsUrl: `https://api.aggiemap.tamu.edu/dining/locations/geojson`,
+    aggiePrintUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/TAMUPrinters/FeatureServer',
+    tsFootballUrl: `https://${gisHost}/arcgis/rest/services/TS/TSFootball/MapServer`,
+    footballGamedayShuttlesUrl: `https://${gisHost}/arcgis/rest/services/TS/Ftbl_Gameday_Shuttles/MapServer`,
+    maroonWhiteGameUrl: `https://${gisHost}/arcgis/rest/services/TS/Maroon_White_Game/MapServer`,
+    accessibleParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/AccessibleParking/MapServer`,
+    aggielandSaturdayUrl: `https://${gisHost}/arcgis/rest/services/TS/AggielandSaturday/MapServer`,
+    avpParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/AnyValidPermitParking/MapServer`,
+    baseballParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/BaseballParking/MapServer`,
+    bigEventUrl: `https://${gisHost}/arcgis/rest/services/TS/Big_Event/MapServer`,
+    breakSummerParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/SummerBreakParking/MapServer`,
+    businessParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/BusinessParking/MapServer`,
+    contractorParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/ContractorParking/MapServer`,
+    crossCountryParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/CrossCountryParking/MapServer`,
+    familyWeekendUrl: `https://${gisHost}/arcgis/rest/services/TS/Family_Weekend/MapServer`,
+    freshmanParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/FreshmanSelectableParking/MapServer`,
+    graduationParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/GraduationParking/MapServer`,
+    hsGraduationUrl: `https://${gisHost}/arcgis/rest/services/TS/HS_Graduation/MapServer`,
+    indoorTrackParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/IndoorTrackParking/MapServer`,
+    loadingZonesUrl: `https://${gisHost}/arcgis/rest/services/TS/Loading_Zones/MapServer`,
+    maintenanceParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/MaintenanceParking/MapServer`,
+    mediaParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/MediaParking/MapServer`,
+    mensBasketballUrl: `https://${gisHost}/arcgis/rest/services/TS/BaseMBasketTennisXCountry/MapServer`,
+    motorcycleParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/MotorcycleParking/MapServer`,
+    motoristAssistanceUrl: `https://${gisHost}/arcgis/rest/services/TS/MotoristAssistance/MapServer`,
+    moveInParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/FallMoveInParking/MapServer`,
+    moveOutParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/MoveOutParking/MapServer`,
+    ms150Url: `https://${gisHost}/arcgis/rest/services/TS/MS150/MapServer`,
+    musterUrl: `https://${gisHost}/arcgis/rest/services/TS/Muster/MapServer`,
+    nightWeekendParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/NightWeekendParking/MapServer`,
+    nscParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/NewStudentConferenceParking/MapServer`,
+    outdoorTrackParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/OutdoorTrackParking/MapServer`,
+    physicsFestUrl: `https://${gisHost}/arcgis/rest/services/TS/Physics_Fest/MapServer`,
+    retireeParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/RetireeParking/MapServer`,
+    ringDayUrl: `https://${gisHost}/arcgis/rest/services/TS/Ring_Day/MapServer`,
+    savannahBananasUrl: `https://${gisHost}/arcgis/rest/services/TS/SavannahBananas/MapServer`,
+    secGroundsConferenceUrl: `https://${gisHost}/arcgis/rest/services/TS/SEC_Grounds_Conference/MapServer`,
+    soccerParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/SoccerParking/MapServer`,
+    softballParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/SoftballParking/MapServer`,
+    softballRegionalsUrl: `https://${gisHost}/arcgis/rest/services/TS/Softball_Regionals/MapServer`,
+    staffParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/StaffSelectableParking/MapServer`,
+    studentParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/StudentSelectableParking/MapServer`,
+    summerCommencementUrl: `https://${gisHost}/arcgis/rest/services/TS/Summer_Commencement/MapServer`,
+    swimmingParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/SwimmingParking/MapServer`,
+    tennisParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/TennisParking/MapServer`,
+    timedParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/TimedParking/MapServer`,
+    troubadourFestivalUrl: `https://${gisHost}/arcgis/rest/services/TS/Troubadour_Festival/MapServer`,
+    vendorParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/VendorParking/MapServer`,
+    visitorParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/VisitorParking/MapServer`,
+    volleyballParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/VolleyballParking/MapServer`,
+    womensBasketballUrl: `https://${gisHost}/arcgis/rest/services/TS/TracSocSoftSwimVollWbask/MapServer`,
+    fourHRoundupUrl: `https://${gisHost}/arcgis/rest/services/TS/4H_Roundup/MapServer`,
+    gisDayUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer'
   };
 }
 
@@ -27,4 +79,56 @@ export interface IComposedConnections {
   bikeLocationsUrl: string;
   poiUrl: string;
   diningLocationsUrl: string;
+  aggiePrintUrl: string;
+  tsFootballUrl: string;
+  footballGamedayShuttlesUrl: string;
+  maroonWhiteGameUrl: string;
+  accessibleParkingUrl: string;
+  aggielandSaturdayUrl: string;
+  avpParkingUrl: string;
+  baseballParkingUrl: string;
+  bigEventUrl: string;
+  breakSummerParkingUrl: string;
+  businessParkingUrl: string;
+  contractorParkingUrl: string;
+  crossCountryParkingUrl: string;
+  familyWeekendUrl: string;
+  freshmanParkingUrl: string;
+  graduationParkingUrl: string;
+  hsGraduationUrl: string;
+  indoorTrackParkingUrl: string;
+  loadingZonesUrl: string;
+  maintenanceParkingUrl: string;
+  mediaParkingUrl: string;
+  mensBasketballUrl: string;
+  motorcycleParkingUrl: string;
+  motoristAssistanceUrl: string;
+  moveInParkingUrl: string;
+  moveOutParkingUrl: string;
+  ms150Url: string;
+  musterUrl: string;
+  nightWeekendParkingUrl: string;
+  nscParkingUrl: string;
+  outdoorTrackParkingUrl: string;
+  physicsFestUrl: string;
+  retireeParkingUrl: string;
+  ringDayUrl: string;
+  savannahBananasUrl: string;
+  secGroundsConferenceUrl: string;
+  soccerParkingUrl: string;
+  softballParkingUrl: string;
+  softballRegionalsUrl: string;
+  staffParkingUrl: string;
+  studentParkingUrl: string;
+  summerCommencementUrl: string;
+  swimmingParkingUrl: string;
+  tennisParkingUrl: string;
+  timedParkingUrl: string;
+  troubadourFestivalUrl: string;
+  vendorParkingUrl: string;
+  visitorParkingUrl: string;
+  volleyballParkingUrl: string;
+  womensBasketballUrl: string;
+  fourHRoundupUrl: string;
+  gisDayUrl: string;
 }

--- a/libs/aggiemap/ngx/common/src/lib/definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions.ts
@@ -96,14 +96,14 @@ export function Definitions(Connections: IComposedConnections): IComposedIDefini
       id: 'aggieprint-locations',
       layerId: 'aggieprint-locations-layer',
       name: 'AggiePrint Locations',
-      url: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/TAMUPrinters/FeatureServer/0',
+      url: `${Connections.aggiePrintUrl}/0`,
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     },
     SINGLE_OCCUPANCY_RESTROOMS: {
       id: 'single-occupancy-restroom-locations',
       layerId: 'single-occupancy-restroom-locations-layer',
       name: 'Single Occupancy Restroom Locations',
-      url: 'https://gis.tamu.edu/arcgis/rest/services/FCOR/MapInfo_20190529/MapServer/1',
+      url: `${Connections.inforUrl}/1`,
       popupComponent: Popups.MarkdownWDirectionsPopupComponent
     },
     BIKE_DISMOUNT_ZONES: {

--- a/libs/aggiemap/ngx/common/src/lib/utils/definitionFactory.ts
+++ b/libs/aggiemap/ngx/common/src/lib/utils/definitionFactory.ts
@@ -1,7 +1,7 @@
 import { LayerSource } from '@tamu-gisc/common/types';
 import { SearchSource } from '@tamu-gisc/ui-kits/ngx/search';
 
-import { Connections } from '../connections';
+import { Connections, IComposedConnections } from '../connections';
 import { Definitions, IComposedIDefinitions } from '../definitions';
 import { LayerSources, ThreeDLayers } from '../layer-sources/layer-sources';
 import { ComposedSearchSourcesKeyMap, SearchSources } from '../search-sources/search-sources';
@@ -40,7 +40,7 @@ export interface IFactoryExcludeOptions<T> {
 }
 
 export interface Definitions {
-  Connections: Record<string, string>;
+  Connections: IComposedConnections;
   Definitions: IComposedIDefinitions;
   LayerSources: Array<LayerSource>;
   SearchSources: Array<SearchSource>;

--- a/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
@@ -15,7 +15,7 @@ export enum FOUR_H_ROUNDUP_LAYERS {
   FOUR_H_ROUNDUP_LOCATIONS = 'four-h-roundup-locations'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').fourHRoundupUrl;
+const eventUrl = Connections.fourHRoundupUrl;
 
 const FourHRoundupEventDefinitions = {
   FOUR_H_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -14,7 +15,7 @@ export enum FOUR_H_ROUNDUP_LAYERS {
   FOUR_H_ROUNDUP_LOCATIONS = 'four-h-roundup-locations'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/4H_Roundup/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').fourHRoundupUrl;
 
 const FourHRoundupEventDefinitions = {
   FOUR_H_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -10,7 +11,7 @@ export enum ACCESSIBLE_PARKING_LAYERS {
   ACCESSIBLE_PARKING_SPACE = 'Accessible Parking Space'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AccessibleParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').accessibleParkingUrl;
 
 export const AccessibleParkingDefinitions = {
   ACCESSIBLE_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/accessible-parking.definitions.ts
@@ -11,7 +11,7 @@ export enum ACCESSIBLE_PARKING_LAYERS {
   ACCESSIBLE_PARKING_SPACE = 'Accessible Parking Space'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').accessibleParkingUrl;
+const eventUrl = Connections.accessibleParkingUrl;
 
 export const AccessibleParkingDefinitions = {
   ACCESSIBLE_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -18,7 +18,7 @@ export enum AGGIELAND_SATURDAY_LAYERS {
   PARKING = 'aggieland-saturday-parking'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').aggielandSaturdayUrl;
+const eventUrl = Connections.aggielandSaturdayUrl;
 
 export const AggielandSaturdayEventDefinitions = {
   EVENT_BUS_STOPS: {

--- a/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggieland-saturday.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -17,7 +18,7 @@ export enum AGGIELAND_SATURDAY_LAYERS {
   PARKING = 'aggieland-saturday-parking'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/AggielandSaturday/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').aggielandSaturdayUrl;
 
 export const AggielandSaturdayEventDefinitions = {
   EVENT_BUS_STOPS: {

--- a/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
@@ -12,7 +12,7 @@ export enum AVP_PARKING_LAYERS {
   AVP_PARKING_LOTS = 'AVP-parking-lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').avpParkingUrl;
+const eventUrl = Connections.avpParkingUrl;
 
 export const AVPParkingDefinitions = {
   AVP_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
 import {
@@ -11,7 +12,7 @@ export enum AVP_PARKING_LAYERS {
   AVP_PARKING_LOTS = 'AVP-parking-lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/AnyValidPermitParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').avpParkingUrl;
 
 export const AVPParkingDefinitions = {
   AVP_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -25,7 +26,7 @@ enum BaseballMapMode {
   ACCESSIBLE = 'accessible'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/BaseballParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').baseballParkingUrl;
 
 export const BaseballParkingColdLayerSources: LayerSource[] = [
   {

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -26,7 +26,7 @@ enum BaseballMapMode {
   ACCESSIBLE = 'accessible'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').baseballParkingUrl;
+const eventUrl = Connections.baseballParkingUrl;
 
 export const BaseballParkingColdLayerSources: LayerSource[] = [
   {

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -23,7 +23,7 @@ export enum BIG_EVENT_MAP_TYPE_OPTIONS {
   TOOL_RETURN = 'Tool Dropoff'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').bigEventUrl;
+const eventUrl = Connections.bigEventUrl;
 
 const BIG_EVENT_LAYER_INDICES = {
   PARKING_LOTS: 48,

--- a/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/big-event.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -22,7 +23,7 @@ export enum BIG_EVENT_MAP_TYPE_OPTIONS {
   TOOL_RETURN = 'Tool Dropoff'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Big_Event/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').bigEventUrl;
 
 const BIG_EVENT_LAYER_INDICES = {
   PARKING_LOTS: 48,

--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -15,7 +15,7 @@ export enum BREAK_SUMMER_LAYERS {
   BREAK_SUMMER_LOTS = 'Break-Summer Parking Lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').breakSummerParkingUrl;
+const eventUrl = Connections.breakSummerParkingUrl;
 
 export const BreakSummerDefinitions = {
   BREAK_SUMMER_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -14,7 +15,7 @@ export enum BREAK_SUMMER_LAYERS {
   BREAK_SUMMER_LOTS = 'Break-Summer Parking Lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SummerBreakParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').breakSummerParkingUrl;
 
 export const BreakSummerDefinitions = {
   BREAK_SUMMER_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
@@ -14,7 +14,7 @@ export enum BUSINESS_PARKING_LAYERS {
   UB_AND_UB_PLUS = 'UB Permit and UB+ Permit Authorized',
   UB_PLUS_ONLY = 'Only UB+ Permit Authorized'
 }
-const eventUrl = Connections('gis.it.tamu.edu').businessParkingUrl;
+const eventUrl = Connections.businessParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/business-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
@@ -13,7 +14,7 @@ export enum BUSINESS_PARKING_LAYERS {
   UB_AND_UB_PLUS = 'UB Permit and UB+ Permit Authorized',
   UB_PLUS_ONLY = 'Only UB+ Permit Authorized'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/BusinessParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').businessParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
@@ -11,7 +11,7 @@ export enum CONTRACTOR_PARKING_LAYERS {
   CONTRACTOR_AND_CONTRACTOR_PLUS = 'Contractor Permit and Contractor+ Permit Authorized',
   CONTRACTOR_PLUS_ONLY = 'Only Contractor+ Permit Authorized'
 }
-const eventUrl = Connections('gis.it.tamu.edu').contractorParkingUrl;
+const eventUrl = Connections.contractorParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/contractor-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
   EventConfiguration,
@@ -10,7 +11,7 @@ export enum CONTRACTOR_PARKING_LAYERS {
   CONTRACTOR_AND_CONTRACTOR_PLUS = 'Contractor Permit and Contractor+ Permit Authorized',
   CONTRACTOR_PLUS_ONLY = 'Only Contractor+ Permit Authorized'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/ContractorParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').contractorParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -17,7 +18,7 @@ export enum CROSS_COUNTRY_PARKING_LAYERS {
   PARKING_LOTS = 'cross-country-parking-lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/CrossCountryParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').crossCountryParkingUrl;
 
 export const CrossCountryParkingDefinitions = {
   CROSS_COUNTRY_AREA: {

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -18,7 +18,7 @@ export enum CROSS_COUNTRY_PARKING_LAYERS {
   PARKING_LOTS = 'cross-country-parking-lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').crossCountryParkingUrl;
+const eventUrl = Connections.crossCountryParkingUrl;
 
 export const CrossCountryParkingDefinitions = {
   CROSS_COUNTRY_AREA: {

--- a/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ev-chargers.definitions.ts
@@ -12,7 +12,7 @@ export enum EV_CHARGERS_LAYERS {
   EV_CHARGERS = 'ev-chargers'
 }
 
-const bikeLayersUrl = Connections('gis.it.tamu.edu').bikeMapUrl;
+const bikeLayersUrl = Connections.bikeMapUrl;
 
 export const EvChargersDefinitions = {
   EV_CHARGERS: {

--- a/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
@@ -18,7 +19,7 @@ export enum FAMILY_WEEKEND_LAYERS {
   SUNDAY_PARKING_LOTS = 'family-weekend-sunday-parking-lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Family_Weekend/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').familyWeekendUrl;
 
 const familyWeekendEventParkingSymbol = {
   type: 'simple-fill',

--- a/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/family-weekend.definitions.ts
@@ -19,7 +19,7 @@ export enum FAMILY_WEEKEND_LAYERS {
   SUNDAY_PARKING_LOTS = 'family-weekend-sunday-parking-lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').familyWeekendUrl;
+const eventUrl = Connections.familyWeekendUrl;
 
 const familyWeekendEventParkingSymbol = {
   type: 'simple-fill',

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -23,7 +23,7 @@ export enum FOOTBALL_PARKING_LAYERS {
   FP_GAMEDAY_SHUTTLE = 'football-gameday-shuttle'
 }
 
-const { tsFootballUrl: eventUrl, bikeMapUrl: bikeLayersUrl, footballGamedayShuttlesUrl: shuttleLayersUrl } = Connections('gis.it.tamu.edu');
+const { tsFootballUrl: eventUrl, bikeMapUrl: bikeLayersUrl, footballGamedayShuttlesUrl: shuttleLayersUrl } = Connections;
 
 const FootballParkingEventDefinitions = {
   FP_POIS: {

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -22,9 +23,7 @@ export enum FOOTBALL_PARKING_LAYERS {
   FP_GAMEDAY_SHUTTLE = 'football-gameday-shuttle'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TSFootball/MapServer';
-const bikeLayersUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/BikeMap/MapServer';
-const shuttleLayersUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Ftbl_Gameday_Shuttles/MapServer';
+const { tsFootballUrl: eventUrl, bikeMapUrl: bikeLayersUrl, footballGamedayShuttlesUrl: shuttleLayersUrl } = Connections('gis.it.tamu.edu');
 
 const FootballParkingEventDefinitions = {
   FP_POIS: {

--- a/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
@@ -13,7 +13,7 @@ export enum FRESHMAN_SELECTABLE_LAYERS {
   RESIDENT_STUDENT_PRIORITY = 'Resident Student Priority',
   FRESHMAN_STUDENT_SELECTABLE = 'Freshman Student Selectable'
 }
-const eventUrl = Connections('gis.it.tamu.edu').freshmanParkingUrl;
+const eventUrl = Connections.freshmanParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/freshman-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
@@ -12,7 +13,7 @@ export enum FRESHMAN_SELECTABLE_LAYERS {
   RESIDENT_STUDENT_PRIORITY = 'Resident Student Priority',
   FRESHMAN_STUDENT_SELECTABLE = 'Freshman Student Selectable'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/FreshmanSelectableParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').freshmanParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
@@ -13,7 +13,7 @@ export enum GIS_DAY_LAYERS {
   CSG = 'gis-day-csg'
 }
 
-const { gisDayUrl } = Connections('gis.it.tamu.edu');
+const { gisDayUrl } = Connections;
 const GARAGES_URL = `${gisDayUrl}/0`;
 const CSG_URL = `${gisDayUrl}/1`;
 const MSC_RUDDER_URL = `${gisDayUrl}/2`;

--- a/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/gis-day-map.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
   AggiemapCustomMapConfiguration,
@@ -12,14 +13,10 @@ export enum GIS_DAY_LAYERS {
   CSG = 'gis-day-csg'
 }
 
-const GARAGES_URL =
-  'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer/0';
-
-const CSG_URL =
-  'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer/1';
-
-const MSC_RUDDER_URL =
-  'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer/2';
+const { gisDayUrl } = Connections('gis.it.tamu.edu');
+const GARAGES_URL = `${gisDayUrl}/0`;
+const CSG_URL = `${gisDayUrl}/1`;
+const MSC_RUDDER_URL = `${gisDayUrl}/2`;
 
 export const GisDayLayerSources: LayerSource[] = [
   {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -20,7 +20,7 @@ export enum GRADUATION_LAYERS {
   GRADUATION_EVENT_PARKING_LOTS = 'graduation-event-parking-lots',
   GRADUATION_ROAD_CLOSURES = 'graduation-road-closed'
 }
-const eventUrl = Connections('gis.it.tamu.edu').graduationParkingUrl;
+const eventUrl = Connections.graduationParkingUrl;
 
 const GraduationEventDefinitions = {
   GRADUATION_ACCESSIBLE_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-fall.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -19,7 +20,7 @@ export enum GRADUATION_LAYERS {
   GRADUATION_EVENT_PARKING_LOTS = 'graduation-event-parking-lots',
   GRADUATION_ROAD_CLOSURES = 'graduation-road-closed'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/GraduationParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').graduationParkingUrl;
 
 const GraduationEventDefinitions = {
   GRADUATION_ACCESSIBLE_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -20,7 +20,7 @@ export enum GRADUATION_LAYERS {
   GRADUATION_EVENT_PARKING_LOTS = 'graduation-event-parking-lots',
   GRADUATION_ROAD_CLOSURES = 'graduation-road-closed'
 }
-const eventUrl = Connections('gis.it.tamu.edu').graduationParkingUrl;
+const eventUrl = Connections.graduationParkingUrl;
 
 const GraduationEventDefinitions = {
   GRADUATION_ACCESSIBLE_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-spring.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -19,7 +20,7 @@ export enum GRADUATION_LAYERS {
   GRADUATION_EVENT_PARKING_LOTS = 'graduation-event-parking-lots',
   GRADUATION_ROAD_CLOSURES = 'graduation-road-closed'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/GraduationParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').graduationParkingUrl;
 
 const GraduationEventDefinitions = {
   GRADUATION_ACCESSIBLE_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -15,7 +15,7 @@ export enum SUMMER_COMMENCEMENT_LAYERS {
   TRAFFIC_FLOW = 'summer-commencement-traffic-flow'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').summerCommencementUrl;
+const eventUrl = Connections.summerCommencementUrl;
 
 const SummerCommencementEventDefinitions = {
   TRAFFIC_FLOW: {

--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
@@ -14,7 +15,7 @@ export enum SUMMER_COMMENCEMENT_LAYERS {
   TRAFFIC_FLOW = 'summer-commencement-traffic-flow'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Summer_Commencement/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').summerCommencementUrl;
 
 const SummerCommencementEventDefinitions = {
   TRAFFIC_FLOW: {

--- a/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -15,7 +16,7 @@ export enum HS_GRADUATION_LAYERS {
   TRAFFIC_ADVISORIES = 'hs-graduation-traffic-advisories'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/HS_Graduation/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').hsGraduationUrl;
 
 const HsGraduationEventDefinitions = {
   GRADUATION_TRAFFIC_FLOW: {

--- a/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/hs-graduation.definitions.ts
@@ -16,7 +16,7 @@ export enum HS_GRADUATION_LAYERS {
   TRAFFIC_ADVISORIES = 'hs-graduation-traffic-advisories'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').hsGraduationUrl;
+const eventUrl = Connections.hsGraduationUrl;
 
 const HsGraduationEventDefinitions = {
   GRADUATION_TRAFFIC_FLOW: {

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -19,7 +19,7 @@ export enum INDOOR_TRACK_PARKING_LAYERS {
   TEAM_BUS_PARKING = 'indoor-track-parking-team-bus'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').indoorTrackParkingUrl;
+const eventUrl = Connections.indoorTrackParkingUrl;
 
 export const IndoorTrackParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -18,7 +19,7 @@ export enum INDOOR_TRACK_PARKING_LAYERS {
   TEAM_BUS_PARKING = 'indoor-track-parking-team-bus'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/IndoorTrackParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').indoorTrackParkingUrl;
 
 export const IndoorTrackParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -16,7 +16,7 @@ export enum TS_MAIN_PARKING_LAYERS {
   RNS_SPACES = 'RNS Spaces'
 }
 
-const eventUrl = Connections('gis.tamu.edu').tsMainUrl;
+const eventUrl = Connections.tsMainUrl;
 
 export const TsMainParkingDefinitions = {
   ROUTE_STOP_START_POINTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { AggiemapCustomMapConfiguration, EventConfiguration, SpecialEventOptions } from '../interfaces/special-event.interface';
@@ -15,7 +16,7 @@ export enum TS_MAIN_PARKING_LAYERS {
   RNS_SPACES = 'RNS Spaces'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TS_Main/MapServer';
+const eventUrl = Connections('gis.tamu.edu').tsMainUrl;
 
 export const TsMainParkingDefinitions = {
   ROUTE_STOP_START_POINTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
@@ -13,7 +14,7 @@ export enum MAINTENANCE_PARKING_LAYERS {
   MAINTENANCE_LOTS = 'maintenance-parking-lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MaintenanceParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').maintenanceParkingUrl;
 
 export const MaintenanceParkingDefinitions = {
   MAINTENANCE_SPACES: {

--- a/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maintenance-parking.definitions.ts
@@ -14,7 +14,7 @@ export enum MAINTENANCE_PARKING_LAYERS {
   MAINTENANCE_LOTS = 'maintenance-parking-lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').maintenanceParkingUrl;
+const eventUrl = Connections.maintenanceParkingUrl;
 
 export const MaintenanceParkingDefinitions = {
   MAINTENANCE_SPACES: {

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -15,7 +15,7 @@ export enum MAROON_WHITE_GAME_LAYERS {
   EVENT_PARKING_LOTS = 'maroon-white-game-event-parking-lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').maroonWhiteGameUrl;
+const eventUrl = Connections.maroonWhiteGameUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
@@ -14,7 +15,7 @@ export enum MAROON_WHITE_GAME_LAYERS {
   EVENT_PARKING_LOTS = 'maroon-white-game-event-parking-lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Maroon_White_Game/MapServer';
+const eventUrl = Connections('gis.tamu.edu').maroonWhiteGameUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
@@ -12,7 +12,7 @@ import {
 export enum MEDIA_PARKING_LAYERS {
   MEDIA_PARKING_LOTS = 'media-parking-lots'
 }
-const eventUrl = Connections('gis.tamu.edu').mediaParkingUrl;
+const eventUrl = Connections.mediaParkingUrl;
 
 export const MediaParkingDefinitions = {
   MEDIA_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/media-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
@@ -11,7 +12,7 @@ import {
 export enum MEDIA_PARKING_LAYERS {
   MEDIA_PARKING_LOTS = 'media-parking-lots'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MediaParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').mediaParkingUrl;
 
 export const MediaParkingDefinitions = {
   MEDIA_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -14,7 +15,7 @@ export enum MENS_BASKETBALL_LAYERS {
   PARKING_LOTS = 'mens-basketball-parking-lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/BaseMBasketTennisXCountry/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').mensBasketballUrl;
 
 export const MensBasketball_Definitions = {
   LINE_PAINT: {

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -15,7 +15,7 @@ export enum MENS_BASKETBALL_LAYERS {
   PARKING_LOTS = 'mens-basketball-parking-lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').mensBasketballUrl;
+const eventUrl = Connections.mensBasketballUrl;
 
 export const MensBasketball_Definitions = {
   LINE_PAINT: {

--- a/libs/ts/events/ngx/src/lib/definitions/motorcycle-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorcycle-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -11,7 +12,7 @@ export enum MOTORCYCLE_PARKING_LAYERS {
   MOTORCYCLE_PARKING_SPACE = 'motorcycle-parking-space'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MotorcycleParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').motorcycleParkingUrl;
 
 export const MotorcycleParkingDefinitions = {
   MOTORCYCLE_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/motorcycle-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorcycle-parking.definitions.ts
@@ -12,7 +12,7 @@ export enum MOTORCYCLE_PARKING_LAYERS {
   MOTORCYCLE_PARKING_SPACE = 'motorcycle-parking-space'
 }
 
-const eventUrl = Connections('gis.tamu.edu').motorcycleParkingUrl;
+const eventUrl = Connections.motorcycleParkingUrl;
 
 export const MotorcycleParkingDefinitions = {
   MOTORCYCLE_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -10,7 +11,7 @@ export enum MOTORIST_ASSISTANCE_LAYERS {
   SERVICE_AREA = 'Service Area'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MotoristAssistance/MapServer';
+const eventUrl = Connections('gis.tamu.edu').motoristAssistanceUrl;
 
 export const MotoristAssistanceDefinitions = {
   SERVICE_AREA: {

--- a/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/motorist-assistance.definitions.ts
@@ -11,7 +11,7 @@ export enum MOTORIST_ASSISTANCE_LAYERS {
   SERVICE_AREA = 'Service Area'
 }
 
-const eventUrl = Connections('gis.tamu.edu').motoristAssistanceUrl;
+const eventUrl = Connections.motoristAssistanceUrl;
 
 export const MotoristAssistanceDefinitions = {
   SERVICE_AREA: {

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -17,7 +17,7 @@ export enum MOVE_IN_LAYERS {
   RESIDENCE_HALL = 'Residence Hall'
 }
 
-const { moveInParkingUrl: moveInServiceUrl, basemapUrl: basemapServiceUrl } = Connections('gis.it.tamu.edu');
+const { moveInParkingUrl: moveInServiceUrl, basemapUrl: basemapServiceUrl } = Connections;
 
 const lotUseField = '"GIS.TS.SPEV_Lot_Use.Fall_MoveIn"';
 

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
@@ -16,8 +17,7 @@ export enum MOVE_IN_LAYERS {
   RESIDENCE_HALL = 'Residence Hall'
 }
 
-const moveInServiceUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/FallMoveInParking/MapServer';
-const basemapServiceUrl = 'https://gis.tamu.edu/arcgis/rest/services/FCOR/TAMU_BaseMap/MapServer';
+const { moveInParkingUrl: moveInServiceUrl, basemapUrl: basemapServiceUrl } = Connections('gis.it.tamu.edu');
 
 const lotUseField = '"GIS.TS.SPEV_Lot_Use.Fall_MoveIn"';
 

--- a/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -13,7 +14,7 @@ export enum MOVE_OUT_LAYERS {
   MOVE_OUT_LOTS = 'Move-Out Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/MoveOutParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').moveOutParkingUrl;
 
 export const MoveOutDefinitions = {
   NO_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-out.definitions.ts
@@ -14,7 +14,7 @@ export enum MOVE_OUT_LAYERS {
   MOVE_OUT_LOTS = 'Move-Out Lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').moveOutParkingUrl;
+const eventUrl = Connections.moveOutParkingUrl;
 
 export const MoveOutDefinitions = {
   NO_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
@@ -14,7 +14,7 @@ export enum MS150_LAYERS {
   ROUTE = 'ms150-route'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').ms150Url;
+const eventUrl = Connections.ms150Url;
 
 export const MS150Definitions = {
   AVP_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ms150.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -13,7 +14,7 @@ export enum MS150_LAYERS {
   ROUTE = 'ms150-route'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/MS150/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').ms150Url;
 
 export const MS150Definitions = {
   AVP_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
@@ -17,7 +17,7 @@ export enum MUSTER_LAYERS {
   ACCESSIBLE_PARKING = 'muster-accessible-parking'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').musterUrl;
+const eventUrl = Connections.musterUrl;
 const accessibleParkingIconUrl = eventUrl + '/1/images/956c1de4ae59fdb677e36c1631af01e3';
 
 export const MusterEventDefinitions = {

--- a/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/muster.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum MUSTER_LAYERS {
   ACCESSIBLE_PARKING = 'muster-accessible-parking'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Muster/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').musterUrl;
 const accessibleParkingIconUrl = eventUrl + '/1/images/956c1de4ae59fdb677e36c1631af01e3';
 
 export const MusterEventDefinitions = {

--- a/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -11,7 +12,7 @@ export enum NIGHT_WEEKEND_LAYERS {
   NIGHT_PRIVILEGES = 'Night Privileges 5:00pm - 6:00am'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/NightWeekendParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').nightWeekendParkingUrl;
 
 export const NightWeekendDefinitions = {
   NIGHT_PRIVILEGES: {

--- a/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/night-weekend.definitions.ts
@@ -12,7 +12,7 @@ export enum NIGHT_WEEKEND_LAYERS {
   NIGHT_PRIVILEGES = 'Night Privileges 5:00pm - 6:00am'
 }
 
-const eventUrl = Connections('gis.tamu.edu').nightWeekendParkingUrl;
+const eventUrl = Connections.nightWeekendParkingUrl;
 
 export const NightWeekendDefinitions = {
   NIGHT_PRIVILEGES: {

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   AggiemapCustomMapConfiguration,
@@ -14,7 +15,7 @@ export enum NSC_PARKING_LAYERS {
   NSC_PARKING_LOTS = 'NSC Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/NewStudentConferenceParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').nscParkingUrl;
 
 export const NscParkingDefinitions = {
   NSC_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -15,7 +15,7 @@ export enum NSC_PARKING_LAYERS {
   NSC_PARKING_LOTS = 'NSC Parking Lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').nscParkingUrl;
+const eventUrl = Connections.nscParkingUrl;
 
 export const NscParkingDefinitions = {
   NSC_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum OUTDOOR_TRACK_PARKING_LAYERS {
   SAFETY_FIRST = 'outdoor-track-parking-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/OutdoorTrackParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').outdoorTrackParkingUrl;
 
 export const OutdoorTrackParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -17,7 +17,7 @@ export enum OUTDOOR_TRACK_PARKING_LAYERS {
   SAFETY_FIRST = 'outdoor-track-parking-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').outdoorTrackParkingUrl;
+const eventUrl = Connections.outdoorTrackParkingUrl;
 
 export const OutdoorTrackParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -27,7 +27,7 @@ export enum PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS {
   WESTBOUND_PEDESTRIAN_PATH = 'phys-eng-festival-westbound-pedestrian-path'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').physicsFestUrl;
+const eventUrl = Connections.physicsFestUrl;
 
 type AutoCastSimpleLineSymbol = { type: 'simple-line' } & esri.SimpleLineSymbolProperties;
 

--- a/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/phys-engineering-festival.definitions.ts
@@ -1,4 +1,5 @@
 import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -26,7 +27,7 @@ export enum PHYSICS_AND_ENGINEERING_FESTIVAL_LAYERS {
   WESTBOUND_PEDESTRIAN_PATH = 'phys-eng-festival-westbound-pedestrian-path'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Physics_Fest/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').physicsFestUrl;
 
 type AutoCastSimpleLineSymbol = { type: 'simple-line' } & esri.SimpleLineSymbolProperties;
 

--- a/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
@@ -12,7 +12,7 @@ export enum RETIREE_PARKING_LAYERS {
   RETIREE_PARKING_LOTS = 'Retiree Parking Lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').retireeParkingUrl;
+const eventUrl = Connections.retireeParkingUrl;
 
 export const RetireeParkingDefinitions = {
   RETIREE_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/retiree-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import {
   EventConfiguration,
@@ -11,7 +12,7 @@ export enum RETIREE_PARKING_LAYERS {
   RETIREE_PARKING_LOTS = 'Retiree Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/RetireeParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').retireeParkingUrl;
 
 export const RetireeParkingDefinitions = {
   RETIREE_PARKING_LOTS: {

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -20,7 +20,7 @@ enum RingDayDates {
   DAY3 = '2026-04-10'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').ringDayUrl;
+const eventUrl = Connections.ringDayUrl;
 
 const RingDayEventDefinitions = {
   RD_AREAS: {

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -19,7 +20,7 @@ enum RingDayDates {
   DAY3 = '2026-04-10'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Ring_Day/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').ringDayUrl;
 
 const RingDayEventDefinitions = {
   RD_AREAS: {

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -17,7 +17,7 @@ export enum SAVANNAH_BANANAS_PARKING_LAYERS {
   EVENT_PARKING = 'savannah-bananas-event-parking'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').savannahBananasUrl;
+const eventUrl = Connections.savannahBananasUrl;
 
 export const SavannahBananasParkingDefinitions = {
   SHUTTLE_GROUP: {

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum SAVANNAH_BANANAS_PARKING_LAYERS {
   EVENT_PARKING = 'savannah-bananas-event-parking'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SavannahBananas/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').savannahBananasUrl;
 
 export const SavannahBananasParkingDefinitions = {
   SHUTTLE_GROUP: {

--- a/libs/ts/events/ngx/src/lib/definitions/sec-grounds-conference.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sec-grounds-conference.definitions.ts
@@ -21,7 +21,7 @@ enum ConferenceDay {
   DAY3 = 'day3'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').secGroundsConferenceUrl;
+const eventUrl = Connections.secGroundsConferenceUrl;
 
 type FeatureLayerNative = NonNullable<FeatureLayerSourceProperties['native']>;
 type AutoCastCimSymbol = { type: 'cim' } & esri.CIMSymbolProperties;

--- a/libs/ts/events/ngx/src/lib/definitions/sec-grounds-conference.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sec-grounds-conference.definitions.ts
@@ -1,4 +1,5 @@
 import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { AggiemapCustomMapConfiguration, EventConfiguration, SpecialEventOptions } from '../interfaces/special-event.interface';
@@ -20,7 +21,7 @@ enum ConferenceDay {
   DAY3 = 'day3'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SEC_Grounds_Conference/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').secGroundsConferenceUrl;
 
 type FeatureLayerNative = NonNullable<FeatureLayerSourceProperties['native']>;
 type AutoCastCimSymbol = { type: 'cim' } & esri.CIMSymbolProperties;

--- a/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 
@@ -12,7 +13,7 @@ export enum SERVICE_LOADING_LAYERS {
   SERVICE_SPACES = 'service-parking-spaces',
   SERVICE_LOTS = 'service-parking-lots'
 }
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Loading_Zones/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').loadingZonesUrl;
 
 export const ServiceLoadingDefinitions = {
   SERVICE_SPACES: {

--- a/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/service-and-loading-zones.definitions.ts
@@ -13,7 +13,7 @@ export enum SERVICE_LOADING_LAYERS {
   SERVICE_SPACES = 'service-parking-spaces',
   SERVICE_LOTS = 'service-parking-lots'
 }
-const eventUrl = Connections('gis.it.tamu.edu').loadingZonesUrl;
+const eventUrl = Connections.loadingZonesUrl;
 
 export const ServiceLoadingDefinitions = {
   SERVICE_SPACES: {

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -17,7 +17,7 @@ export enum SOCCER_PARKING_LAYERS {
   SAFETY_FIRST = 'soccer-parking-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').soccerParkingUrl;
+const eventUrl = Connections.soccerParkingUrl;
 
 export const SoccerParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum SOCCER_PARKING_LAYERS {
   SAFETY_FIRST = 'soccer-parking-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SoccerParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').soccerParkingUrl;
 
 export const SoccerParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum SOFTBALL_PARKING_LAYERS {
   SAFETY_FIRST = 'softball-parking-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SoftballParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').softballParkingUrl;
 
 export const SoftballParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -17,7 +17,7 @@ export enum SOFTBALL_PARKING_LAYERS {
   SAFETY_FIRST = 'softball-parking-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').softballParkingUrl;
+const eventUrl = Connections.softballParkingUrl;
 
 export const SoftballParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -15,7 +15,7 @@ export enum SOFTBALL_LAYERS {
   SOFTBALL_LOCATIONS = 'softball-locations'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').softballRegionalsUrl;
+const eventUrl = Connections.softballRegionalsUrl;
 
 const SoftballEventDefinitions = {
   SOFTBALL_ROUTES: {

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -14,7 +15,7 @@ export enum SOFTBALL_LAYERS {
   SOFTBALL_LOCATIONS = 'softball-locations'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/Softball_Regionals/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').softballRegionalsUrl;
 
 const SoftballEventDefinitions = {
   SOFTBALL_ROUTES: {

--- a/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
@@ -12,7 +12,7 @@ export enum STAFF_SELECTABLE_LAYERS {
   STAFF_SELECTABLE = 'Staff Selectable Parking Lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').staffParkingUrl;
+const eventUrl = Connections.staffParkingUrl;
 
 export const StaffSelectableDefinitions = {
   STAFF_SELECTABLE: {

--- a/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/staff-selectable.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -11,7 +12,7 @@ export enum STAFF_SELECTABLE_LAYERS {
   STAFF_SELECTABLE = 'Staff Selectable Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/StaffSelectableParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').staffParkingUrl;
 
 export const StaffSelectableDefinitions = {
   STAFF_SELECTABLE: {

--- a/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -10,7 +11,7 @@ import {
 export enum STUDENT_SELECTABLE_LAYERS {
   STUDENT_SELECTABLE = 'Student Selectable Parking Lots'
 }
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/StudentSelectableParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').studentParkingUrl;
 
 export const StudentSelectableDefinitions = {
   STUDENT_SELECTABLE: {

--- a/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/student-selectable.definitions.ts
@@ -11,7 +11,7 @@ import {
 export enum STUDENT_SELECTABLE_LAYERS {
   STUDENT_SELECTABLE = 'Student Selectable Parking Lots'
 }
-const eventUrl = Connections('gis.tamu.edu').studentParkingUrl;
+const eventUrl = Connections.studentParkingUrl;
 
 export const StudentSelectableDefinitions = {
   STUDENT_SELECTABLE: {

--- a/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/sustainable-transportation.definitions.ts
@@ -18,7 +18,7 @@ export enum SUSTAINABLE_TRANSPORTATION_LAYERS {
   BIKE_DISMOUNT_ZONES = 'sustainable-transportation-bike-dismount-zones',
 }
 
-const bikeLayersUrl = Connections('gis.it.tamu.edu').bikeMapUrl;
+const bikeLayersUrl = Connections.bikeMapUrl;
 
 export const SustainableTransportationEvChargersLayerSource: LayerSource = {
   type: 'feature',

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -17,7 +17,7 @@ export enum SWIMMING_PARKING_LAYERS {
   SAFETY_FIRST = 'swimming-parking-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').swimmingParkingUrl;
+const eventUrl = Connections.swimmingParkingUrl;
 
 export const SwimmingParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum SWIMMING_PARKING_LAYERS {
   SAFETY_FIRST = 'swimming-parking-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/SwimmingParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').swimmingParkingUrl;
 
 export const SwimmingParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -12,7 +12,7 @@ export enum TENNIS_PARKING_LAYERS {
   PARKING_LOTS = 'tennis-parking-lots'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').tennisParkingUrl;
+const eventUrl = Connections.tennisParkingUrl;
 
 export const TennisParkingDefinitions = {
   PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -11,7 +12,7 @@ export enum TENNIS_PARKING_LAYERS {
   PARKING_LOTS = 'tennis-parking-lots'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/TennisParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').tennisParkingUrl;
 
 export const TennisParkingDefinitions = {
   PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
@@ -12,7 +12,7 @@ export enum TIMED_PARKING_LAYERS {
   TIMED_PARKING_SPACE = 'Timed Parking Space'
 }
 
-const eventUrl = Connections('gis.tamu.edu').timedParkingUrl;
+const eventUrl = Connections.timedParkingUrl;
 
 export const TimedParkingDefinitions = {
   TIMED_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/timed-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -11,7 +12,7 @@ export enum TIMED_PARKING_LAYERS {
   TIMED_PARKING_SPACE = 'Timed Parking Space'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/TimedParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').timedParkingUrl;
 
 export const TimedParkingDefinitions = {
   TIMED_PARKING_SPACE: {

--- a/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
 
@@ -12,7 +13,7 @@ export enum TROUBADOUR_LAYERS {
   PARKING = 'troubadour-parking'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/Troubadour_Festival/MapServer';
+const eventUrl = Connections('gis.tamu.edu').troubadourFestivalUrl;
 
 const TroubadourFestivalEventDefinitions = {
   TROUBADOUR_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
@@ -13,7 +13,7 @@ export enum TROUBADOUR_LAYERS {
   PARKING = 'troubadour-parking'
 }
 
-const eventUrl = Connections('gis.tamu.edu').troubadourFestivalUrl;
+const eventUrl = Connections.troubadourFestivalUrl;
 
 const TroubadourFestivalEventDefinitions = {
   TROUBADOUR_PARKING: {

--- a/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
@@ -11,7 +11,7 @@ export enum VENDOR_PARKING_LAYERS {
   VENDOR_PARKING_LOTS = 'vendor-parking-lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').vendorParkingUrl;
+const eventUrl = Connections.vendorParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/vendor-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { AggiemapCustomMapConfiguration, EventConfiguration, SpecialEventOptions } from '../interfaces/special-event.interface';
@@ -10,7 +11,7 @@ export enum VENDOR_PARKING_LAYERS {
   VENDOR_PARKING_LOTS = 'vendor-parking-lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/VendorParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').vendorParkingUrl;
 
 type FeatureNative = Extract<LayerSource, { type: 'feature' }>['native'];
 type FeatureRenderer = NonNullable<NonNullable<FeatureNative>['renderer']>;

--- a/libs/ts/events/ngx/src/lib/definitions/visitor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/visitor-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
@@ -15,7 +16,7 @@ export enum VISITOR_PARKING_LAYERS {
   VISITOR_PARKING_LOTS = 'Visitor Parking Lots'
 }
 
-const eventUrl = 'https://gis.tamu.edu/arcgis/rest/services/TS/VisitorParking/MapServer';
+const eventUrl = Connections('gis.tamu.edu').visitorParkingUrl;
 
 export const VisitorParkingDefinitions = {
   VISITOR_KIOSKS: {

--- a/libs/ts/events/ngx/src/lib/definitions/visitor-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/visitor-parking.definitions.ts
@@ -16,7 +16,7 @@ export enum VISITOR_PARKING_LAYERS {
   VISITOR_PARKING_LOTS = 'Visitor Parking Lots'
 }
 
-const eventUrl = Connections('gis.tamu.edu').visitorParkingUrl;
+const eventUrl = Connections.visitorParkingUrl;
 
 export const VisitorParkingDefinitions = {
   VISITOR_KIOSKS: {

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -17,7 +17,7 @@ export enum VOLLEYBALL_PARKING_LAYERS {
   SAFETY_FIRST = 'volleyball-parking-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').volleyballParkingUrl;
+const eventUrl = Connections.volleyballParkingUrl;
 
 export const VolleyballParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -16,7 +17,7 @@ export enum VOLLEYBALL_PARKING_LAYERS {
   SAFETY_FIRST = 'volleyball-parking-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/VolleyballParking/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').volleyballParkingUrl;
 
 export const VolleyballParkingDefinitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -1,4 +1,5 @@
 import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -14,7 +15,7 @@ export enum WOMENS_BASKETBALL_LAYERS {
   SAFETY_FIRST = 'womens-basketball-safety-first'
 }
 
-const eventUrl = 'https://gis.it.tamu.edu/arcgis/rest/services/TS/TracSocSoftSwimVollWbask/MapServer';
+const eventUrl = Connections('gis.it.tamu.edu').womensBasketballUrl;
 
 export const WomensBasketball_Definitions = {
   VISITOR_KIOSK: {

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -15,7 +15,7 @@ export enum WOMENS_BASKETBALL_LAYERS {
   SAFETY_FIRST = 'womens-basketball-safety-first'
 }
 
-const eventUrl = Connections('gis.it.tamu.edu').womensBasketballUrl;
+const eventUrl = Connections.womensBasketballUrl;
 
 export const WomensBasketball_Definitions = {
   VISITOR_KIOSK: {


### PR DESCRIPTION
This PR cleans up how AggieMap layer source URLs are managed by moving map URLs into the shared 'connections.ts config file and updating event map definitions to reference those shared values instead of hardcoded URLs.

It also updates the previously hardcoded common layer definitions, including AggiePrint and single-occupancy restrooms, so source configuration is more consistent across the app. 

Closes #768 