### PR TITLE
fix(aggiemap-angular) Update Break/Summer dates + Fix mobile version

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/break-summer.definitions.ts
@@ -136,7 +136,7 @@ export const BreakSummerConfiguration: EventConfiguration = {
           'Jan. 19, 2026 – MLK',
           'Mar. 9 – 13, 2026 – Spring Break',
           'May 10 – 25, 2026',
-          'Aug. 10 – 23, 2026'
+          'Aug. 10 – 21, 2026'
         ]
       },
       {

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.html
@@ -1,3 +1,15 @@
+<ng-container *ngIf="sidebarInfo as info">
+  <div *ngFor="let section of info.sections" class="sidebar-info-section">
+    <div class="sidebar-component-name">
+      <p [ngStyle]="section.styleOverrides?.heading">{{ section.heading }}</p>
+    </div>
+    <p *ngIf="section.subheading" class="sidebar-info-subheading" [ngStyle]="section.styleOverrides?.subheading">{{ section.subheading }}</p>
+    <ul *ngIf="section.items?.length" class="sidebar-info-items" [ngStyle]="section.styleOverrides?.items">
+      <li *ngFor="let item of section.items" [ngStyle]="section.styleOverrides?.item">{{ item }}</li>
+    </ul>
+  </div>
+</ng-container>
+
 <tamu-gisc-legend
   [deduplicate]="deduplicate"
   [respectDefinitionExpression]="respectDefinitionExpression"

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.scss
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.scss
@@ -1,0 +1,27 @@
+.sidebar-info-section {
+  padding: 0.35rem;
+  margin-bottom: 0.5rem;
+
+  .sidebar-component-name p {
+    margin: 0 0 0.25rem;
+  }
+
+  .sidebar-info-subheading {
+    margin: 0 0 0.25rem;
+    font-size: 0.8rem;
+    font-style: italic;
+    color: #6e6e6e;
+  }
+
+  .sidebar-info-items {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    li {
+      color: #323232;
+      font-size: 0.875rem;
+      padding: 0.1rem 0;
+    }
+  }
+}

--- a/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/map/components/event-legend/event-legend.component.ts
@@ -1,16 +1,19 @@
 import { Component, OnInit } from '@angular/core';
 
 import { EventSettingsService } from '../../../../services/settings/event-settings.service';
+import { SidebarInfoPanel } from '../../../../interfaces/special-event.interface';
 
 @Component({
   selector: 'tamu-gisc-event-legend',
-  templateUrl: './event-legend.component.html'
+  templateUrl: './event-legend.component.html',
+  styleUrls: ['./event-legend.component.scss']
 })
 export class EventLegendComponent implements OnInit {
   public deduplicate = true;
   public respectDefinitionExpression = true;
   public allowVisibilityToggle = true;
   public combineChildrenUnderPrimary = false;
+  public sidebarInfo: SidebarInfoPanel | undefined;
 
   constructor(private readonly eventSettingsService: EventSettingsService) {}
 
@@ -19,5 +22,6 @@ export class EventLegendComponent implements OnInit {
 
     this.allowVisibilityToggle = config?.legendAllowVisibilityToggle ?? true;
     this.combineChildrenUnderPrimary = config?.legendCombineChildrenUnderPrimary ?? false;
+    this.sidebarInfo = config?.sidebarInfo;
   }
 }


### PR DESCRIPTION
This PR updates the August date for Break/Summer and makes the dates appear on mobile.

<img width="1172" height="1886" alt="image" src="https://github.com/user-attachments/assets/a217ef74-bf80-4865-9b9f-01004a007a3f" />

Closes #872 