### PR TITLE
feat(aggiemap-angular): Update summer graduation details

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -124,16 +124,39 @@ export const SummerCommencementConfiguration: EventConfiguration = {
   applicationName: 'Summer Commencement Transportation Map',
   shortApplicationName: 'Summer Commencement Map',
   introductionText: 'Get the best transportation and parking information for the summer commencement ceremonies.',
-  eventDates: ['2025-08-09'],
+  eventDates: ['2026-08-08'],
+  scheduleUrl: 'https://aggie.tamu.edu/graduation',
   mapCenter: [-96.34458, 30.60629],
   zoom: 17
 };
 
 enum SummerCommencementAttendanceDateChoices {
-  DayOne = '2025-08-09T05:00:00.000Z' // May 8, 12AM UTC
+  DayOne = '2026-08-08T05:00:00.000Z' // August 8, 12AM UTC
 }
 
-export const SummerCommencementOptions: SpecialEventOptions = [];
+export const SummerCommencementOptions: SpecialEventOptions = [
+  {
+    value: 'date',
+    description:
+      'Please select the day of your commencement ceremony to provide the most accurate transportation and parking information.',
+    shortDescription: 'Event Day',
+    label: 'Event Day',
+    uiType: 'date-card-grid',
+    choices: [{ value: SummerCommencementAttendanceDateChoices.DayOne, label: 'August 8, 2026' }],
+    effects: {
+      layers: [
+        {
+          layerId: SUMMER_COMMENCEMENT_LAYERS.PARKING_LOTS,
+          conversions: [{ input: SummerCommencementAttendanceDateChoices.DayOne, propOverrides: { visible: true } }]
+        },
+        {
+          layerId: SUMMER_COMMENCEMENT_LAYERS.TRAFFIC_FLOW,
+          conversions: [{ input: SummerCommencementAttendanceDateChoices.DayOne, propOverrides: { visible: true } }]
+        }
+      ]
+    }
+  }
+];
 
 export const SummerCommencementTs: AggiemapCustomMapConfiguration = {
   type: 'special-event',


### PR DESCRIPTION
This PR adds a builder to the Summer Graduation map that shows the updated date of August 8, 2026 and provides a link to the details of the event.

<img width="2440" height="1568" alt="image" src="https://github.com/user-attachments/assets/ff3f43a8-7f63-4368-8b8a-065379fb1bb1" />
<img width="3139" height="1136" alt="image" src="https://github.com/user-attachments/assets/2871aaeb-b0be-47f8-bc00-70a6fd0a28d1" />
<img width="2537" height="2034" alt="image" src="https://github.com/user-attachments/assets/889d995f-67f5-47dd-9b7e-044976e57761" />

Closes #873