### PR TITLE
fix(aggiemap-angular) Use $gishost on new maps

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -66,29 +66,11 @@ function createConnections(gisHost: string): IComposedConnections {
     fourHRoundupUrl: `https://${gisHost}/arcgis/rest/services/TS/4H_Roundup/MapServer`,
     gisDayUrl: 'https://services1.arcgis.com/qr14biwnHA6Vis6l/ArcGIS/rest/services/MSC_and_Rudder_Building_Polygon_Layer/FeatureServer',
     argentinaVsHondurasUrl: `https://${gisHost}/arcgis/rest/services/TS/Argentina_vs_Honduras26/MapServer`,
-    // NOTE: TS/Fish_Camp is currently only published to the dev GIS host (gis-dev.it.tamu.edu) — it is
-    // NOT yet on the production host. It resolves via `gisHost` like every other layer, so the dev
-    // deployment loads it correctly; it will 404 on production until the service is published there.
     fishCampUrl: `https://${gisHost}/arcgis/rest/services/TS/Fish_Camp/MapServer`,
-    // NOTE: TS/T_Camp is currently only published to the dev GIS host (gis-dev.it.tamu.edu) — it is
-    // NOT yet on the production host. It resolves via `gisHost` like every other layer, so the dev
-    // deployment loads it correctly; it will 404 on production until the service is published there.
     tCampUrl: `https://${gisHost}/arcgis/rest/services/TS/T_Camp/MapServer`,
-    // NOTE: hard-pinned to gis-dev. The Municipal_Fire_School_Vendor_Show service is only usable on
-    // the dev GIS host — on production (gis.it.tamu.edu) it is published but token-protected, so the
-    // `${gisHost}` form fails to load on localhost/prod (struck-through layers, empty legend). Revert
-    // to `https://${gisHost}/...` once the prod service is public.
-    fireSchoolUrl: `https://gis-dev.it.tamu.edu/arcgis/rest/services/TS/Municipal_Fire_School_Vendor_Show/MapServer`,
-    // NOTE: hard-pinned to gis-dev. The Beef_Cattle_Vendor_Load_In service is only usable on the dev
-    // GIS host — on production (gis.it.tamu.edu) it is published but token-protected, so the
-    // `${gisHost}` form fails to load on localhost/prod (struck-through layers, empty legend). Revert
-    // to `https://${gisHost}/...` once the prod service is public.
-    beefCattleUrl: `https://gis-dev.it.tamu.edu/arcgis/rest/services/TS/Beef_Cattle_Vendor_Load_In/MapServer`,
-    // NOTE: TS/Games_of_Texas is only published to the dev GIS host. On production it is either
-    // absent or token-protected, so the `${gisHost}` form 401s/404s from localhost and prod. Pin to
-    // the dev host so local dev (`npx nx serve`) loads it. Revert to `${gisHost}` once the service
-    // is published publicly on production.
-    gamesOfTexasUrl: `https://gis-dev.it.tamu.edu/arcgis/rest/services/TS/Games_of_Texas/MapServer`
+    fireSchoolUrl: `https://${gisHost}/arcgis/rest/services/TS/Municipal_Fire_School_Vendor_Show/MapServer`,
+    beefCattleUrl: `https://${gisHost}/arcgis/rest/services/TS/Beef_Cattle_Vendor_Load_In/MapServer`,
+    gamesOfTexasUrl: `https://${gisHost}/arcgis/rest/services/TS/Games_of_Texas/MapServer`
   };
 }
 

--- a/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/move-in.definitions.ts
@@ -34,11 +34,7 @@ export enum MOVE_IN_LAYERS {
   LOTS_CLOSURES = 'move-in-lots-closures'
 }
 
-// NOTE: The Fall Move-In service schema this map depends on (CampusArea, StartDate/EndDate, and the
-// split `Type` values) is currently only published to the dev GIS host. Pin the move-in service to
-// gis-dev so local/dev builds load the new schema instead of the older production one.
-// TODO: revert to `Connections.moveInParkingUrl` once the new schema is published to production.
-const moveInServiceUrl = Connections('gis-dev.it.tamu.edu').moveInParkingUrl;
+const moveInServiceUrl = Connections.moveInParkingUrl;
 const basemapServiceUrl = Connections.basemapUrl;
 
 const poiUrl = `${moveInServiceUrl}/0`;


### PR DESCRIPTION
This PR moves the following maps that were previoiusly on dev to prod using $gishost:

Fish Camp, Fire School, Beef Cattle, Games of Texas