### PR TITLE
fix(aggiemap-angular): Update link for Changelog on ? menu for AggieMap

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -14,7 +14,7 @@
       <p><a href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a routerLink="/requesting-maps" tabindex="0">Requesting Maps &amp; Changes</a></p>
       <p><a routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed+sort%3Aupdated-desc" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
+++ b/libs/aggiemap/ngx/ui/mobile/src/lib/components/main-mobile-sidebar/main-mobile-sidebar.component.ts
@@ -78,7 +78,7 @@ export class MainMobileSidebarComponent {
     {
       name: 'Changelog',
       type: 'link-external',
-      path: 'https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed'
+      path: 'https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed'
     }
   ];
 

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -12,7 +12,7 @@
       <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
       <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/football/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/football/ngx/src/lib/modules/map/map.component.html
@@ -11,7 +11,7 @@
       <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
       <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
@@ -11,7 +11,7 @@
       <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
       <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
@@ -11,7 +11,7 @@
       <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
       <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
@@ -11,7 +11,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
       <p><a href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
       <p><a routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
This PR updates the Changelog to link to https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed 

instead of https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+project%3Atamugeoinnovation%2F2+is%3Aclosed

Closes #781 
