### PR TITLE
fix(aggiemap-angular) Fix URL for Break/Summer map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -161,7 +161,7 @@ export const BreakSummerParkingTs: AggiemapCustomMapConfiguration = {
     name: BreakSummerConfiguration.name,
     description: 'Parking lot authorization information for Break and Summer.',
     source: 'internal',
-    type: 'event',
+    type: 'parking',
     mapType: 'parking',
     keywords: ['break', 'summer', 'parking', 'permit']
   }


### PR DESCRIPTION
This PR changes the Break/Summer URL from an "event" to "parking."

Closes ##816