### PR TITLE
feat(aggiemap-angular): Update Ring Day Dates for October

### DIFF
--- a/apps/aggiemap-angular/src/environments/notification-events.ts
+++ b/apps/aggiemap-angular/src/environments/notification-events.ts
@@ -26,7 +26,8 @@ export const NotificationEvents: NotificationProperties[] = [
   {
     id: 'ring-day-fall-1',
     title: 'Aggie Ring Day',
-    range: [1728495718000, 1728752400000],
+    // Ring Pick Up / Accessibility day: Thu Oct 8, 2026 (9-3); Ring Days: Fri Oct 9 & Sat Oct 10, 2026 (9-6)
+    range: [1791468000000, 1791673200000],
     acknowledge: false,
     message:
       'Congratulations Ags! Get the best transportation information on your Ring Day with the <a href="https://aggiemap.tamu.edu/ringday/" target="_blank">Ring Day Event Map</a>.',

--- a/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/ring-day.definitions.ts
@@ -15,9 +15,9 @@ export enum RING_DAY_LAYERS {
 }
 
 enum RingDayDates {
-  DAY1 = '2026-04-08',
-  DAY2 = '2026-04-09',
-  DAY3 = '2026-04-10'
+  DAY1 = '2026-10-08',
+  DAY2 = '2026-10-09',
+  DAY3 = '2026-10-10'
 }
 
 const eventUrl = Connections.ringDayUrl;
@@ -144,11 +144,11 @@ export const RingDaySpecialEventOptions: SpecialEventOptions = [
     choices: [
       {
         value: EventDay.DAY1,
-        label: 'Aggie Ring Pickup (April 8, 2026)'
+        label: 'Aggie Ring Pickup (October 8, 2026)'
       },
       {
         value: EventDay.DAY2,
-        label: 'Aggie Ring Day (April 9-10, 2026)'
+        label: 'Aggie Ring Day (October 9-10, 2026)'
       }
     ],
     effects: {


### PR DESCRIPTION
This PR updates the Aggie Ring Day event for the Fall 2026 schedule:

- Ring Pick Up / Accessibility Day: Thursday, October 8, 2026 (9 AM–3 PM)
- Ring Days: Friday, October 9 & Saturday, October 10, 2026 (9 AM–6 PM)

Also updates the `ring-day-fall-1` notification range to the new event window (Thu Oct 8 9 AM → Sat Oct 10 6 PM, Central Time).

Closes #820 