### PR TITLE
fix(aggiemap-angular): Break parking sidebar changes

### DIFF
--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -138,6 +138,21 @@ export interface SidebarInfoSection {
   heading: string;
   subheading?: string;
   items?: Array<string>;
+
+  /**
+   * Optional per-section style overrides. When omitted, the section inherits the same look
+   * as the Layers and Legend panels (heading from `.sidebar-component-name`, content from
+   * `.sidebar-component-content-container`). Use this to opt-in to event-specific accent
+   * colors or typography from the definition file.
+   */
+  styleOverrides?: SidebarInfoSectionStyleOverrides;
+}
+
+export interface SidebarInfoSectionStyleOverrides {
+  heading?: Record<string, string>;
+  subheading?: Record<string, string>;
+  items?: Record<string, string>;
+  item?: Record<string, string>;
 }
 
 /**

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.html
@@ -25,15 +25,19 @@
   </div>
 </div>
 
-<div *ngIf="configuration?.sidebarInfo as info" class="leader-1 sidebar-info">
+<ng-container *ngIf="configuration?.sidebarInfo as info">
   <div *ngFor="let section of info.sections" class="sidebar-info-section">
-    <h4 class="sidebar-info-heading">{{ section.heading }}</h4>
-    <p *ngIf="section.subheading" class="sidebar-info-subheading">{{ section.subheading }}</p>
-    <ul *ngIf="section.items?.length" class="sidebar-info-items">
-      <li *ngFor="let item of section.items">{{ item }}</li>
-    </ul>
+    <div class="sidebar-component-name">
+      <p [ngStyle]="section.styleOverrides?.heading">{{ section.heading }}</p>
+    </div>
+    <div class="sidebar-component-content-container">
+      <p *ngIf="section.subheading" class="sidebar-info-subheading" [ngStyle]="section.styleOverrides?.subheading">{{ section.subheading }}</p>
+      <ul *ngIf="section.items?.length" class="sidebar-info-items" [ngStyle]="section.styleOverrides?.items">
+        <li *ngFor="let item of section.items" [ngStyle]="section.styleOverrides?.item">{{ item }}</li>
+      </ul>
+    </div>
   </div>
-</div>
+</ng-container>
 
 <tamu-gisc-layer-list [allowedLayerIds]="eventLayerIds"></tamu-gisc-layer-list>
 

--- a/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/sidebar/components/sidebar-reference/sidebar-reference.component.scss
@@ -29,23 +29,15 @@
   padding-bottom: 0.25rem;
 }
 
-.sidebar-info {
-  .sidebar-info-section + .sidebar-info-section {
-    margin-top: 0.75rem;
-  }
-
-  .sidebar-info-heading {
-    margin: 0 0 0.1rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: #500000;
-  }
+.sidebar-info-section {
+  padding: 0.35rem;
+  margin-bottom: 0.5rem;
 
   .sidebar-info-subheading {
-    margin: 0;
+    margin: 0 0 0.25rem;
     font-size: 0.8rem;
     font-style: italic;
-    color: #555;
+    color: #6e6e6e;
   }
 
   .sidebar-info-items {
@@ -54,7 +46,8 @@
     list-style: none;
 
     li {
-      font-size: 0.85rem;
+      color: #323232;
+      font-size: 0.875rem;
       padding: 0.1rem 0;
     }
   }


### PR DESCRIPTION
This PR reformats and refactors the new sidebar feature that is currently on the Break/Summer map.

## Changes:
- fixed indentation to match Layers and Legends sections
- font formatting is now the same as the Layers and Legends sections
- removed the maroon-accented custom heading style. Default appearance now inherits from the shared sidebar styles
- added optional `styleOverrides` on `SidebarInfoSection` with heading, subheading, items, and item slots so a definition file can opt into custom styling per section without changing the shared component


<img width="850" height="2047" alt="image" src="https://github.com/user-attachments/assets/f0b9b593-d718-478a-9ed7-f29251bc80c0" />

Closes #811 