### PR TITLE
feat(aggiemap-angular): Honduras vs Argentina map

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -63,7 +63,8 @@ function createConnections(gisHost: string): IComposedConnections {
     volleyballParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/VolleyballParking/MapServer`,
     womensBasketballUrl: `https://${gisHost}/arcgis/rest/services/TS/TracSocSoftSwimVollWbask/MapServer`,
     fourHRoundupUrl: `https://${gisHost}/arcgis/rest/services/TS/4H_Roundup/MapServer`,
-    gisDayUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer'
+    gisDayUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer',
+    argentinaVsHondurasUrl: `https://${gisHost}/arcgis/rest/services/TS/Argentina_vs_Honduras26/MapServer`
   };
 }
 
@@ -145,4 +146,5 @@ export interface IComposedConnections {
   womensBasketballUrl: string;
   fourHRoundupUrl: string;
   gisDayUrl: string;
+  argentinaVsHondurasUrl: string;
 }

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -53,6 +53,7 @@ import { SustainableTransportationTs } from './sustainable-transportation.defini
 import { EvChargersTs } from './ev-chargers.definitions';
 import { TsMainParkingTs } from './main-parking.definitions';
 import { SecGroundsConferenceTs } from './sec-grounds-conference.definitions';
+import { ArgentinaVsHondurasTs } from './argentina-vs-honduras.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -108,5 +109,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   SustainableTransportationTs,
   EvChargersTs,
   TsMainParkingTs,
-  SecGroundsConferenceTs
+  SecGroundsConferenceTs,
+  ArgentinaVsHondurasTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
@@ -1,0 +1,183 @@
+import { LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+import { MarkdownWDirectionsPopupComponent } from '../modules/popups/markdown-w-directions-popup/markdown-w-directions-popup.component';
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
+
+export enum ARGENTINA_VS_HONDURAS_LAYERS {
+  EVENT_SHUTTLES_GROUP = 'argentina-vs-honduras-event-shuttles-group',
+  CAMPUS_SHUTTLE_STOPS = 'argentina-vs-honduras-campus-shuttle-stops',
+  SHUTTLE_ROUTES = 'argentina-vs-honduras-shuttle-routes',
+  EVENT_PARKING_GROUP = 'argentina-vs-honduras-event-parking-group',
+  PARKING_AND_RIDESHARE = 'argentina-vs-honduras-parking-and-rideshare',
+  EVENT_PARKING = 'argentina-vs-honduras-event-parking'
+}
+
+const eventUrl = Connections.argentinaVsHondurasUrl;
+
+const ArgentinaVsHondurasEventDefinitions = {
+  EVENT_SHUTTLES_GROUP: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.EVENT_SHUTTLES_GROUP,
+    name: 'Event Shuttles',
+    url: `${eventUrl}/0`
+  },
+  CAMPUS_SHUTTLE_STOPS: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.CAMPUS_SHUTTLE_STOPS,
+    name: 'Campus Shuttle Stops',
+    url: `${eventUrl}/1`
+  },
+  SHUTTLE_ROUTES: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.SHUTTLE_ROUTES,
+    name: 'Shuttle Routes',
+    url: `${eventUrl}/2`
+  },
+  EVENT_PARKING_GROUP: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.EVENT_PARKING_GROUP,
+    name: 'Event Parking',
+    url: `${eventUrl}/3`
+  },
+  PARKING_AND_RIDESHARE: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.PARKING_AND_RIDESHARE,
+    name: 'Parking & Rideshare',
+    url: `${eventUrl}/4`
+  },
+  EVENT_PARKING: {
+    id: ARGENTINA_VS_HONDURAS_LAYERS.EVENT_PARKING,
+    name: 'Event Parking',
+    url: `${eventUrl}/5`
+  }
+};
+
+const ArgentinaVsHondurasLayerReferences: Record<string, string> = {
+  EVENT_SHUTTLES_GROUP: ARGENTINA_VS_HONDURAS_LAYERS.EVENT_SHUTTLES_GROUP,
+  EVENT_PARKING_GROUP: ARGENTINA_VS_HONDURAS_LAYERS.EVENT_PARKING_GROUP
+};
+
+export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
+  {
+    type: 'group',
+    id: ArgentinaVsHondurasEventDefinitions.EVENT_SHUTTLES_GROUP.id,
+    title: ArgentinaVsHondurasEventDefinitions.EVENT_SHUTTLES_GROUP.name,
+    visible: true,
+    listMode: 'show',
+    layerIndex: 60,
+    sources: [
+      {
+        type: 'feature',
+        id: ArgentinaVsHondurasEventDefinitions.SHUTTLE_ROUTES.id,
+        title: ArgentinaVsHondurasEventDefinitions.SHUTTLE_ROUTES.name,
+        url: ArgentinaVsHondurasEventDefinitions.SHUTTLE_ROUTES.url,
+        popupComponent: MarkdownPopupComponent,
+        popupData: {
+          name: { field: 'name' },
+          description: { field: 'description' }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: ArgentinaVsHondurasEventDefinitions.CAMPUS_SHUTTLE_STOPS.id,
+        title: ArgentinaVsHondurasEventDefinitions.CAMPUS_SHUTTLE_STOPS.name,
+        url: ArgentinaVsHondurasEventDefinitions.CAMPUS_SHUTTLE_STOPS.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: { field: 'name' },
+          description: { field: 'description' }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      }
+    ],
+    native: {
+      listMode: 'hide-children'
+    }
+  },
+  {
+    type: 'group',
+    id: ArgentinaVsHondurasEventDefinitions.EVENT_PARKING_GROUP.id,
+    title: ArgentinaVsHondurasEventDefinitions.EVENT_PARKING_GROUP.name,
+    visible: true,
+    listMode: 'show',
+    layerIndex: 61,
+    sources: [
+      {
+        type: 'feature',
+        id: ArgentinaVsHondurasEventDefinitions.EVENT_PARKING.id,
+        title: ArgentinaVsHondurasEventDefinitions.EVENT_PARKING.name,
+        url: ArgentinaVsHondurasEventDefinitions.EVENT_PARKING.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: { field: 'name' },
+          description: { field: 'description' }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      },
+      {
+        type: 'feature',
+        id: ArgentinaVsHondurasEventDefinitions.PARKING_AND_RIDESHARE.id,
+        title: ArgentinaVsHondurasEventDefinitions.PARKING_AND_RIDESHARE.name,
+        url: ArgentinaVsHondurasEventDefinitions.PARKING_AND_RIDESHARE.url,
+        popupComponent: MarkdownWDirectionsPopupComponent,
+        popupData: {
+          name: { field: 'name' },
+          description: { field: 'description' }
+        },
+        visible: true,
+        listMode: 'show',
+        native: {
+          outFields: ['*']
+        }
+      }
+    ],
+    native: {
+      listMode: 'hide-children'
+    }
+  }
+];
+
+export const ArgentinaVsHondurasConfiguration: EventConfiguration = {
+  id: 'argentina-vs-honduras-2026',
+  name: 'Argentina vs. Honduras',
+  applicationName: 'Argentina vs. Honduras Transportation Map',
+  shortApplicationName: 'Argentina vs. Honduras Map',
+  introductionText: 'Get the best transportation and parking information for the Argentina vs. Honduras soccer match.',
+  eventDates: [],
+  mapCenter: [-96.34454, 30.60338],
+  zoom: 16,
+  legendAllowVisibilityToggle: true,
+  legendCombineChildrenUnderPrimary: true
+};
+
+export const ArgentinaVsHondurasOptions: SpecialEventOptions = [];
+
+export const ArgentinaVsHondurasTs: AggiemapCustomMapConfiguration = {
+  type: 'special-event',
+  configuration: ArgentinaVsHondurasConfiguration,
+  sources: ArgentinaVsHondurasColdLayerSources,
+  options: ArgentinaVsHondurasOptions,
+  references: ArgentinaVsHondurasLayerReferences,
+  discover: {
+    id: ArgentinaVsHondurasConfiguration.id,
+    name: ArgentinaVsHondurasConfiguration.name,
+    description: 'Transportation and parking information for the Argentina vs. Honduras soccer match.',
+    source: 'internal',
+    type: 'event',
+    keywords: ['argentina', 'honduras', 'soccer', 'parking', 'shuttle', 'transportation']
+  }
+};

--- a/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
@@ -157,7 +157,7 @@ export const ArgentinaVsHondurasConfiguration: EventConfiguration = {
   applicationName: 'Argentina vs. Honduras Transportation Map',
   shortApplicationName: 'Argentina vs. Honduras Map',
   introductionText: 'Get the best transportation and parking information for the Argentina vs. Honduras soccer match.',
-  eventDates: [],
+  eventDates: ['2026-06-06'],
   mapCenter: [-96.34454, 30.60338],
   zoom: 16,
   legendAllowVisibilityToggle: true,


### PR DESCRIPTION
This PR adds the new Argentina vs. Honduras Soccer match map with two toggleable checkboxes and two groups for event shuttles and event parking.

<img width="3447" height="2028" alt="image" src="https://github.com/user-attachments/assets/079add26-39bf-44da-be19-6cefb86f799f" />

Working popups:

<img width="2203" height="1267" alt="image" src="https://github.com/user-attachments/assets/7473a598-c274-4940-ac2e-1c0ce49d7915" />

Closes #779 