### PR TITLE
fix(aggiemap): Standardize ? menu across all maps + fix duplicate Request Maps button

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -13,10 +13,12 @@
       <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
       <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
-      <p><a href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a routerLink="/requesting-maps" tabindex="0">Requesting Maps &amp; Changes</a></p>
-      <p><a routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/map/map.component.html
@@ -18,7 +18,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -4,15 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
-      <p><a title="" routerLink="/instructions" tabindex="0">Map Instructions</a></p>
-      <p><a title="" routerLink="/directory" tabindex="0">Building Directory</a></p>
-      <p><a title="" href="https://aggiemap.tamu.edu/feedback.asp" tabindex="0">Feedback</a></p>
-      <p><a title="" routerLink="/about" tabindex="0">About</a></p>
-      <p><a title="" routerLink="/discover" tabindex="0">All Maps</a></p>
-      <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
+      <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
+      <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/events/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/map/map.component.scss
@@ -42,6 +42,12 @@
   outline-offset: 2px;
 }
 
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}
+
 @media only screen and (max-width: 768px) {
   .map-overlay-ui .overlay-zone.top.left {
     left: 1rem;

--- a/libs/ts/football/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/football/ngx/src/lib/modules/map/map.component.html
@@ -4,14 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
-      <p><a title="" routerLink="/instructions" tabindex="0">Map Instructions</a></p>
-      <p><a title="" routerLink="/directory" tabindex="0">Building Directory</a></p>
-      <p><a title="" href="https://aggiemap.tamu.edu/feedback.asp" tabindex="0">Feedback</a></p>
-      <p><a title="" routerLink="/about" tabindex="0">About</a></p>
-      <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
+      <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
+      <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/football/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/football/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/football/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ts/football/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,8 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}

--- a/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
@@ -4,14 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
-      <p><a title="" routerLink="/instructions" tabindex="0">Map Instructions</a></p>
-      <p><a title="" routerLink="/directory" tabindex="0">Building Directory</a></p>
-      <p><a title="" href="https://aggiemap.tamu.edu/feedback.asp" tabindex="0">Feedback</a></p>
-      <p><a title="" routerLink="/about" tabindex="0">About</a></p>
-      <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
+      <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
+      <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/movein/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/movein/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ts/movein/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,8 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}

--- a/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
@@ -4,14 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
-      <p><a title="" routerLink="/instructions" tabindex="0">Map Instructions</a></p>
-      <p><a title="" routerLink="/directory" tabindex="0">Building Directory</a></p>
-      <p><a title="" href="https://aggiemap.tamu.edu/feedback.asp" tabindex="0">Feedback</a></p>
-      <p><a title="" routerLink="/about" tabindex="0">About</a></p>
-      <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a title="" routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a title="" href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
+      <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
+      <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ts/ringday/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ts/ringday/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ts/ringday/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,8 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}

--- a/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
@@ -4,14 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
       <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
       <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
-      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Feedback</a></p>
-      <p><a routerLink="/about" tabindex="0">About</a></p>
-      <p><a href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
-      <p><a routerLink="/privacy" tabindex="0">Privacy &amp; Security</a></p>
-      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ues/effluent/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ues/effluent/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ues/effluent/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,8 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}

--- a/libs/ues/operations/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ues/operations/ngx/src/lib/modules/map/map.component.html
@@ -4,8 +4,20 @@
   <div class="help map-ui-element" title="Instructions and policies" tabindex="0" role="button" aria-label="Click for map usage instructions and policies" *ngIf="!isMobile" (click)="toggleClass($event, 'active')" (keydown.space)="toggleClass($event, 'active')" (keydown.enter)="toggleClass($event, 'active')">
     <span class="material-icons">help</span>
     <div class="topics">
-      <p><a title="" href="https://www.tamu.edu/statements/index.html" tabindex="0">Site Policies</a></p>
-      <p><a title="" href="http://itaccessibility.tamu.edu" tabindex="0">Accessibility Policy</a></p>
+      <p><a routerLink="/discover" tabindex="0">All Maps</a></p>
+      <p><a routerLink="/about" tabindex="0">About Aggie Map</a></p>
+      <p><a routerLink="/instructions" tabindex="0">Map Instructions</a></p>
+      <p><a routerLink="/directory" tabindex="0">Building Directory</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a routerLink="/requesting-maps" tabindex="0">Request Maps &amp; Changes</a></p>
+      <p><a href="mailto:aggiemap@tamu.edu?subject=Aggiemap%20Feedback" target="_blank" tabindex="0">Submit Feedback</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="http://itaccessibility.tamu.edu" target="_blank" tabindex="0">Accessibility Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/privacy.html" target="_blank" tabindex="0">Privacy &amp; Security Policy</a></p>
+      <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
+      <p class="topics-separator" aria-hidden="true"></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
+      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ues/operations/ngx/src/lib/modules/map/map.component.html
+++ b/libs/ues/operations/ngx/src/lib/modules/map/map.component.html
@@ -17,7 +17,7 @@
       <p><a href="https://www.tamu.edu/statements/index.html" target="_blank" tabindex="0">Site Policies</a></p>
       <p class="topics-separator" aria-hidden="true"></p>
       <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo" target="_blank" tabindex="0">GitHub</a></p>
-      <p><a routerLink="/changelog" tabindex="0">Changelog</a></p>
+      <p><a href="https://github.com/TamuGeoInnovation/Tamu.GeoInnovation.js.monorepo/pulls?q=is%3Apr+is%3Aclosed" target="_blank" tabindex="0">Changelog</a></p>
     </div>
   </div>
 

--- a/libs/ues/operations/ngx/src/lib/modules/map/map.component.scss
+++ b/libs/ues/operations/ngx/src/lib/modules/map/map.component.scss
@@ -1,2 +1,8 @@
 @import 'libs/sass/mixins';
 @import 'libs/sass/modules/esri_map';
+
+.help .topics .topics-separator {
+  margin: 0.6rem 0;
+  border-top: 1px solid rgb(0 0 0 / 14%);
+  pointer-events: none;
+}


### PR DESCRIPTION
This PR updates the help (?) <img width="31" height="34" alt="image" src="https://github.com/user-attachments/assets/86008d04-b12e-4244-84fc-cc685bff447f" /> menu to a consistent structure across all maps.

Changes:

- Removed duplicate "Requesting Maps & Changes" typo
- Standardized menu items and order to match the reference design: All Maps, About Aggie Map, Map Instructions, Building Directory, Request Maps & Changes, Submit Feedback, Accessibility Policy, Privacy & Security Policy, Site Policies, GitHub, Changelog
- Updated Privacy & Security to link to tamu.edu/statements/privacy.html and added Site Policies (tamu.edu/statements/index.html)
    - This was supposed to be added in #771 but was accidentally removed when trying to resolve a merge conflict


New menu working in Baseball map:

<img width="1905" height="947" alt="image" src="https://github.com/user-attachments/assets/2cb2e820-ec86-4e14-8c18-a4e03d38449e" />

Closes #784 