### PR TITLE
fix(aggiemap-angular): Fix stretched icons on Road to 26 Map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
@@ -98,13 +98,6 @@ export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
         native: {
           outFields: ['*']
         },
-        legend: {
-          mode: 'renderer-symbol',
-          preserveAspectRatio: true,
-          fit: 'contain',
-          width: 24,
-          height: 30
-        }
       }
     ],
     native: {
@@ -161,8 +154,8 @@ export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
           mode: 'renderer-symbol',
           preserveAspectRatio: true,
           fit: 'contain',
-          width: 24,
-          height: 30
+          width: 26,
+          height: 32
         }
       }
     ],

--- a/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/argentina-vs-honduras.definitions.ts
@@ -97,6 +97,13 @@ export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
         listMode: 'show',
         native: {
           outFields: ['*']
+        },
+        legend: {
+          mode: 'renderer-symbol',
+          preserveAspectRatio: true,
+          fit: 'contain',
+          width: 24,
+          height: 30
         }
       }
     ],
@@ -126,6 +133,13 @@ export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
         listMode: 'show',
         native: {
           outFields: ['*']
+        },
+        legend: {
+          mode: 'renderer-symbol',
+          preserveAspectRatio: true,
+          fit: 'contain',
+          width: 24,
+          height: 30
         }
       },
       {
@@ -142,6 +156,13 @@ export const ArgentinaVsHondurasColdLayerSources: LayerSource[] = [
         listMode: 'show',
         native: {
           outFields: ['*']
+        },
+        legend: {
+          mode: 'renderer-symbol',
+          preserveAspectRatio: true,
+          fit: 'contain',
+          width: 24,
+          height: 30
         }
       }
     ],


### PR DESCRIPTION
This PR adjusts the aspect ratio's of the icons on the Road to 26: Argentina vs. Honduras Transportation Map to reduce the stretching issue.

### Before:

<img width="761" height="469" alt="image" src="https://github.com/user-attachments/assets/bb1cadb6-98ad-41ce-9c75-7e2cc0ab6988" />

### After:
<img width="817" height="547" alt="image" src="https://github.com/user-attachments/assets/c7f1b53e-092a-4ee6-a58a-d97811c100e7" />
<img width="3147" height="1877" alt="image" src="https://github.com/user-attachments/assets/89bcc6ad-5cb6-4273-9255-82677abc43f2" />

Closes #815 

