### PR TITLE
feat(aggiemap-angular) New URL type for Operations maps

### DIFF
--- a/libs/aggiemap/ngx/core/src/lib/aggiemap-ngx-core.module.ts
+++ b/libs/aggiemap/ngx/core/src/lib/aggiemap-ngx-core.module.ts
@@ -33,6 +33,10 @@ const hybridRoutes: Routes = [
     loadChildren: () => import('@tamu-gisc/ts/events/ngx').then((m) => m.TsEventsNgxModule)
   },
   {
+    path: 'operations',
+    loadChildren: () => import('@tamu-gisc/ts/events/ngx').then((m) => m.TsEventsNgxModule)
+  },
+  {
     path: '**',
     redirectTo: 'map'
   }

--- a/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/interfaces/discover-application.interface.ts
@@ -22,7 +22,7 @@ export interface ExternalDiscoverApplication extends BaseDiscoverApplication {
 
 export interface InternalDiscoverApplication extends BaseDiscoverApplication {
   source: 'internal';
-  type: 'event' | 'parking';
+  type: 'event' | 'parking' | 'operations';
   mapType: DiscoverMapType;
   configuration: EventConfiguration;
 }

--- a/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
+++ b/libs/aggiemap/ngx/discover/src/lib/services/discovery/discovery.service.ts
@@ -21,7 +21,7 @@ export class DiscoveryService {
       id: event.discover?.id || event.configuration.id,
       source: 'internal' as const,
       type: event.discover?.type || 'event',
-      mapType: event.discover?.mapType || (event.discover?.type === 'parking' ? 'parking' : 'campus'),
+      mapType: event.discover?.mapType || (event.discover?.type === 'parking' ? 'parking' : event.discover?.type === 'operations' ? 'operations' : 'campus'),
       name: event.discover?.name || event.configuration.name,
       description: event.discover?.description || event.configuration.introductionText || '',
       configuration: event.configuration,

--- a/libs/ts/events/ngx/src/lib/definitions/construction-map.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/construction-map.definitions.ts
@@ -225,7 +225,7 @@ export const ConstructionMapTs: AggiemapCustomMapConfiguration = {
     name: ConstructionMapConfiguration.name,
     description: 'Current and planned campus construction projects.',
     source: 'internal',
-    type: 'parking',
+    type: 'operations',
     mapType: 'operations',
     keywords: ['construction', 'planned', 'current', 'operations', 'projects']
   }

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -372,7 +372,7 @@ export interface DiscoverMetadata {
    */
   labels?: string[];
   source: 'internal';
-  type: 'event' | 'parking';
+  type: 'event' | 'parking' | 'operations';
   /**
    * Optional tab grouping override for the Discover page.
    *


### PR DESCRIPTION
This PR adds a URL type for Operations maps I.e Construction)

<img width="3810" height="2170" alt="image" src="https://github.com/user-attachments/assets/31516bd8-8914-489b-81f8-172094d0994b" />

Closes #829 