### PR TITLE
feat(aggiemap-angular): New sidebar information menu for Break / Summer map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -118,6 +118,11 @@ export const BreakSummerConfiguration: EventConfiguration = {
   mapCenter: [-96.34731, 30.60543],
   eventDates: [],
   zoom: 16,
+  defaultLayerOverrides: {
+    'surface-lots-layer': {
+      popupComponent: null
+    }
+  },
   sidebarInfo: {
     sections: [
       {

--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -117,7 +117,29 @@ export const BreakSummerConfiguration: EventConfiguration = {
   shortApplicationName: 'Break / Summer Map',
   mapCenter: [-96.34731, 30.60543],
   eventDates: [],
-  zoom: 16
+  zoom: 16,
+  sidebarInfo: {
+    sections: [
+      {
+        heading: 'Break Parking',
+        subheading: '(night permits valid all day)',
+        items: [
+          'Sept. 1, 2025 – Labor Day',
+          'Oct. 13 – 14, 2025 – Fall Break',
+          'Nov. 27 – 28, 2025 – Thanksgiving Break',
+          'Dec. 19, 2025 – Jan. 11, 2026',
+          'Jan. 19, 2026 – MLK',
+          'Mar. 9 – 13, 2026 – Spring Break',
+          'May 10 – 25, 2026'
+        ]
+      },
+      {
+        heading: 'Summer Parking',
+        subheading: '(night permits NOT valid during the day)',
+        items: ['May 26, 2026 – Aug. 9, 2026']
+      }
+    ]
+  }
 };
 
 export const BreakSummerOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -58,7 +58,7 @@ export const NscParkingColdLayerSources: LayerSource[] = [
         field: 'GIS.TS.ParkingLots.Name',
         collapsed: true
       },
-      description: {
+      notes: {
         field: 'GIS.TS.Lot_Notes.NewStudentConfN',
         collapsed: true
       }

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -77,12 +77,7 @@ export const NscParkingConfiguration: EventConfiguration = {
   introductionText: 'Parking map for New Student Conference (NSC) permits.',
   mapCenter: [-96.34731, 30.60543],
   eventDates: [],
-  zoom: 16,
-  defaultLayerOverrides: {
-    'surface-lots-layer': {
-      popupComponent: null
-    }
-  }
+  zoom: 16
 };
 
 export const NscParkingOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -58,7 +58,7 @@ export const NscParkingColdLayerSources: LayerSource[] = [
         field: 'GIS.TS.ParkingLots.Name',
         collapsed: true
       },
-      notes: {
+      description: {
         field: 'GIS.TS.Lot_Notes.NewStudentConfN',
         collapsed: true
       }
@@ -77,7 +77,12 @@ export const NscParkingConfiguration: EventConfiguration = {
   introductionText: 'Parking map for New Student Conference (NSC) permits.',
   mapCenter: [-96.34731, 30.60543],
   eventDates: [],
-  zoom: 16
+  zoom: 16,
+  defaultLayerOverrides: {
+    'surface-lots-layer': {
+      popupComponent: null
+    }
+  }
 };
 
 export const NscParkingOptions: SpecialEventOptions = [];

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -117,6 +117,27 @@ export interface EventConfiguration {
    * Text to display on the review step.
    */
   reviewText?: string;
+
+  /**
+   * Optional informational panel rendered in the right-hand sidebar above the layer list and legend.
+   *
+   * Used to surface reference content that lives outside of the map data — for example, the
+   * Break / Summer Parking dates that Transportation Services enforcement relies on.
+   */
+  sidebarInfo?: SidebarInfoPanel;
+}
+
+/**
+ * Static informational content rendered in the right-hand sidebar above Layers and Legend.
+ */
+export interface SidebarInfoPanel {
+  sections: Array<SidebarInfoSection>;
+}
+
+export interface SidebarInfoSection {
+  heading: string;
+  subheading?: string;
+  items?: Array<string>;
 }
 
 /**

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -25,6 +25,16 @@
   </div>
 </div>
 
+<div *ngIf="configuration?.sidebarInfo as info" class="leader-1 sidebar-info">
+  <div *ngFor="let section of info.sections" class="sidebar-info-section">
+    <h4 class="sidebar-info-heading">{{ section.heading }}</h4>
+    <p *ngIf="section.subheading" class="sidebar-info-subheading">{{ section.subheading }}</p>
+    <ul *ngIf="section.items?.length" class="sidebar-info-items">
+      <li *ngFor="let item of section.items">{{ item }}</li>
+    </ul>
+  </div>
+</div>
+
 <tamu-gisc-layer-list [allowedLayerIds]="eventLayerIds"></tamu-gisc-layer-list>
 
 <tamu-gisc-legend

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
@@ -28,3 +28,34 @@
   margin-right: 1rem;
   padding-bottom: 0.25rem;
 }
+
+.sidebar-info {
+  .sidebar-info-section + .sidebar-info-section {
+    margin-top: 0.75rem;
+  }
+
+  .sidebar-info-heading {
+    margin: 0 0 0.1rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #500000;
+  }
+
+  .sidebar-info-subheading {
+    margin: 0;
+    font-size: 0.8rem;
+    font-style: italic;
+    color: #555;
+  }
+
+  .sidebar-info-items {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      font-size: 0.85rem;
+      padding: 0.1rem 0;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the sidebar popup information to the Break / Summer map, with all the same features as the Transporation Services website's version.

This menu type can be applied to any map, but is currently only in use on the Break / Summer map.

<img width="1606" height="1547" alt="image" src="https://github.com/user-attachments/assets/d3dc15b5-00cd-4205-972b-6ccecc82d062" />

<img width="2571" height="2049" alt="image" src="https://github.com/user-attachments/assets/3f6264f3-a791-4a6b-850f-0138291552bf" />

Closes #789 