### PR TITLE
feat(aggiemap-angular) (Dev-only) Add Fish Camp Map

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -64,7 +64,11 @@ function createConnections(gisHost: string): IComposedConnections {
     womensBasketballUrl: `https://${gisHost}/arcgis/rest/services/TS/TracSocSoftSwimVollWbask/MapServer`,
     fourHRoundupUrl: `https://${gisHost}/arcgis/rest/services/TS/4H_Roundup/MapServer`,
     gisDayUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer',
-    argentinaVsHondurasUrl: `https://${gisHost}/arcgis/rest/services/TS/Argentina_vs_Honduras26/MapServer`
+    argentinaVsHondurasUrl: `https://${gisHost}/arcgis/rest/services/TS/Argentina_vs_Honduras26/MapServer`,
+    // NOTE: TS/Fish_Camp is currently only published to the dev GIS host (gis-dev.it.tamu.edu) — it is
+    // NOT yet on the production host. It resolves via `gisHost` like every other layer, so the dev
+    // deployment loads it correctly; it will 404 on production until the service is published there.
+    fishCampUrl: `https://${gisHost}/arcgis/rest/services/TS/Fish_Camp/MapServer`
   };
 }
 
@@ -147,4 +151,5 @@ export interface IComposedConnections {
   fourHRoundupUrl: string;
   gisDayUrl: string;
   argentinaVsHondurasUrl: string;
+  fishCampUrl: string;
 }

--- a/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/all.definitions.ts
@@ -55,6 +55,7 @@ import { TsMainParkingTs } from './main-parking.definitions';
 import { SecGroundsConferenceTs } from './sec-grounds-conference.definitions';
 import { ArgentinaVsHondurasTs } from './argentina-vs-honduras.definitions';
 import { ConstructionMapTs } from './construction-map.definitions';
+import { FishCampTs } from './fish-camp.definitions';
 
 export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   FourHRoundupTs,
@@ -112,5 +113,6 @@ export const EventDefinitions: Array<AggiemapCustomMapConfiguration> = [
   TsMainParkingTs,
   SecGroundsConferenceTs,
   ArgentinaVsHondurasTs,
-  ConstructionMapTs
+  ConstructionMapTs,
+  FishCampTs
 ];

--- a/libs/ts/events/ngx/src/lib/definitions/fish-camp.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/fish-camp.definitions.ts
@@ -1,0 +1,280 @@
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
+import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
+
+import esri = __esri;
+
+import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
+
+import {
+  AggiemapCustomMapConfiguration,
+  EventConfiguration,
+  SpecialEventOptions
+} from '../interfaces/special-event.interface';
+
+export enum FISH_CAMP_LAYERS {
+  ARRIVAL_GROUP = 'fish-camp-arrival-group',
+  ARRIVAL_PARKING_INFO = 'fish-camp-arrival-parking-info',
+  ARRIVAL_ROUTES = 'fish-camp-arrival-routes',
+  ARRIVAL_PARKING_LOTS = 'fish-camp-arrival-parking-lots',
+  DEPARTURE_GROUP = 'fish-camp-departure-group',
+  DEPARTURE_PARKING_INFO = 'fish-camp-departure-parking-info',
+  DEPARTURE_ROUTES = 'fish-camp-departure-routes',
+  DEPARTURE_PARKING_LOTS = 'fish-camp-departure-parking-lots'
+}
+
+const fishCampUrl = Connections.fishCampUrl;
+
+// The published service tags every feature with a start/end date. The two Fish Camp drop-off
+// locations are distinguished entirely by those dates:
+//   - Sessions A–F (Reed area):  Jul 20 – Aug 6, 2026
+//   - Session G    (Lot 40):     Aug 7  – Aug 9, 2026
+// The two ranges are disjoint, so a single split date (Aug 1) cleanly separates them and is robust
+// to any timezone offset. Point/route layers expose the date as `Start_Date`; lot layers use
+// `StartDate`, hence the two field variants below.
+const SESSION_SPLIT_DATE = "DATE '2026-08-01'";
+
+enum FishCampBuilderOptions {
+  SESSION = 'fish-camp-session'
+}
+
+enum FishCampSessionChoices {
+  SESSIONS_A_F = 'sessions-a-f',
+  SESSION_G = 'session-g'
+}
+
+const pointRouteDateFilter: Record<FishCampSessionChoices, string> = {
+  [FishCampSessionChoices.SESSIONS_A_F]: `Start_Date < ${SESSION_SPLIT_DATE}`,
+  [FishCampSessionChoices.SESSION_G]: `Start_Date >= ${SESSION_SPLIT_DATE}`
+};
+
+const lotDateFilter: Record<FishCampSessionChoices, string> = {
+  [FishCampSessionChoices.SESSIONS_A_F]: `StartDate < ${SESSION_SPLIT_DATE}`,
+  [FishCampSessionChoices.SESSION_G]: `StartDate >= ${SESSION_SPLIT_DATE}`
+};
+
+const pointRouteConversions = [
+  { input: FishCampSessionChoices.SESSIONS_A_F, expression: pointRouteDateFilter[FishCampSessionChoices.SESSIONS_A_F] },
+  { input: FishCampSessionChoices.SESSION_G, expression: pointRouteDateFilter[FishCampSessionChoices.SESSION_G] }
+];
+
+const lotConversions = [
+  { input: FishCampSessionChoices.SESSIONS_A_F, expression: lotDateFilter[FishCampSessionChoices.SESSIONS_A_F] },
+  { input: FishCampSessionChoices.SESSION_G, expression: lotDateFilter[FishCampSessionChoices.SESSION_G] }
+];
+
+const popup = {
+  popupComponent: MarkdownPopupComponent,
+  popupData: {
+    name: { field: 'name' },
+    description: { field: 'description' }
+  }
+};
+
+// Routes are directional, so render each type with an arrowhead at the end of the line to show the
+// direction of travel. Colors match the published service renderer (green = vehicle, blue = walking).
+const routesNative: NonNullable<FeatureLayerSourceProperties['native']> = {
+  outFields: ['*'],
+  renderer: {
+    type: 'unique-value',
+    field: 'name',
+    uniqueValueInfos: [
+      {
+        value: 'Preferred Vehicle Route',
+        symbol: {
+          type: 'simple-line',
+          color: [0, 115, 76, 255],
+          width: 4,
+          marker: { style: 'arrow', color: [0, 115, 76, 255], placement: 'end' }
+        } as unknown as esri.SimpleLineSymbolProperties
+      },
+      {
+        value: 'Preferred Walking Route',
+        symbol: {
+          type: 'simple-line',
+          color: [0, 92, 230, 255],
+          width: 3,
+          marker: { style: 'arrow', color: [0, 92, 230, 255], placement: 'end' }
+        } as unknown as esri.SimpleLineSymbolProperties
+      }
+    ]
+  }
+};
+
+/**
+ * Builds the three feature-layer children that make up an Arrival/Departure group. The service
+ * exposes the same shape (Parking Information, Routes, Parking Lots) for both phases at different
+ * sub-layer indexes.
+ */
+function buildPhaseChildren(ids: {
+  parkingInfo: FISH_CAMP_LAYERS;
+  routes: FISH_CAMP_LAYERS;
+  parkingLots: FISH_CAMP_LAYERS;
+}, indexes: { parkingInfo: number; routes: number; parkingLots: number }): LayerSource[] {
+  // Order matters: later entries draw on top. Parking Lots (polygons) sit at the bottom, Routes
+  // (lines) above them, and Parking Information (points) on top.
+  return [
+    {
+      type: 'feature',
+      id: ids.parkingLots,
+      title: 'Parking Lots',
+      url: `${fishCampUrl}/${indexes.parkingLots}`,
+      visible: true,
+      listMode: 'show',
+      ...popup,
+      native: {
+        outFields: ['*']
+      }
+    },
+    {
+      type: 'feature',
+      id: ids.routes,
+      title: 'Routes',
+      url: `${fishCampUrl}/${indexes.routes}`,
+      visible: true,
+      listMode: 'show',
+      ...popup,
+      native: routesNative
+    },
+    {
+      type: 'feature',
+      id: ids.parkingInfo,
+      title: 'Parking Information',
+      url: `${fishCampUrl}/${indexes.parkingInfo}`,
+      visible: true,
+      listMode: 'show',
+      ...popup,
+      // The published picture-marker icons are pin-shaped (natural 32x40, ~0.8 ratio) but the
+      // renderer forces them to a square (25x25 / 30x30), which stretches them. Re-render at a
+      // matching 0.8 ratio (24x30) to remove the distortion — these sizing hints are applied to both
+      // the legend swatches and the on-map symbols.
+      legend: {
+        mode: 'renderer-symbol',
+        preserveAspectRatio: true,
+        fit: 'contain',
+        width: 24,
+        height: 30
+      },
+      native: {
+        outFields: ['*']
+      }
+    }
+  ];
+}
+
+export const FishCampColdLayerSources: LayerSource[] = [
+  {
+    type: 'group',
+    id: FISH_CAMP_LAYERS.ARRIVAL_GROUP,
+    title: 'Send Off/Arrival',
+    visible: true,
+    listMode: 'show',
+    layerIndex: 61,
+    sources: buildPhaseChildren(
+      {
+        parkingInfo: FISH_CAMP_LAYERS.ARRIVAL_PARKING_INFO,
+        routes: FISH_CAMP_LAYERS.ARRIVAL_ROUTES,
+        parkingLots: FISH_CAMP_LAYERS.ARRIVAL_PARKING_LOTS
+      },
+      { parkingInfo: 1, routes: 2, parkingLots: 3 }
+    ),
+    // Collapse the children so the group acts as a single on/off toggle in the layer list.
+    native: {
+      listMode: 'hide-children'
+    }
+  },
+  {
+    type: 'group',
+    id: FISH_CAMP_LAYERS.DEPARTURE_GROUP,
+    title: 'Bring Back/Departure',
+    visible: true,
+    listMode: 'show',
+    layerIndex: 60,
+    sources: buildPhaseChildren(
+      {
+        parkingInfo: FISH_CAMP_LAYERS.DEPARTURE_PARKING_INFO,
+        routes: FISH_CAMP_LAYERS.DEPARTURE_ROUTES,
+        parkingLots: FISH_CAMP_LAYERS.DEPARTURE_PARKING_LOTS
+      },
+      { parkingInfo: 5, routes: 6, parkingLots: 7 }
+    ),
+    native: {
+      listMode: 'hide-children'
+    }
+  }
+];
+
+export const FishCampConfiguration: EventConfiguration = {
+  id: 'fish-camp',
+  name: 'Fish Camp',
+  applicationName: 'Fish Camp Parking & Transportation Map',
+  shortApplicationName: 'Fish Camp Map',
+  introductionText:
+    'Plan ahead for Fish Camp send-off and pickup! Select your session to get the right parking, drop-off, and route information.',
+  reviewText: 'Please review your selection. The map will zoom to your session’s send-off and pickup location.',
+  eventDates: ['2026-07-20', '2026-08-09'],
+  scheduleUrl: 'https://fishcamp.tamu.edu/',
+  // Default framing before/without a session selection. Each session choice carries its own
+  // `mapView` (see options below), which recenters the map on that session's location after load.
+  mapCenter: [-96.34618, 30.60580],
+  zoom: 16,
+  legendAllowVisibilityToggle: true,
+  legendCombineChildrenUnderPrimary: true,
+  builderStartStep: 'accommodations'
+};
+
+export const FishCampOptions: SpecialEventOptions = [
+  {
+    value: FishCampBuilderOptions.SESSION,
+    label: 'Fish Camp Session',
+    shortDescription: 'Fish Camp Session',
+    description: 'Select your Fish Camp session to see the correct send-off and pickup location.',
+    choices: [
+      {
+        value: FishCampSessionChoices.SESSIONS_A_F,
+        label: 'Sessions A–F',
+        secondaryLabel: 'July 20 – August 8',
+        // Reed area (Lot 100c / 100e). Tune center/zoom here to adjust framing.
+        mapView: { center: [-96.34924, 30.6037], zoom: 17 }
+      },
+      {
+        value: FishCampSessionChoices.SESSION_G,
+        label: 'Session G',
+        secondaryLabel: 'August 7 – 9',
+        // Lot 40. Tune center/zoom here to adjust framing.
+        mapView: { center: [-96.33266, 30.61241], zoom: 17 }
+      }
+    ],
+    effects: {
+      layers: [
+        { layerId: FISH_CAMP_LAYERS.ARRIVAL_PARKING_INFO, conversions: pointRouteConversions },
+        { layerId: FISH_CAMP_LAYERS.ARRIVAL_ROUTES, conversions: pointRouteConversions },
+        { layerId: FISH_CAMP_LAYERS.ARRIVAL_PARKING_LOTS, conversions: lotConversions },
+        { layerId: FISH_CAMP_LAYERS.DEPARTURE_PARKING_INFO, conversions: pointRouteConversions },
+        { layerId: FISH_CAMP_LAYERS.DEPARTURE_ROUTES, conversions: pointRouteConversions },
+        { layerId: FISH_CAMP_LAYERS.DEPARTURE_PARKING_LOTS, conversions: lotConversions }
+      ]
+    }
+  }
+];
+
+const FishCampLayerReferences: Record<string, string> = {
+  ARRIVAL_GROUP: FISH_CAMP_LAYERS.ARRIVAL_GROUP,
+  DEPARTURE_GROUP: FISH_CAMP_LAYERS.DEPARTURE_GROUP
+};
+
+export const FishCampTs: AggiemapCustomMapConfiguration = {
+  type: 'general-map',
+  configuration: FishCampConfiguration,
+  options: FishCampOptions,
+  sources: FishCampColdLayerSources,
+  references: FishCampLayerReferences,
+  discover: {
+    id: FishCampConfiguration.id,
+    name: FishCampConfiguration.name,
+    description: 'Parking, drop-off, and route information for Fish Camp send-off and pickup.',
+    source: 'internal',
+    type: 'event',
+    mapType: 'campus',
+    keywords: ['fish camp', 'fishcamp', 'new student', 'send off', 'pickup', 'parking', 'transportation']
+  }
+};

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -315,6 +315,26 @@ export interface EventAccommodationOption {
    * Optional note that can be surfaced by events that opt into resolved setting notes.
    */
   note?: string;
+
+  /**
+   * Optional map view applied once the event layers load when this choice is the active selection.
+   *
+   * Use this to recenter the map on a fixed location tied to a builder choice (for example, a session
+   * whose drop-off location differs from other sessions). When provided, it takes precedence over the
+   * configuration-level `mapCenter`/`zoom` and avoids any feature-extent computation, giving precise,
+   * hand-tunable control over the framing.
+   */
+  mapView?: {
+    /**
+     * Map center as `[longitude, latitude]`.
+     */
+    center: [number, number];
+
+    /**
+     * Optional zoom level. When omitted, the current view zoom is preserved.
+     */
+    zoom?: number;
+  };
 }
 
 export interface ResolvedEventSetting {

--- a/libs/ts/events/ngx/src/lib/services/event/event.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/event/event.service.ts
@@ -150,12 +150,18 @@ export class EventService {
             }
           }
 
+          // Group layers (e.g. Fish Camp's Arrival/Departure groups) hold their feature layers in a
+          // nested `sources` array. The block above only targets the top-level source, so walk the
+          // children and apply any option effects whose layerId matches a nested feature layer.
+          this.applyEffectsToGroupChildren(source);
+
           return source;
         });
 
       if (sources.length > 0) {
         await this.mapService.loadLayers(sources);
         await this.selectFeatureFromUrl(sources);
+        await this.applySelectedChoiceView();
       } else {
         throw new Error('drawEvent: No layer sources found.');
       }
@@ -163,6 +169,125 @@ export class EventService {
       console.error(`Failed to event areas`, err);
     }
   }
+
+  /**
+   * Recursively applies option effects to a group source's nested feature layers.
+   *
+   * Unlike top-level sources (handled inline in `drawEvent`), group children are not direct effect
+   * targets in the reference list, so their definition expressions must be resolved by walking the
+   * tree. The resolved expression is written to the child's `native.definitionExpression` because
+   * `EsriMapService.generateLayer` spreads `native` last — any expression set elsewhere would be
+   * overridden by it.
+   */
+  private applyEffectsToGroupChildren(source: LayerSource): void {
+    const children = (source as { sources?: LayerSource[] }).sources;
+
+    if (!children || children.length === 0) {
+      return;
+    }
+
+    for (const child of children) {
+      // Handle nested groups before applying effects to the immediate child.
+      this.applyEffectsToGroupChildren(child);
+
+      const optionsTargetingChild = this.eventOptions.filter((o) =>
+        o.effects.layers?.some((layer) => layer.layerId === child.id)
+      );
+
+      for (const option of optionsTargetingChild) {
+        const settingValue = this.settings[option.value];
+
+        if (settingValue === undefined) {
+          continue;
+        }
+
+        for (const layer of option.effects.layers ?? []) {
+          if (layer.layerId !== child.id || !layer.conversions) {
+            continue;
+          }
+
+          const conversion = layer.conversions.find((c) => c.input === settingValue);
+
+          if (!conversion) {
+            continue;
+          }
+
+          if (conversion.propOverrides) {
+            Object.assign(child, deepmerge(child, conversion.propOverrides));
+          }
+
+          if (conversion.expression) {
+            this.setChildDefinitionExpression(child, conversion.expression, conversion.deconflictingStrategy);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Sets a group child's definition expression on its `native` block, honoring any deconflicting
+   * strategy when an expression is already present. A `'1=0'` placeholder is treated as empty.
+   */
+  private setChildDefinitionExpression(
+    child: LayerSource,
+    expression: string,
+    strategy?: ConversionDeconflictingStrategy
+  ): void {
+    const native = ((child as { native?: { definitionExpression?: string } }).native ??= {});
+    const existingRaw = native.definitionExpression;
+    const existing = existingRaw && existingRaw !== '1=0' ? existingRaw : undefined;
+
+    if (!existing) {
+      native.definitionExpression = expression;
+      return;
+    }
+
+    const deconflictingStrategy = strategy || ConversionDeconflictingStrategy.APPEND_AND;
+
+    if (deconflictingStrategy === ConversionDeconflictingStrategy.APPEND_AND) {
+      native.definitionExpression = `(${existing}) AND (${expression})`;
+    } else if (deconflictingStrategy === ConversionDeconflictingStrategy.APPEND_OR) {
+      native.definitionExpression = `(${existing}) OR (${expression})`;
+    } else if (deconflictingStrategy === ConversionDeconflictingStrategy.REPLACE) {
+      native.definitionExpression = expression;
+    }
+    // ConversionDeconflictingStrategy.IGNORE leaves the existing expression untouched.
+  }
+
+  /**
+   * Recenters the map on the active selection's configured `mapView`, if any.
+   *
+   * Applies an explicit `[lon, lat]` center and optional zoom carried by the selected builder choice.
+   * It gives events with fixed, choice-specific locations precise control over framing and takes
+   * precedence over the configuration-level `mapCenter`/`zoom`.
+   */
+  private async applySelectedChoiceView(): Promise<void> {
+    if (!this._view) {
+      return;
+    }
+
+    for (const option of this.eventOptions) {
+      const settingValue = this.settings[option.value];
+
+      if (settingValue === undefined) {
+        continue;
+      }
+
+      const selectedChoice = option.choices?.find((choice) => choice.value === settingValue);
+      const view = selectedChoice?.mapView;
+
+      if (view?.center) {
+        try {
+          await this._view.goTo({ center: view.center, zoom: view.zoom ?? this._view.zoom });
+        } catch (err) {
+          console.error('EventService: Failed to apply selected choice view', err);
+        }
+
+        return;
+      }
+    }
+  }
+
 
   /**
    * Returns a clone layer source of the provided layer source `id` reference.


### PR DESCRIPTION
This PR adds the Fish Camp map with a builder that zooms to the correct map features depending on the chosen session.

The layers are currently set to the dev server, so this will only work on dev. Will need to be updated before being pushed to prod. 

Closes #837 