### PR TITLE
fix(aggiemap-angular): Allow links to buildings to use abbreviations and number code

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
@@ -13,7 +13,9 @@ jest.mock('@tamu-gisc/aggiemap/ngx/popups', () => ({
 import { ComposedSearchSourcesKeyMap, SearchSources } from './search-sources';
 
 describe('SearchSources', () => {
-  const connections: IComposedConnections = {
+  // Only the connection URLs referenced by the search sources under test are mocked; the cast keeps
+  // the partial fixture assignable without enumerating every unrelated connection.
+  const connections = {
     basemapUrl: 'https://example.com/basemap',
     departmentUrl: 'https://example.com/department',
     bikeRacksUrl: 'https://example.com/bike-racks',
@@ -24,9 +26,10 @@ describe('SearchSources', () => {
     tsMainUrl: 'https://example.com/ts-main',
     poiUrl: 'https://example.com/poi-service',
     diningLocationsUrl: 'https://example.com/dining-locations'
-  };
+  } as unknown as IComposedConnections;
 
-  const definitions: IComposedIDefinitions = {
+  // As above: only the definitions referenced by the sources under test are mocked.
+  const definitions = {
     TRANSPORTATION_PARKING: {
       id: 'transportation-parking',
       layerId: 'transportation-parking-layer',
@@ -117,11 +120,11 @@ describe('SearchSources', () => {
       name: 'Single Occupancy Restroom Locations',
       url: 'https://example.com/single-occupancy-restrooms'
     }
-  };
+  } as unknown as IComposedIDefinitions;
 
   it('should return all search sources when no options are provided', () => {
     const result = SearchSources(connections, definitions);
-    expect(result.length).toBe(13); // Ensure the number of search sources matches
+    expect(result.length).toBe(14); // Ensure the number of search sources matches
   });
 
   it('should exclude specified search sources', () => {
@@ -129,7 +132,7 @@ describe('SearchSources', () => {
       exclude: ['BUILDING', 'BIKE_RACKS']
     };
     const result = SearchSources(connections, definitions, options);
-    expect(result.length).toBe(11); // Ensure the number of search sources matches after exclusion
+    expect(result.length).toBe(12); // Ensure the number of search sources matches after exclusion
     expect(result.find((source) => source.source === 'building')).toBeUndefined();
     expect(result.find((source) => source.source === 'bike-racks')).toBeUndefined();
   });
@@ -139,7 +142,7 @@ describe('SearchSources', () => {
       exclude: []
     };
     const result = SearchSources(connections, definitions, options);
-    expect(result.length).toBe(13); // Ensure the number of search sources matches
+    expect(result.length).toBe(14); // Ensure the number of search sources matches
   });
 
   it('should return an empty array if all search sources are excluded', () => {
@@ -147,6 +150,7 @@ describe('SearchSources', () => {
       exclude: [
         'BUILDING',
         'BUILDING_EXACT',
+        'BUILDING_EXACT_ABBR',
         'UNIVERSITY_DEPARTMENTS',
         'UNIVERSITY_DEPARTMENTS_EXACT',
         'ALL_PARKING',
@@ -186,5 +190,28 @@ describe('SearchSources', () => {
     });
     expect(poiExact?.urlQueryParam).toBe('poi');
     expect(poiExact?.urlQueryParamAliases).toEqual(['POI']);
+  });
+
+  it('should resolve building deep links by number and by abbreviation against the correct fields', () => {
+    const result = SearchSources(connections, definitions);
+    const bldgExact = result.find((source) => source.source === 'building-exact');
+    const bldgExactAbbr = result.find((source) => source.source === 'building-exact-abbr');
+
+    // `?bldg=1510` style links query the building Number field.
+    expect(bldgExact?.urlQueryParam).toBe('bldg');
+    expect(bldgExact?.urlQueryParamAliases).toEqual(['Bldg']);
+    expect(bldgExact?.queryParams?.where).toEqual({
+      keys: ['Number'],
+      operators: ['=']
+    });
+
+    // `?BldgAbbrv=WCBA` style links (used by the registrar) must query the BldgAbbr field, not Number.
+    expect(bldgExactAbbr?.urlQueryParam).toBe('BldgAbbrv');
+    expect(bldgExactAbbr?.urlQueryParamAliases).toEqual(['bldgabbrv', 'BldgAbbr', 'bldgabbr']);
+    expect(bldgExactAbbr?.queryParams?.where).toEqual({
+      keys: ['BldgAbbr'],
+      operators: ['='],
+      transformations: ['UPPER']
+    });
   });
 });

--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
@@ -62,7 +62,30 @@ export function SearchSources(
       popupComponent: Popups.BuildingPopupComponent,
       searchActive: false,
       urlQueryParam: 'bldg',
-      urlQueryParamAliases: ['Bldg', 'BldgAbbrv', 'bldgabbrv']
+      urlQueryParamAliases: ['Bldg']
+    },
+    // Resolves a building from its abbreviation (e.g. `?BldgAbbrv=WCBA`) rather than its number.
+    // Kept separate from BUILDING_EXACT because the registrar's links select by `BldgAbbr`, which
+    // requires its own where clause; folding it into BUILDING_EXACT's aliases would (incorrectly)
+    // query the abbreviation against the `Number` field and return no results.
+    BUILDING_EXACT_ABBR: {
+      source: 'building-exact-abbr',
+      name: 'Building',
+      url: `${connections.basemapUrl}/1`,
+      queryParams: {
+        ...commonQueryParams,
+        where: {
+          keys: ['BldgAbbr'],
+          operators: ['='],
+          transformations: ['UPPER']
+        }
+      },
+      featuresLocation: 'features',
+      displayTemplate: '{attributes.BldgName} ({attributes.Number})',
+      popupComponent: Popups.BuildingPopupComponent,
+      searchActive: false,
+      urlQueryParam: 'BldgAbbrv',
+      urlQueryParamAliases: ['bldgabbrv', 'BldgAbbr', 'bldgabbr']
     },
     UNIVERSITY_DEPARTMENTS: {
       source: 'university-departments',
@@ -298,6 +321,7 @@ export function SearchSources(
 export type ComposedSearchSourcesKeyMap = {
   BUILDING: SearchSource;
   BUILDING_EXACT: SearchSource;
+  BUILDING_EXACT_ABBR: SearchSource;
   UNIVERSITY_DEPARTMENTS: SearchSource;
   UNIVERSITY_DEPARTMENTS_EXACT: SearchSource;
   ALL_PARKING: SearchSource;


### PR DESCRIPTION
This PR fixes an issue where using an incoming link to AggieMap with a building abbreviation did not work:

<img width="3823" height="2181" alt="image" src="https://github.com/user-attachments/assets/96eb187c-aaa3-4f0c-8a82-5da8f6c7d5ed" />

URLs from Howdy work as well:

<img width="3820" height="2174" alt="image" src="https://github.com/user-attachments/assets/89e5523f-f487-4707-8a0d-9655e5d89c71" />

URLs with the building number code also still work:

<img width="3797" height="2212" alt="image" src="https://github.com/user-attachments/assets/2b892da6-8089-4811-ad57-a6322cb817b6" />

Closes #838