### PR TITLE
fix(aggiemap-angular): Reorganize Banana Ball layer groups

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -111,7 +111,10 @@ export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
           outFields: ['*']
         }
       }
-    ]
+    ],
+    native: {
+      listMode: 'hide-children'
+    }
   },
   {
     type: 'group',
@@ -120,6 +123,26 @@ export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
     sources: [
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
+        title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
+        url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
       {
         type: 'feature',
         id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
@@ -147,28 +170,11 @@ export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
         native: {
           outFields: ['*']
         }
-      },
-      {
-        type: 'feature',
-        id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
-        title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
-        url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
-        popupComponent: MarkdownWDirectionsPopupComponent,
-        popupData: {
-          name: {
-            field: 'name'
-          },
-          description: {
-            field: 'description'
-          }
-        },
-        visible: true,
-        listMode: 'show',
-        native: {
-          outFields: ['*']
-        }
       }
-    ]
+    ],
+    native: {
+      listMode: 'hide-children'
+    }
   }
 ];
 

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -53,106 +53,122 @@ export const SavannahBananasParkingDefinitions = {
   EVENT_PARKING: {
     id: SAVANNAH_BANANAS_PARKING_LAYERS.EVENT_PARKING,
     layerId: SAVANNAH_BANANAS_PARKING_LAYERS.EVENT_PARKING,
-    name: 'Event Parking',
+    name: 'Event Lots',
     url: `${eventUrl}/5`
   }
 };
 
 const SavannahBananasLayerReferences: Record<string, string> = {
-  SHUTTLE_STOPS: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_STOPS,
-  SHUTTLE_ROUTES: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_ROUTES,
-  ACCESSIBLE_PREPAID_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.ACCESSIBLE_PREPAID_PARKING,
-  EVENT_PARKING: SAVANNAH_BANANAS_PARKING_LAYERS.EVENT_PARKING
+  PARKING_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.PARKING_GROUP,
+  SHUTTLE_GROUP: SAVANNAH_BANANAS_PARKING_LAYERS.SHUTTLE_GROUP
 };
 
 export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
   {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
-    title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
-    url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
-      },
-      description: {
-        field: 'description'
-      }
-    },
+    type: 'group',
+    id: SavannahBananasParkingDefinitions.PARKING_GROUP.id,
+    title: SavannahBananasParkingDefinitions.PARKING_GROUP.name,
     visible: true,
     listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
+    sources: [
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.EVENT_PARKING.id,
+        title: SavannahBananasParkingDefinitions.EVENT_PARKING.name,
+        url: SavannahBananasParkingDefinitions.EVENT_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
+        title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
+        url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      }
+    ]
   },
   {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.id,
-    title: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.name,
-    url: SavannahBananasParkingDefinitions.ACCESSIBLE_PREPAID_PARKING.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
+    type: 'group',
+    id: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.id,
+    title: SavannahBananasParkingDefinitions.SHUTTLE_GROUP.name,
+    visible: true,
+    listMode: 'show',
+    sources: [
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
+        title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
+        url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupDataResolutionStrategy: 'cumulative',
+        popupData: {
+          name: {
+            field: 'StopName'
+          },
+          routeName: {
+            field: 'RouteName'
+          },
+          route: {
+            field: 'Route'
+          },
+          stopNumber: {
+            field: 'StopNum'
+          },
+          description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       },
-      description: {
-        field: 'description'
+      {
+        type: 'feature',
+        id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
+        title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
+        url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: {
+            field: 'name'
+          },
+          description: {
+            field: 'description'
+          }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
       }
-    },
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.id,
-    title: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.name,
-    url: SavannahBananasParkingDefinitions.SHUTTLE_ROUTES.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupData: {
-      name: {
-        field: 'name'
-      },
-      description: {
-        field: 'description'
-      }
-    },
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.id,
-    title: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.name,
-    url: SavannahBananasParkingDefinitions.SHUTTLE_STOPS.url,
-    popupComponent: MarkdownWDirectionsPopupComponent,
-    popupDataResolutionStrategy: 'cumulative',
-    popupData: {
-      name: {
-        field: 'StopName'
-      },
-      routeName: {
-        field: 'RouteName'
-      },
-      route: {
-        field: 'Route'
-      },
-      stopNumber: {
-        field: 'StopNum'
-      },
-      description: '<strong>{attributes.routeName}</strong><br>Route {attributes.route}<br>Stop {attributes.stopNumber}'
-    },
-    visible: true,
-    listMode: 'show',
-    native: {
-      outFields: ['*']
-    }
+    ]
   }
 ];
 
@@ -166,7 +182,8 @@ export const SavannahBananasParkingConfiguration: EventConfiguration = {
   scheduleUrl: 'https://app.12thman.com/bananaball',
   mapCenter: [-96.34046, 30.60798],
   zoom: 16,
-  legendAllowVisibilityToggle: true
+  legendAllowVisibilityToggle: true,
+  legendCombineChildrenUnderPrimary: true
 };
 
 export const SavannahBananasParkingOptions: SpecialEventOptions = [];


### PR DESCRIPTION
This PR reorganizes the group layers for Banana Ball to fit the following order:




- "Event Parking" (Main grouping)
-- "Event Lots"
-- "Accessible/Prepaid/AVP Parking"

- "Event Shuttles" (Main grouping)
-- "Campus Shuttle Stops"
-- "Shuttle Routes"



<img width="2087" height="1204" alt="image" src="https://github.com/user-attachments/assets/6522c563-7c71-4f31-9363-2a36d404accc" />



<img width="3805" height="1805" alt="image" src="https://github.com/user-attachments/assets/d1c34c25-6882-4a56-83fb-52166e4a55b9" />

Closes #780 