### PR TITLE
feat(aggiemap-angular) Custom width/height adjusting for icons on Legends and Maps

### DIFF
--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -388,7 +388,61 @@ export type LayerSource = LayerSourceType & {
    * protected resources.
    */
   auth?: LayerSourceAuthInfo;
+
+  /**
+   * Optional opt-in override that controls how the layer's icons are rendered in the legend.
+   *
+   * Without this property, the legend keeps its existing default behavior (the ArcGIS-generated
+   * preview is used as-is). Set this when the service-provided icon swatch is visually inconsistent
+   * (for example, stretched non-square picture markers) and the layer needs targeted control over
+   * its legend icons.
+   */
+  legend?: LayerLegendOverride;
 };
+
+/**
+ * Per-layer legend icon override applied by the legend component when present on a `LayerSource`.
+ *
+ * Designed as an opt-in escape hatch so existing legends remain unchanged. When provided, the
+ * legend component uses the chosen `mode` to resolve the icon source and applies the supplied
+ * sizing/fit hints to the rendered `<img>`.
+ */
+export interface LayerLegendOverride {
+  /**
+   * Source used to resolve the legend icon for this layer.
+   *
+   * - `'arcgis'` (default): use the ArcGIS-generated legend preview/source unchanged.
+   * - `'renderer-symbol'`: pull the icon URL directly from the layer's renderer (picture-marker
+   *   symbols on simple/unique-value renderers). Falls back to `'arcgis'` when no URL is available.
+   * - `'custom-src'`: use the explicit URL provided in `src`.
+   */
+  mode?: 'arcgis' | 'renderer-symbol' | 'custom-src';
+
+  /**
+   * Explicit image URL or data URI for the legend icon. Required when `mode === 'custom-src'`.
+   */
+  src?: string;
+
+  /**
+   * Preserve the icon's aspect ratio when scaling. Convenience flag equivalent to `fit: 'contain'`.
+   */
+  preserveAspectRatio?: boolean;
+
+  /**
+   * CSS `object-fit` value applied to the rendered icon. Use `'contain'` to avoid stretching.
+   */
+  fit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+
+  /**
+   * Rendered icon width in pixels.
+   */
+  width?: number;
+
+  /**
+   * Rendered icon height in pixels.
+   */
+  height?: number;
+}
 
 interface LayerSourceAuthInfo {
   /**

--- a/libs/maps/esri/src/lib/services/layer-sources/layer-sources.service.ts
+++ b/libs/maps/esri/src/lib/services/layer-sources/layer-sources.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 
 import deepmerge from 'deepmerge';
 
-import { LayerSource } from '@tamu-gisc/common/types';
+import { LayerLegendOverride, LayerSource } from '@tamu-gisc/common/types';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 export interface LayerSourceOverrides {
@@ -14,6 +14,7 @@ export interface LayerSourceOverrides {
 export class LayerSourcesService {
   private _layerSources: BehaviorSubject<LayerSource[]> = new BehaviorSubject<LayerSource[]>([]);
   private _overrides: BehaviorSubject<LayerSourceOverrides> = new BehaviorSubject<LayerSourceOverrides>({});
+  private _legendOverrides: Map<string, LayerLegendOverride> = new Map();
 
   public readonly layerSources$: Observable<LayerSource[]> = this._layerSources.asObservable();
   public readonly overrides$: Observable<LayerSourceOverrides> = this._overrides.asObservable();
@@ -28,6 +29,43 @@ export class LayerSourcesService {
   private initializeLayerSources(): void {
     const sources = this.environment.value('LayerSources') || [];
     this._layerSources.next(sources);
+    this.collectLegendOverrides(sources);
+  }
+
+  /**
+   * Walks the provided layer sources (including nested group sources) and indexes any `legend`
+   * overrides so the legend component can look them up by layer id at render time.
+   *
+   * Event-driven sources are not part of the env-initialized list, so callers that load layers
+   * dynamically (for example `EsriMapService.loadLayers`) should call this with the new sources
+   * after they are loaded.
+   */
+  public collectLegendOverrides(sources: LayerSource[] | undefined | null): void {
+    if (!sources || sources.length === 0) {
+      return;
+    }
+
+    for (const source of sources) {
+      if (source?.legend) {
+        this._legendOverrides.set(source.id, source.legend);
+      }
+
+      const childSources = (source as unknown as { sources?: LayerSource[] })?.sources;
+      if (childSources?.length) {
+        this.collectLegendOverrides(childSources);
+      }
+    }
+  }
+
+  /**
+   * Returns the `legend` override registered for a given layer id, if any.
+   */
+  public getLegendOverride(layerId: string | undefined | null): LayerLegendOverride | undefined {
+    if (!layerId) {
+      return undefined;
+    }
+
+    return this._legendOverrides.get(layerId);
   }
 
   /**

--- a/libs/maps/esri/src/lib/services/map/map.service.ts
+++ b/libs/maps/esri/src/lib/services/map/map.service.ts
@@ -12,7 +12,7 @@ import {
   getLayerTypeFromPortalJSON,
   IPortalLayer
 } from '@tamu-gisc/common/utils/geometry/esri';
-import { LayerSource, IRemoteLayerService, GroupLayerSourceProperties } from '@tamu-gisc/common/types';
+import { LayerLegendOverride, LayerSource, IRemoteLayerService, GroupLayerSourceProperties } from '@tamu-gisc/common/types';
 import { EnvironmentService } from '@tamu-gisc/common/ngx/environment';
 
 import { EsriModuleProviderService } from '../module-provider/module-provider.service';
@@ -278,6 +278,10 @@ export class EsriMapService {
   public async loadLayers(sources: LayerSource[]) {
     await this.registerIdentityAuthInfos(sources);
 
+    // Index legend overrides from dynamically-loaded sources (e.g. event layers loaded outside
+    // the env-initialized LayerSources list) so the legend component can resolve them by id.
+    this.layerSourcesService.collectLegendOverrides(sources);
+
     for (const source of sources) {
       await this.findLayerOrCreateFromSource(source);
     }
@@ -294,9 +298,20 @@ export class EsriMapService {
       props = { ...source };
     }
 
+    // Capture the legend override before it gets stripped — the same sizing hints are applied
+    // to the on-map picture-marker symbols once the layer loads.
+    const legendOverride = (source as LayerSource).legend;
+
     // Remove the 'native' property from the object since it's not needed in the layer creation.
     if ('native' in props) {
       delete props.native;
+    }
+
+    // Strip the legend override before constructing the esri layer. It's only consumed by the
+    // legend component (via LayerSourcesService.getLegendOverride) and ArcGIS will reject or
+    // misinterpret an unknown `legend` property on the layer constructor.
+    if ('legend' in props) {
+      delete props.legend;
     }
 
     // Delete any additional properties to avoid polluting layer instances
@@ -310,7 +325,9 @@ export class EsriMapService {
         delete props.type;
 
         // Create and return new feature layer
-        return new FeatureLayer(props as esri.FeatureLayerProperties);
+        const layer = new FeatureLayer(props as esri.FeatureLayerProperties);
+        this.applyLegendOverrideToLayerSymbols(layer, legendOverride);
+        return layer;
       });
     } else if (source.type === 'map-image') {
       return this.moduleProvider.require(['MapImageLayer']).then(([ImageLayer]: [esri.MapImageLayerConstructor]) => {
@@ -496,6 +513,71 @@ export class EsriMapService {
     });
 
     return mapped;
+  }
+
+  /**
+   * Applies the `legend` override's sizing hints (`width` / `height`) to the on-map picture-marker
+   * symbols of the supplied layer once it has loaded. This keeps the map icon and the legend
+   * swatch visually consistent — without this, a `legend.width` of 24 would only shrink the legend
+   * swatch while the map would keep the larger service-defined dimensions.
+   *
+   * Only picture-marker symbols are touched; non-image symbols (simple-fill, simple-line, …) are
+   * left alone because they don't have a meaningful width/height in the same sense.
+   */
+  private applyLegendOverrideToLayerSymbols(layer: esri.FeatureLayer, override: LayerLegendOverride | undefined): void {
+    if (!override) {
+      return;
+    }
+
+    const { width, height } = override;
+    if (width === undefined && height === undefined) {
+      return;
+    }
+
+    const applyToSymbol = (symbol: unknown): void => {
+      if (!symbol || (symbol as { type?: string }).type !== 'picture-marker') {
+        return;
+      }
+
+      const target = symbol as { width?: number; height?: number };
+      if (width !== undefined) {
+        target.width = width;
+      }
+      if (height !== undefined) {
+        target.height = height;
+      }
+    };
+
+    const applyToRenderer = (renderer: esri.Renderer | undefined | null): void => {
+      if (!renderer) {
+        return;
+      }
+
+      if (renderer.type === 'simple') {
+        applyToSymbol((renderer as esri.SimpleRenderer).symbol);
+      } else if (renderer.type === 'unique-value') {
+        const unique = renderer as esri.UniqueValueRenderer;
+        unique.uniqueValueInfos?.forEach((info) => applyToSymbol(info.symbol));
+        applyToSymbol(unique.defaultSymbol);
+      } else if (renderer.type === 'class-breaks') {
+        const classBreaks = renderer as esri.ClassBreaksRenderer;
+        classBreaks.classBreakInfos?.forEach((info) => applyToSymbol(info.symbol));
+        applyToSymbol(classBreaks.defaultSymbol);
+      }
+    };
+
+    // The renderer is typically populated by the service after the layer loads. Apply once on
+    // load, and again any time the renderer is reassigned.
+    layer
+      .when()
+      .then(() => {
+        applyToRenderer(layer.renderer);
+      })
+      .catch(() => {
+        /* swallow — the layer may fail to load for unrelated reasons */
+      });
+
+    layer.watch('renderer', (renderer: esri.Renderer) => applyToRenderer(renderer));
   }
 
   /**

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.html
@@ -46,10 +46,20 @@ of the table -->
 
             <!-- This case will be reached of every info node and will terminate either with an info.preview or info.src -->
             <div *ngSwitchDefault>
-              <ng-container [ngSwitch]="$any(info).preview !== undefined">
-                <div *ngSwitchCase="true" class="image-container" [elementInsert]="$any(info).preview"></div>
-                <img *ngSwitchCase="false" class="image-container" [src]="$any(info).src" [ngStyle]="{opacity: $any(info).opacity}" alt="Layer legend icon" />
+              <ng-container *ngIf="hasLegendOverrideForInfo(info); else defaultIconRendering">
+                <img
+                  class="image-container"
+                  [src]="resolveLegendIconSrc(info)"
+                  [ngStyle]="legendOverrideStyles"
+                  alt="Layer legend icon"
+                />
               </ng-container>
+              <ng-template #defaultIconRendering>
+                <ng-container [ngSwitch]="$any(info).preview !== undefined">
+                  <div *ngSwitchCase="true" class="image-container" [elementInsert]="$any(info).preview"></div>
+                  <img *ngSwitchCase="false" class="image-container" [src]="$any(info).src" [ngStyle]="{opacity: $any(info).opacity}" alt="Layer legend icon" />
+                </ng-container>
+              </ng-template>
             </div>
           </div>
 

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 
-import { EsriModuleProviderService } from '@tamu-gisc/maps/esri';
+import { EsriModuleProviderService, LayerSourcesService } from '@tamu-gisc/maps/esri';
+import { LayerLegendOverride } from '@tamu-gisc/common/types';
 import {
   catchError,
   concatMap,
@@ -39,7 +40,10 @@ import esri = __esri;
   styleUrls: ['./legend-element.component.scss']
 })
 export class LegendElementComponent implements OnInit {
-  constructor(private readonly moduleProvider: EsriModuleProviderService) {}
+  constructor(
+    private readonly moduleProvider: EsriModuleProviderService,
+    private readonly layerSourcesService: LayerSourcesService
+  ) {}
 
   private readonly sportsSafetyFirstLayerIds = new Set([
     'softball-parking-safety-first',
@@ -170,6 +174,152 @@ export class LegendElementComponent implements OnInit {
       distinctUntilChanged(),
       shareReplay(1)
     );
+  }
+
+  /**
+   * Returns the configured legend override for the current layer, if any.
+   *
+   * Resolves against both the layer's own id and (for sublayers) the parent layer's id so the
+   * override applies for either top-level feature layers or sublayers of map-image layers.
+   */
+  public get legendOverride(): LayerLegendOverride | undefined {
+    const candidateIds = [
+      this.layer?.id,
+      (this.layer as unknown as esri.Sublayer)?.layer?.id
+    ].filter((id): id is string => typeof id === 'string');
+
+    for (const id of candidateIds) {
+      const match = this.layerSourcesService?.getLegendOverride?.(id);
+      if (match) {
+        return match;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * True when the override is active for the supplied info — i.e. it specifies a custom rendering
+   * mode or any sizing/fit hint. When false, the template falls back to existing default rendering.
+   */
+  public hasLegendOverrideForInfo(info: unknown): boolean {
+    const override = this.legendOverride;
+
+    if (!override) {
+      return false;
+    }
+
+    if (override.mode === 'custom-src' && !override.src) {
+      return false;
+    }
+
+    return this.resolveLegendIconSrc(info) !== null;
+  }
+
+  /**
+   * Resolve the icon URL for `info` based on the configured override mode.
+   *
+   * - `custom-src`: returns the explicit override URL.
+   * - `renderer-symbol`: extracts the picture-marker URL from the layer's renderer that matches
+   *   the legend info's value (for unique-value renderers) or the single symbol (for simple renderers).
+   * - `arcgis` (default): returns the info's own `src` or `preview` image URL if available.
+   *
+   * Returns null when no URL can be resolved — the template should then fall through to default rendering.
+   */
+  public resolveLegendIconSrc(info: unknown): string | null {
+    const override = this.legendOverride;
+
+    if (!override) {
+      return null;
+    }
+
+    if (override.mode === 'custom-src') {
+      return override.src ?? null;
+    }
+
+    if (override.mode === 'renderer-symbol') {
+      const fromRenderer = this._extractSymbolUrl(info);
+      if (fromRenderer) {
+        return fromRenderer;
+      }
+    }
+
+    const infoSrc = (info as { src?: string })?.src;
+    if (typeof infoSrc === 'string' && infoSrc.length > 0) {
+      return infoSrc;
+    }
+
+    const previewSrc = this._extractPreviewImageSrc(info);
+    return previewSrc;
+  }
+
+  /**
+   * Builds the `[ngStyle]` payload applied to the override `<img>` element. Honors `width`,
+   * `height`, `fit`, and `preserveAspectRatio`.
+   */
+  public get legendOverrideStyles(): Record<string, string> {
+    const override = this.legendOverride;
+    const styles: Record<string, string> = {};
+
+    if (!override) {
+      return styles;
+    }
+
+    if (typeof override.width === 'number') {
+      styles['width'] = `${override.width}px`;
+    }
+
+    if (typeof override.height === 'number') {
+      styles['height'] = `${override.height}px`;
+    }
+
+    if (override.fit) {
+      styles['object-fit'] = override.fit;
+    } else if (override.preserveAspectRatio) {
+      styles['object-fit'] = 'contain';
+    }
+
+    return styles;
+  }
+
+  private _extractSymbolUrl(info: unknown): string | null {
+    const renderer = (this.layer as esri.FeatureLayer)?.renderer;
+    if (!renderer) {
+      return null;
+    }
+
+    const infoValue = (info as { value?: unknown })?.value;
+
+    if (renderer.type === 'unique-value') {
+      const uniqueRenderer = renderer as esri.UniqueValueRenderer;
+      const match = uniqueRenderer.uniqueValueInfos?.find((u) => `${u.value}` === `${infoValue}`);
+      const url = (match?.symbol as { url?: string })?.url;
+      if (typeof url === 'string' && url.length > 0) {
+        return url;
+      }
+
+      const defaultUrl = (uniqueRenderer.defaultSymbol as { url?: string })?.url;
+      return typeof defaultUrl === 'string' && defaultUrl.length > 0 ? defaultUrl : null;
+    }
+
+    if (renderer.type === 'simple') {
+      const simpleRenderer = renderer as esri.SimpleRenderer;
+      const url = (simpleRenderer.symbol as { url?: string })?.url;
+      return typeof url === 'string' && url.length > 0 ? url : null;
+    }
+
+    return null;
+  }
+
+  private _extractPreviewImageSrc(info: unknown): string | null {
+    const preview = (info as { preview?: Element })?.preview;
+    if (!preview) {
+      return null;
+    }
+
+    const img = preview instanceof HTMLImageElement ? preview : preview.querySelector?.('img');
+    const src = (img as HTMLImageElement | null)?.src;
+    return typeof src === 'string' && src.length > 0 ? src : null;
   }
 
   public useSportsSafetyFirstFallback(): boolean {

--- a/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/4h-roundup.definitions.ts
@@ -47,6 +47,13 @@ export const FourHColdLayerSources: LayerSource[] = [
     listMode: 'show',
     native: {
       outFields: ['*']
+    },
+    legend: {
+      mode: 'renderer-symbol',
+      preserveAspectRatio: true,
+      fit: 'contain',
+      width: 24,
+      height: 30
     }
   },
   {


### PR DESCRIPTION
There has been an ongoing issue with some map icons getting stretched when brought into AggieMap. This PR adds an opt-in, reusuable system for manually adjusting the width, height, and style of icons.

4H Map Icons before:

<img width="660" height="458" alt="Screenshot 2026-05-26 105845" src="https://github.com/user-attachments/assets/7345eacd-23bb-49ab-a8cf-27eb8241eadd" />

After:

<img width="625" height="449" alt="image" src="https://github.com/user-attachments/assets/38c8d2ae-e735-4bd0-9625-ab706543e1d3" />

This PR only adjusts the 4H map as an example. This can be applied to other maps in the future.

Closes #722 