### PR TITLE
fix(aggiemap-angular) Add new August dates to Break/Summer map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -135,7 +135,8 @@ export const BreakSummerConfiguration: EventConfiguration = {
           'Dec. 19, 2025 – Jan. 11, 2026',
           'Jan. 19, 2026 – MLK',
           'Mar. 9 – 13, 2026 – Spring Break',
-          'May 10 – 25, 2026'
+          'May 10 – 25, 2026',
+          'Aug. 10 – 23, 2026'
         ]
       },
       {


### PR DESCRIPTION
This PR adds August 10-23 to the list of dates on the Break/Summer map.

<img width="839" height="1109" alt="image" src="https://github.com/user-attachments/assets/3d33f69b-73ee-4958-b4e7-fe00c690940a" />

Closes #864
