### PR TITLE
fix(aggiemap-angular) Fix popups for grouped layer maps

### DIFF
--- a/libs/ts/events/ngx/src/lib/services/event/event.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/event/event.service.ts
@@ -165,16 +165,33 @@ export class EventService {
     const sources: Array<LayerSource> = this.eventSettingsService.eventLayerSources();
     const root = sources.find((s) => s.id == reference);
 
-    const popupComponent = root?.popupComponent;
-
     if (root) {
       const copied = JSON.parse(JSON.stringify(root));
 
-      copied.popupComponent = popupComponent;
+      // JSON.stringify strips non-serializable values like Angular component class references.
+      // Walk both trees in parallel to restore them on the cloned copy.
+      this._restoreNonSerializableSourceProperties(root, copied);
 
       return copied;
     } else {
       throw new Error(`Layer source reference '${reference}' not found.`);
+    }
+  }
+
+  private _restoreNonSerializableSourceProperties(original: LayerSource, copy: LayerSource): void {
+    if (original.popupComponent) {
+      copy.popupComponent = original.popupComponent;
+    }
+
+    const originalChildren = (original as { sources?: LayerSource[] }).sources;
+    const copyChildren = (copy as { sources?: LayerSource[] }).sources;
+
+    if (originalChildren && copyChildren) {
+      originalChildren.forEach((child, index) => {
+        if (copyChildren[index]) {
+          this._restoreNonSerializableSourceProperties(child, copyChildren[index]);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where popups were not loading on special event maps with grouped dropdown layers, like the Banana Ball Map and Physics Festival Map (when those layers appear, that is...):

<img width="1109" height="812" alt="image" src="https://github.com/user-attachments/assets/666ecc2c-7721-4dc7-9cf0-d2566e74a8cc" />


<img width="1267" height="880" alt="image" src="https://github.com/user-attachments/assets/5357db8d-5a41-4688-ac90-627bc7c36824" />

This does not resolve issue #793 and is still being actively investigated.