### PR TITLE
fix(aggiemap-angular): Make new construction map actually appear on AggieMap

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -54,6 +54,7 @@ import { EvChargersTs } from './ev-chargers.definitions';
 import { TsMainParkingTs } from './main-parking.definitions';
 import { SecGroundsConferenceTs } from './sec-grounds-conference.definitions';
 import { ArgentinaVsHondurasTs } from './argentina-vs-honduras.definitions';
+import { ConstructionMapTs } from './construction-map.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -110,5 +111,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   EvChargersTs,
   TsMainParkingTs,
   SecGroundsConferenceTs,
-  ArgentinaVsHondurasTs
+  ArgentinaVsHondurasTs,
+  ConstructionMapTs
 ];


### PR DESCRIPTION
This PR adds the new construction map to main definitions file, fixing an issue of it not appearing under Operational Maps.

<img width="2622" height="1781" alt="image" src="https://github.com/user-attachments/assets/c4a31107-9d8c-4b9c-9008-a847c40ed890" />

Closes #821 