### PR TITLE
fix(aggiemap-angular): Reorganized Summer/Break map and renamed AVP map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/avp-parking.definitions.ts
@@ -50,8 +50,8 @@ export const AVPParkingColdLayerSources: LayerSource[] = [
 
 export const AVPParkingConfiguration: EventConfiguration = {
   id: 'avp-parking',
-  name: 'AVP Parking',
-  applicationName: 'AVP Parking Map',
+  name: 'Any Valid Permit (AVP) Parking',
+  applicationName: 'Any Valid Permit (AVP) Parking Map',
   shortApplicationName: 'AVP Parking Map',
   introductionText: 'Parking map for AVP permits.',
   eventDates: [],

--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -135,6 +135,7 @@ export const BreakSummerParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking lot authorization information for Break and Summer.',
     source: 'internal',
     type: 'event',
+    mapType: 'parking',
     keywords: ['break', 'summer', 'parking', 'permit']
   }
 };


### PR DESCRIPTION
This PR moves the Summer/Break map out from Campus Events to Parking Maps and renames AVP parking to "Any Valid Permit (AVP) Parking"

Closes #801