### PR TITLE
feat(aggiemap-angular) Auto pan 3D toggle

### DIFF
--- a/libs/maps/feature/perspective/src/lib/components/perspective-toggle/perspective-toggle.component.ts
+++ b/libs/maps/feature/perspective/src/lib/components/perspective-toggle/perspective-toggle.component.ts
@@ -82,13 +82,26 @@ export class PerspectiveToggleComponent implements OnInit {
       return forkJoin([this.mp.require(['SceneView']), this.ms.store.pipe(take(1))]).pipe(
         map(([[SceneView], instance]: [[esri.SceneViewConstructor], MapServiceInstance]) => {
           if (this.perspectives.threeD === undefined) {
-            this.perspectives.threeD = new SceneView({
+            const view = new SceneView({
               map: instance.map,
               viewpoint: instance.view.viewpoint.clone(),
               container: undefined
             });
 
-            return this.perspectives.threeD;
+            this.perspectives.threeD = view;
+
+            // A SceneView cloned from the 2D viewpoint starts looking straight down, which makes the
+            // newly loaded 3D buildings indistinguishable from the 2D map. Once the view is ready
+            // (after its container is attached in `setView`), tilt the camera so the buildings are
+            // clearly visible from an angle.
+            view.when(() => {
+              view.goTo({ tilt: DEFAULT_3D_TILT }).catch(() => {
+                // `goTo` rejects when the animation is interrupted (e.g. the user toggles back to 2D
+                // mid-transition). This is expected and safe to ignore.
+              });
+            });
+
+            return view;
           } else {
             return this.perspectives.threeD;
           }
@@ -137,3 +150,10 @@ export class PerspectiveToggleComponent implements OnInit {
 }
 
 type PerspectiveType = '2D' | '3D';
+
+/**
+ * Camera tilt (in degrees) applied the first time the 3D perspective is activated. `0` is top-down;
+ * higher values produce a more oblique view that highlights building heights. Because the SceneView
+ * is cached for the lifetime of the component, this angle carries over to subsequent 3D activations.
+ */
+const DEFAULT_3D_TILT = 45;


### PR DESCRIPTION
This PR automatically pans the 3D mode to 45 degrees when toggled, showing that the buildings are actually in 3D and not just a flat map.

<img width="3802" height="2028" alt="image" src="https://github.com/user-attachments/assets/0ae7c950-f211-4e0e-930a-18b7ece24c82" />

Closes #554 