### PR TITLE
fix(aggiemap-angular): New basemap broke building search

### DIFF
--- a/apps/gisday-competitions-angular/src/environments/environment.dev.ts
+++ b/apps/gisday-competitions-angular/src/environments/environment.dev.ts
@@ -57,7 +57,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -69,7 +69,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: 'BuildingPopupComponent',

--- a/apps/gisday-competitions-angular/src/environments/environment.prod.ts
+++ b/apps/gisday-competitions-angular/src/environments/environment.prod.ts
@@ -57,7 +57,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -69,7 +69,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: 'BuildingPopupComponent',

--- a/apps/gisday-competitions-angular/src/environments/environment.ts
+++ b/apps/gisday-competitions-angular/src/environments/environment.ts
@@ -61,7 +61,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -73,7 +73,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: 'BuildingPopupComponent',

--- a/apps/trees-angular/src/environments/environment.prod.ts
+++ b/apps/trees-angular/src/environments/environment.prod.ts
@@ -129,7 +129,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -141,7 +141,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: 'BuildingPopupComponent',

--- a/apps/trees-angular/src/environments/environment.ts
+++ b/apps/trees-angular/src/environments/environment.ts
@@ -133,7 +133,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -145,7 +145,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: 'BuildingPopupComponent',

--- a/apps/ts-football-angular/src/environments/definitions.ts
+++ b/apps/ts-football-angular/src/environments/definitions.ts
@@ -410,19 +410,19 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
       },
       scoringWhere: {
-        keys: ['BldgName', 'BldgAbbr'],
+        keys: ['BldgName', 'BldgAbbrev'],
         operators: ['LIKE', 'LIKE'],
         wildcards: ['startsWith', 'startsWith'],
         transformations: ['UPPER', 'UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: Definitions.BUILDINGS.popupComponent,

--- a/apps/ts-move-in-out-angular/src/environments/definitions.ts
+++ b/apps/ts-move-in-out-angular/src/environments/definitions.ts
@@ -629,19 +629,19 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
       },
       scoringWhere: {
-        keys: ['BldgName', 'BldgAbbr'],
+        keys: ['BldgName', 'BldgAbbrev'],
         operators: ['LIKE', 'LIKE'],
         wildcards: ['startsWith', 'startsWith'],
         transformations: ['UPPER', 'UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: Definitions.BUILDINGS.popupComponent,

--- a/apps/ts-ring-day-angular/src/environments/definitions.ts
+++ b/apps/ts-ring-day-angular/src/environments/definitions.ts
@@ -560,19 +560,19 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
       },
       scoringWhere: {
-        keys: ['BldgName', 'BldgAbbr'],
+        keys: ['BldgName', 'BldgAbbrev'],
         operators: ['LIKE', 'LIKE'],
         wildcards: ['startsWith', 'startsWith'],
         transformations: ['UPPER', 'UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: Definitions.BUILDINGS.popupComponent,

--- a/apps/ues-effluent-angular/src/environments/definitions.ts
+++ b/apps/ues-effluent-angular/src/environments/definitions.ts
@@ -246,7 +246,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -258,7 +258,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: Popups.BuildingPopupComponent,

--- a/apps/ues-operations-angular/src/environments/definitions.ts
+++ b/apps/ues-operations-angular/src/environments/definitions.ts
@@ -567,7 +567,7 @@ export const SearchSources: SearchSource[] = [
     queryParams: {
       ...commonQueryParams,
       where: {
-        keys: ['Number', 'BldgAbbr', 'BldgName'],
+        keys: ['Number', 'BldgAbbrev', 'BldgName'],
         operators: ['LIKE', 'LIKE', 'LIKE'],
         wildcards: ['includes', 'includes', 'includes'],
         transformations: ['UPPER', 'UPPER', 'UPPER']
@@ -579,7 +579,7 @@ export const SearchSources: SearchSource[] = [
         transformations: ['UPPER']
       }
     },
-    scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+    scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
     featuresLocation: 'features',
     displayTemplate: '{attributes.BldgName} ({attributes.Number})',
     popupComponent: Popups.BuildingPopupComponent,

--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
@@ -209,7 +209,7 @@ describe('SearchSources', () => {
     expect(bldgExactAbbr?.urlQueryParam).toBe('BldgAbbrv');
     expect(bldgExactAbbr?.urlQueryParamAliases).toEqual(['bldgabbrv', 'BldgAbbr', 'bldgabbr']);
     expect(bldgExactAbbr?.queryParams?.where).toEqual({
-      keys: ['BldgAbbr'],
+      keys: ['BldgAbbrev'],
       operators: ['='],
       transformations: ['UPPER']
     });

--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
@@ -28,19 +28,19 @@ export function SearchSources(
       queryParams: {
         ...commonQueryParams,
         where: {
-          keys: ['Number', 'BldgAbbr', 'BldgName'],
+          keys: ['Number', 'BldgAbbrev', 'BldgName'],
           operators: ['LIKE', 'LIKE', 'LIKE'],
           wildcards: ['includes', 'includes', 'includes'],
           transformations: ['UPPER', 'UPPER', 'UPPER']
         },
         scoringWhere: {
-          keys: ['BldgName', 'BldgAbbr'],
+          keys: ['BldgName', 'BldgAbbrev'],
           operators: ['LIKE', 'LIKE'],
           wildcards: ['startsWith', 'startsWith'],
           transformations: ['UPPER', 'UPPER']
         }
       },
-      scoringKeys: ['attributes.BldgAbbr', 'attributes.Number', 'attributes.BldgName'],
+      scoringKeys: ['attributes.BldgAbbrev', 'attributes.Number', 'attributes.BldgName'],
       featuresLocation: 'features',
       displayTemplate: '{attributes.BldgName} ({attributes.Number})',
       popupComponent: Popups.BuildingPopupComponent,
@@ -75,7 +75,7 @@ export function SearchSources(
       queryParams: {
         ...commonQueryParams,
         where: {
-          keys: ['BldgAbbr'],
+          keys: ['BldgAbbrev'],
           operators: ['='],
           transformations: ['UPPER']
         }

--- a/libs/aggiemap/ngx/core/src/lib/pages/directory/components/directory.component.html
+++ b/libs/aggiemap/ngx/core/src/lib/pages/directory/components/directory.component.html
@@ -24,7 +24,7 @@
 
         <ngx-datatable-column name="Number" prop="Bldg"></ngx-datatable-column>
 
-        <ngx-datatable-column name="Abbreviation" prop="BldgAbbr"></ngx-datatable-column>
+        <ngx-datatable-column name="Abbreviation" prop="BldgAbbrev"></ngx-datatable-column>
       </ngx-datatable>
     </div>
   </div>

--- a/libs/aggiemap/ngx/core/src/lib/pages/directory/components/directory.component.ts
+++ b/libs/aggiemap/ngx/core/src/lib/pages/directory/components/directory.component.ts
@@ -34,7 +34,7 @@ export class DirectoryComponent implements OnInit {
   public columns: TableColumn[] = [
     { name: 'Name', prop: 'BldgName', canAutoResize: true, width: 350 },
     { name: 'Number', prop: 'Bldg', canAutoResize: true },
-    { name: 'Abbreviation', prop: 'BldgAbbr', canAutoResize: true }
+    { name: 'Abbreviation', prop: 'BldgAbbrev', canAutoResize: true }
   ];
 
   public loadingIndicator = true;

--- a/libs/aggiemap/ngx/popups/src/lib/components/lactation/lactation.component.html
+++ b/libs/aggiemap/ngx/popups/src/lib/components/lactation/lactation.component.html
@@ -1,7 +1,7 @@
 <div class="popup-section">
   <div class="feature-style-1" tabindex="0">Lactation Room</div>
   <div class="feature-style-2" tabindex="0">Building Name: {{ data.attributes.Name }}</div>
-  <div class="feature-style-2" tabindex="0">Building Number: {{ data.attributes.BldgNum }}</div>
+  <div class="feature-style-2" tabindex="0">Building Number: {{ data.attributes.Bldg_Number }}</div>
   <div class="feature-style-2" tabindex="0">Availability: {{ data.attributes.MapDisplay }}</div>
   <div class="feature-style-2" tabindex="0">
     <a [href]="data.attributes.Notes" target="_blank">Additional Information</a>

--- a/libs/aggiemap/ngx/popups/src/lib/components/restroom/restroom.component.html
+++ b/libs/aggiemap/ngx/popups/src/lib/components/restroom/restroom.component.html
@@ -1,6 +1,6 @@
 <div class="popup-section">
   <div class="feature-style-1" tabindex="0">Unisex Restroom</div>
   <div class="feature-style-2" tabindex="0">Building Name: {{ data.attributes.Name }}</div>
-  <div class="feature-style-2" tabindex="0">Building Number: {{ data.attributes.BldgNum }}</div>
+  <div class="feature-style-2" tabindex="0">Building Number: {{ data.attributes.Bldg_Number }}</div>
   <div class="feature-style-2" tabindex="0">Note: {{ data.attributes.Notes }}</div>
 </div>


### PR DESCRIPTION
Updated references to building abbreviation from "BldgAbbr" to "BldgAbbrev" in search sources and directory components to reflect the correct property name. This change is required because the underlying database column names were updated.

Fixes #883, part of #880 