### PR TITLE
feat(aggiemap-angular): Football Map builder updates + new parking maps

### DIFF
--- a/libs/common/types/src/lib/common-types.ts
+++ b/libs/common/types/src/lib/common-types.ts
@@ -442,6 +442,18 @@ export interface LayerLegendOverride {
    * Rendered icon height in pixels.
    */
   height?: number;
+
+  /**
+   * When `true`, the legend shows this layer's full renderer legend (all unique-value categories)
+   * even while the layer carries a `definitionExpression` that filters the features drawn on the map.
+   *
+   * By default the legend honors the definition expression (see the legend component's
+   * `respectDefinitionExpression`) and hides categories with no matching features — correct for
+   * layers whose legend should mirror what's drawn. Opt in here for a layer that should always
+   * present its complete color key as a reference (e.g. parking-lot categories that are filtered
+   * to one type per mode but should still explain every color).
+   */
+  ignoreDefinitionExpression?: boolean;
 }
 
 interface LayerSourceAuthInfo {

--- a/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
+++ b/libs/maps/feature/legend/src/lib/components/legend-element/legend-element.component.ts
@@ -134,6 +134,12 @@ export class LegendElementComponent implements OnInit {
           return of(info);
         }
 
+        // Per-layer opt-out: a layer can request its full renderer legend (every category) even when a
+        // definition expression is filtering what's drawn — used for reference color keys.
+        if (this.legendOverride?.ignoreDefinitionExpression === true) {
+          return of(info);
+        }
+
         const operableLayer = this.layer as esri.FeatureLayer;
 
         // If operable layer has no definition expression, return the current legend info as-is

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -19,15 +19,18 @@ import {
  * TODO: revert `tsFootballCacheUrl` to the prod host (`gis.tamu.edu`) once the cache is published there.
  */
 const tsFootballCacheUrl = 'https://gis.dev.tamu.edu/arcgis/rest/services/TS/TSFootball_Cache/MapServer';
-const footballLotsUrl = 'https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots/FeatureServer';
+const footballLotsUrl = 'https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots_view/FeatureServer';
 
 /**
- * The `Hosted/Lots` FeatureServer exposes exactly two sublayers. The service listing is token-gated so the
- * 0 ↔ 1 assignment below is confirmed by rendering in-app.
- * TODO: verify which sublayer is the polygon lots vs the point gameday-parking icons and swap if needed.
+ * `Lots_view` is the PUBLIC view of the Marcomm-maintained hosted lots layer. The base `Hosted/Lots`
+ * service is secured and prompts anonymous visitors to sign in, so the public view is used instead.
+ *
+ * Sublayer 0 = Gameday Parking (points), sublayer 1 = Football Parking Lots (polygons).
+ * Field names on the view are lowercase (e.g. `type`, `twelfthman`, `name`, `note`, `lotname`,
+ * `notes`, `notes_1`) and SQL where-clauses against it are case-sensitive.
  */
-const LOTS_POLYGON_LAYER_INDEX = 0;
-const GAMEDAY_PARKING_POINT_LAYER_INDEX = 1;
+const GAMEDAY_PARKING_POINT_LAYER_INDEX = 0;
+const LOTS_POLYGON_LAYER_INDEX = 1;
 
 export enum FOOTBALL_PARKING_LAYERS {
   FP_STRIPES = 'football-stripes',
@@ -332,19 +335,19 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     url: `${footballLotsUrl}/${LOTS_POLYGON_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'attributes.LotName',
-      description: 'attributes.Note'
+      name: 'attributes.lotname',
+      description: 'attributes.note'
     },
     native: {
       outFields: ['*'],
       visible: false,
       listMode: 'hide',
-      // TODO: confirm the Hosted/Lots polygon schema exposes Name / TwelfthMan / Type; adjust if the fields differ.
+      // Field names on the Lots_view polygon layer are lowercase and case-sensitive in SQL where-clauses.
       labelingInfo: [
         {
-          // TwelfthMan lots (treat blank or single space as empty; anything else shows second line)
+          // twelfthman lots (treat blank or single space as empty; anything else shows second line)
           labelExpressionInfo: {
-            expression: '$feature.Name + TextFormatting.NewLine + $feature.TwelfthMan'
+            expression: '$feature.name + TextFormatting.NewLine + $feature.twelfthman'
           },
           labelPlacement: 'always-horizontal',
           useCodedValues: true,
@@ -362,13 +365,13 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
           },
           minScale: 9500,
           maxScale: 0,
-          where: "TwelfthMan IS NOT NULL AND TRIM(TwelfthMan) <> ''"
+          where: "twelfthman IS NOT NULL AND TRIM(twelfthman) <> ''"
         },
         {
-          // Non-TwelfthMan lots with a price embedded in Type (e.g. "Public $30")
+          // Non-twelfthman lots with a price embedded in type (e.g. "Public $30")
           labelExpressionInfo: {
             expression:
-              "var t=$feature.Type; var p=''; if(t!=null && t!='' && Find('$', t)>-1){ var i=Find('$', t); var seg=Mid(t,i,10); var sp=Find(' ', seg); if(sp>-1){ seg=Left(seg, sp);} var last=Right(seg,1); if(last=='-' || last==':' || last==',' ){ seg=Left(seg, Length(seg)-1);} p=seg; } $feature.Name + IIf(p=='','', ' - '+p);"
+              "var t=$feature.type; var p=''; if(t!=null && t!='' && Find('$', t)>-1){ var i=Find('$', t); var seg=Mid(t,i,10); var sp=Find(' ', seg); if(sp>-1){ seg=Left(seg, sp);} var last=Right(seg,1); if(last=='-' || last==':' || last==',' ){ seg=Left(seg, Length(seg)-1);} p=seg; } $feature.name + IIf(p=='','', ' - '+p);"
           },
           labelPlacement: 'always-horizontal',
           useCodedValues: true,
@@ -386,11 +389,11 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
           },
           minScale: 9500,
           maxScale: 0,
-          where: "(TwelfthMan IS NULL OR TRIM(TwelfthMan) = '') AND Type IS NOT NULL AND Type LIKE '%$%' AND Type <> 'AVP'"
+          where: "(twelfthman IS NULL OR TRIM(twelfthman) = '') AND type IS NOT NULL AND type LIKE '%$%' AND type <> 'AVP'"
         },
         {
-          // Fallback: non-priced, non-TwelfthMan
-          labelExpression: '[Name]',
+          // Fallback: non-priced, non-twelfthman
+          labelExpression: '[name]',
           labelPlacement: 'always-horizontal',
           useCodedValues: true,
           symbol: {
@@ -407,7 +410,7 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
           },
           minScale: 9500,
           maxScale: 0,
-          where: "(TwelfthMan IS NULL OR TRIM(TwelfthMan) = '') AND (Type IS NULL OR Type NOT LIKE '%$%' OR Type = 'AVP')"
+          where: "(twelfthman IS NULL OR TRIM(twelfthman) = '') AND (type IS NULL OR type NOT LIKE '%$%' OR type = 'AVP')"
         }
       ]
     }
@@ -420,14 +423,14 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     url: `${footballLotsUrl}/${LOTS_POLYGON_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'attributes.LotName',
-      description: 'attributes.Note'
+      name: 'attributes.lotname',
+      description: 'attributes.note'
     },
     native: {
       outFields: ['*'],
       visible: false,
       listMode: 'hide',
-      definitionExpression: "Type = 'Charter'"
+      definitionExpression: "type = 'Charter'"
     }
   },
   {
@@ -437,8 +440,8 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     url: `${footballLotsUrl}/${GAMEDAY_PARKING_POINT_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'attributes.Type',
-      description: 'attributes.Notes'
+      name: 'attributes.notes',
+      description: 'attributes.notes_1'
     },
     native: {
       outFields: ['*'],
@@ -612,8 +615,8 @@ export const FootballParkingOptions: SpecialEventOptions = [
         {
           layerId: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
           conversions: [
-            { input: TransportType.TWELFTH_MAN, expression: "Type = 'Reserved Athletic'", propOverrides: SHOW },
-            { input: TransportType.RV, expression: "Type = 'RV'", propOverrides: SHOW },
+            { input: TransportType.TWELFTH_MAN, expression: "type = 'Reserved Athletic'", propOverrides: SHOW },
+            { input: TransportType.RV, expression: "type = 'RV'", propOverrides: SHOW },
             { input: TransportType.PERSONAL_VEHICLE, propOverrides: SHOW }
           ]
         },

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -7,6 +7,8 @@ import {
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
 
+import esri = __esri;
+
 /**
  * Football gameday transportation map.
  *
@@ -37,7 +39,15 @@ const footballLotsUrl = 'https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots_v
 const GAMEDAY_PARKING_POINT_LAYER_INDEX = 0;
 const LOTS_POLYGON_LAYER_INDEX = 1;
 
+/**
+ * Declaration order here IS the top-to-bottom map draw order. `EventService` reads this enum, reverses
+ * it, then adds each layer with `map.add()` (no index), so ArcGIS appends bottom→top — the FIRST entry
+ * ends up drawn on top, the LAST at the bottom. Keep the point icons (`FP_GAMEDAY_PARKING`) first so they
+ * sit above the parking-lot polygons; keep the polygon lots (`FP_PARKING_LOTS`/`FP_CHARTER_PARKING`/
+ * `FP_RV_PARKING`) last so they stay at the bottom.
+ */
 export enum FOOTBALL_PARKING_LAYERS {
+  FP_GAMEDAY_PARKING = 'football-gameday-parking',
   FP_STRIPES = 'football-stripes',
   FP_RNS_SPACES = 'football-rns-spaces',
   FP_ENTRY_ROUTES = 'football-entry-routes',
@@ -54,7 +64,7 @@ export enum FOOTBALL_PARKING_LAYERS {
   FP_PEDICAB_CLOSURES = 'football-pedicab-closures',
   FP_PARKING_LOTS = 'football-parking-lots',
   FP_CHARTER_PARKING = 'football-charter-parking',
-  FP_GAMEDAY_PARKING = 'football-gameday-parking'
+  FP_RV_PARKING = 'football-rv-parking'
 }
 
 /**
@@ -93,6 +103,47 @@ enum FootballBuilderOptions {
  */
 const SHOW: Partial<LayerSource> = { native: { visible: true, listMode: 'show' } };
 const HIDE: Partial<LayerSource> = { native: { visible: false, listMode: 'hide' } };
+
+/**
+ * The route layers publish from the service as flat, thick solid lines (a "green blob") — the arrow
+ * symbology from ArcGIS Pro isn't carried in the exported service renderer. Re-symbolize them as thin
+ * directional lines with an arrowhead at the end. Colors follow the travel `Type` so the shared
+ * Entry/Exit Routes layers render green (vehicle), purple (cyclist), or blue (pedestrian) per mode.
+ */
+const ROUTE_COLORS = {
+  vehicle: 'rgb(38, 115, 0)',
+  cyclist: 'rgb(112, 48, 160)',
+  pedestrian: 'rgb(0, 92, 230)'
+};
+
+/** A solid line with a direction arrow at its end, used to re-symbolize the flat route/arrow layers. */
+const arrowLineSymbol = (color: string): esri.SimpleLineSymbolProperties => ({
+  type: 'simple-line',
+  color,
+  width: 3,
+  style: 'solid',
+  marker: { style: 'arrow', color, placement: 'end' }
+});
+
+/** A solid polygon fill with a matching outline, used for the categorized Football Parking Lots renderer. */
+const lotFillSymbol = (fill: number[], outline: number[]): esri.SimpleFillSymbolProperties => ({
+  type: 'simple-fill',
+  color: fill,
+  outline: { color: outline, width: 1 }
+});
+
+/**
+ * Football Parking Lots categories (mirrors the `Lots_view` service renderer, keyed on `type`). Defining
+ * the renderer explicitly makes it available synchronously — the map factory otherwise only picks up the
+ * service renderer after an async load, so the legend can build before the categories exist. Many `type`
+ * values collapse to a few labeled categories; the legend's `deduplicate` merges the repeated labels and
+ * `respectDefinitionExpression` hides categories not present under a mode's filter.
+ */
+const LOT_RESERVED_SYMBOL = lotFillSymbol([244, 162, 97, 255], [230, 124, 0, 255]);
+const LOT_PERMIT_SYMBOL = lotFillSymbol([94, 137, 234, 255], [94, 52, 234, 255]);
+const LOT_CHARTER_SYMBOL = lotFillSymbol([0, 167, 116, 255], [0, 120, 84, 255]);
+const LOT_PAID_SYMBOL = lotFillSymbol([76, 230, 0, 255], [110, 110, 110, 255]);
+const LOT_FULL_SYMBOL = lotFillSymbol([230, 0, 0, 255], [168, 0, 0, 255]);
 
 export const FootballParkingColdLayerSources: LayerSource[] = [
   // --- RV striping + reserved spaces (RV mode) ---
@@ -145,7 +196,13 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     native: {
       outFields: ['*'],
       visible: false,
-      listMode: 'hide'
+      listMode: 'hide',
+      // Entry Routes only ever show Vehicle routes here, so a single green directional arrow suffices.
+      renderer: {
+        type: 'unique-value',
+        field: 'Type',
+        uniqueValueInfos: [{ value: 'Vehicle', symbol: arrowLineSymbol(ROUTE_COLORS.vehicle) }]
+      }
     }
   },
   {
@@ -161,7 +218,18 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     native: {
       outFields: ['*'],
       visible: false,
-      listMode: 'hide'
+      listMode: 'hide',
+      // Exit Routes are shared by 12th Man/Personal Vehicle (Vehicle), Micromobility (Cyclist) and
+      // Pedestrian, so color the directional arrows by `Type` — each mode filters to one type.
+      renderer: {
+        type: 'unique-value',
+        field: 'Type',
+        uniqueValueInfos: [
+          { value: 'Vehicle', symbol: arrowLineSymbol(ROUTE_COLORS.vehicle) },
+          { value: 'Cyclist', symbol: arrowLineSymbol(ROUTE_COLORS.cyclist) },
+          { value: 'Pedestrian', symbol: arrowLineSymbol(ROUTE_COLORS.pedestrian) }
+        ]
+      }
     }
   },
 
@@ -226,6 +294,17 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     popupData: {
       name: 'attributes.Type',
       description: 'attributes.BR_Notes'
+    },
+    // Same pin-stretch bug as the Gameday Parking icons: the picture marker is a pin (natural 60x73,
+    // ~0.82 ratio) forced into a 30x30 square by the service renderer, so it stretches wide on the map
+    // and in the legend swatch. Re-render both at a matching ~0.82 ratio (25x30). `EsriMapService`
+    // applies these width/height hints to the on-map picture marker too (`applyLegendOverrideToLayerSymbols`).
+    legend: {
+      mode: 'renderer-symbol',
+      preserveAspectRatio: true,
+      fit: 'contain',
+      width: 25,
+      height: 30
     },
     native: {
       outFields: ['*'],
@@ -312,7 +391,17 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     native: {
       outFields: ['*'],
       visible: false,
-      listMode: 'hide'
+      listMode: 'hide',
+      // Directional arrows colored by pedicab trip phase, matching the service's Arrival/Departure scheme.
+      renderer: {
+        type: 'unique-value',
+        field: 'edited',
+        uniqueValueInfos: [
+          { value: 'Arrival', symbol: arrowLineSymbol('rgb(56, 168, 0)') },
+          { value: 'Departure', symbol: arrowLineSymbol('rgb(230, 152, 0)') },
+          { value: 'Arrival/Departure', symbol: arrowLineSymbol('rgb(0, 92, 230)') }
+        ]
+      }
     }
   },
   {
@@ -343,10 +432,35 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
       name: 'attributes.lotname',
       description: 'attributes.note'
     },
+    // Always show the full color key (Reserved/Permit/Charter/Paid/Lot Full) even though each mode
+    // filters the drawn lots to one type — the legend is a reference, not a mirror of what's drawn.
+    legend: { ignoreDefinitionExpression: true },
     native: {
       outFields: ['*'],
       visible: false,
       listMode: 'hide',
+      // Categorize lots so the map + legend show Reserved Parking / Any Valid Texas A&M Permit /
+      // Charter Bus / Paid Parking (and Lot Full when a lot is closed). Mirrors the Lots_view renderer.
+      renderer: {
+        type: 'unique-value',
+        field: 'type',
+        uniqueValueInfos: [
+          { value: 'Reserved Athletic', label: 'Reserved Parking', symbol: LOT_RESERVED_SYMBOL },
+          { value: 'Reserved', label: 'Reserved Parking', symbol: LOT_RESERVED_SYMBOL },
+          { value: 'RV', label: 'Reserved Parking', symbol: LOT_RESERVED_SYMBOL },
+          { value: 'SPresale', label: 'Reserved Parking', symbol: LOT_RESERVED_SYMBOL },
+          { value: 'AVP', label: 'Any Valid Texas A&M Permit', symbol: LOT_PERMIT_SYMBOL },
+          { value: 'Charter', label: 'Charter Bus', symbol: LOT_CHARTER_SYMBOL },
+          { value: 'ParkMobile', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public $20', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public $25', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public $30', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public $40', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Public $G', label: 'Paid Parking', symbol: LOT_PAID_SYMBOL },
+          { value: 'Lot Full', label: 'Lot Full', symbol: LOT_FULL_SYMBOL }
+        ]
+      },
       // Field names on the Lots_view polygon layer are lowercase and case-sensitive in SQL where-clauses.
       labelingInfo: [
         {
@@ -435,7 +549,59 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
       outFields: ['*'],
       visible: false,
       listMode: 'hide',
-      definitionExpression: "type = 'Charter'"
+      definitionExpression: "type = 'Charter'",
+      renderer: {
+        type: 'unique-value',
+        field: 'type',
+        uniqueValueInfos: [{ value: 'Charter', label: 'Charter Bus', symbol: LOT_CHARTER_SYMBOL }]
+      }
+    }
+  },
+  {
+    // Dedicated RV lots layer (same polygon service, scoped to RV). It has its own single-category
+    // renderer and is NOT flagged with `ignoreDefinitionExpression`, so the RV map's legend shows only
+    // "Reserved Parking" — unlike FP_PARKING_LOTS, which shows the full color key for 12th Man / Personal
+    // Vehicle. RV is wired to this layer instead of FP_PARKING_LOTS for that reason.
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_RV_PARKING,
+    title: 'Football Parking Lots',
+    url: `${footballLotsUrl}/${LOTS_POLYGON_LAYER_INDEX}`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.lotname',
+      description: 'attributes.note'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide',
+      definitionExpression: "type = 'RV'",
+      renderer: {
+        type: 'unique-value',
+        field: 'type',
+        uniqueValueInfos: [{ value: 'RV', label: 'Reserved Parking', symbol: LOT_RESERVED_SYMBOL }]
+      },
+      labelingInfo: [
+        {
+          labelExpression: '[name]',
+          labelPlacement: 'always-horizontal',
+          useCodedValues: true,
+          symbol: {
+            type: 'text',
+            color: [255, 255, 255, 255],
+            haloColor: [0, 0, 0, 255],
+            haloSize: 1,
+            font: {
+              family: 'Arial',
+              size: 10,
+              style: 'normal',
+              weight: 'bold'
+            }
+          },
+          minScale: 9500,
+          maxScale: 0
+        }
+      ]
     }
   },
   {
@@ -447,6 +613,18 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     popupData: {
       name: 'attributes.notes',
       description: 'attributes.notes_1'
+    },
+    // The gameday parking picture markers are pin-shaped (natural ~60x73, 0.82 ratio) but the service
+    // renderer forces most of them into a 30x30 square, which stretches them wide on the map AND in the
+    // legend swatch. Re-render both at a matching ~0.82 ratio (25x30). `EsriMapService` applies these
+    // width/height hints to the on-map picture markers too (`applyLegendOverrideToLayerSymbols`), so a
+    // single override de-stretches the icons and the legend swatches without re-embedding the images.
+    legend: {
+      mode: 'renderer-symbol',
+      preserveAspectRatio: true,
+      fit: 'contain',
+      width: 25,
+      height: 30
     },
     native: {
       outFields: ['*'],
@@ -619,12 +797,17 @@ export const FootballParkingOptions: SpecialEventOptions = [
         },
         // Parking lots (per-mode filter)
         {
+          // 12th Man + Personal Vehicle use the shared lots layer (full color key via ignoreDefinitionExpression);
+          // RV uses its own FP_RV_PARKING layer so its legend stays scoped to a single category.
           layerId: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
           conversions: [
             { input: TransportType.TWELFTH_MAN, expression: "type = 'Reserved Athletic'", propOverrides: SHOW },
-            { input: TransportType.RV, expression: "type = 'RV'", propOverrides: SHOW },
             { input: TransportType.PERSONAL_VEHICLE, propOverrides: SHOW }
           ]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_RV_PARKING,
+          conversions: [{ input: TransportType.RV, propOverrides: SHOW }]
         },
         {
           layerId: FOOTBALL_PARKING_LAYERS.FP_CHARTER_PARKING,

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -1,5 +1,4 @@
 import { LayerSource } from '@tamu-gisc/common/types';
-import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
 import {
@@ -8,120 +7,329 @@ import {
   SpecialEventOptions
 } from '../interfaces/special-event.interface';
 
+/**
+ * Football gameday transportation map.
+ *
+ * Data comes from two services:
+ *
+ * 1. `TSFootball_Cache` (all transportation layers except the parking lots / gameday parking icons).
+ * 2. `Hosted/Lots` (the parking-lot polygons + gameday parking point icons that Marcomm edits on game days).
+ *
+ * NOTE: `tsFootballCacheUrl` is pinned to the **dev** host until `TSFootball_Cache` is promoted to prod.
+ * TODO: revert `tsFootballCacheUrl` to the prod host (`gis.tamu.edu`) once the cache is published there.
+ */
+const tsFootballCacheUrl = 'https://gis.dev.tamu.edu/arcgis/rest/services/TS/TSFootball_Cache/MapServer';
+const footballLotsUrl = 'https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots/FeatureServer';
+
+/**
+ * The `Hosted/Lots` FeatureServer exposes exactly two sublayers. The service listing is token-gated so the
+ * 0 ↔ 1 assignment below is confirmed by rendering in-app.
+ * TODO: verify which sublayer is the polygon lots vs the point gameday-parking icons and swap if needed.
+ */
+const LOTS_POLYGON_LAYER_INDEX = 0;
+const GAMEDAY_PARKING_POINT_LAYER_INDEX = 1;
+
 export enum FOOTBALL_PARKING_LAYERS {
-  FP_POIS = 'football-pois',
-  FP_PARKING_LOTS = 'football-parking-lots',
+  FP_STRIPES = 'football-stripes',
+  FP_RNS_SPACES = 'football-rns-spaces',
+  FP_ENTRY_ROUTES = 'football-entry-routes',
+  FP_EXIT_ROUTES = 'football-exit-routes',
   FP_STREET_GRASS_AREAS = 'football-street-grass-areas',
-  TS_BIKE_DISMOUNT_ZONES = 'ts-bike-dismount-zones',
-  TS_BIKE_LANES = 'ts-bike-lanes',
-  TS_CITY_BIKE_LANES_ROUTES = 'ts-city-bike-lanes-routes',
-  TS_BIKE_RACKS = 'ts-bike-racks',
-  TS_SHUTTLE_STOPS_ON = 'ts-shuttle-stops-on',
-  TS_SHUTTLE_STOPS_OFF = 'ts-shuttle-stops-off',
-  TS_SHUTTLE_ROUTES_ON = 'ts-shuttle-routes-on',
-  TS_SHUTTLE_ROUTES_OFF = 'ts-shuttle-routes-off',
-  FP_GAMEDAY_SHUTTLE = 'football-gameday-shuttle'
+  FP_SHUTTLE_STOPS = 'football-shuttle-stops',
+  FP_SHUTTLE_ROUTES = 'football-shuttle-routes',
+  FP_MICROMOBILITY_PARKING = 'football-micromobility-parking',
+  FP_BIKE_DISMOUNT_ZONES = 'football-bike-dismount-zones',
+  FP_BIKE_VEO_GEOFENCE = 'football-bike-veo-geofence',
+  FP_BIKE_LANES = 'football-bike-lanes',
+  FP_PEDICAB_STOPS = 'football-pedicab-stops',
+  FP_PEDICAB_ROUTES = 'football-pedicab-routes',
+  FP_PEDICAB_CLOSURES = 'football-pedicab-closures',
+  FP_PARKING_LOTS = 'football-parking-lots',
+  FP_CHARTER_PARKING = 'football-charter-parking',
+  FP_GAMEDAY_PARKING = 'football-gameday-parking'
 }
 
-const { tsFootballUrl: eventUrl, bikeMapUrl: bikeLayersUrl, footballGamedayShuttlesUrl: shuttleLayersUrl } = Connections;
+/**
+ * The user-selectable transportation modes (the first builder step).
+ *
+ * `PEDICAB` is intentionally defined here (layers + effects are wired) but omitted from the builder choices
+ * below until it is approved to appear on AggieMap.
+ */
+enum TransportType {
+  TWELFTH_MAN = '12th-man',
+  SHUTTLE = 'shuttle',
+  RV = 'rv',
+  PERSONAL_VEHICLE = 'personal-vehicle',
+  MICROMOBILITY = 'micromobility',
+  PEDESTRIAN = 'pedestrian',
+  PEDICAB = 'pedicab'
+}
 
-const FootballParkingEventDefinitions = {
-  FP_POIS: {
-    id: FOOTBALL_PARKING_LAYERS.FP_POIS,
-    layerId: FOOTBALL_PARKING_LAYERS.FP_POIS,
-    name: 'Gameday Points of Interest',
-    url: `${eventUrl}/2`
-  },
-  FP_PARKING_LOTS: {
-    id: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
-    layerId: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
-    name: 'Football Parking Lots',
-    url: `${eventUrl}/5`
-  },
-  FP_STREET_GRASS_AREAS: {
-    id: FOOTBALL_PARKING_LAYERS.FP_STREET_GRASS_AREAS,
-    layerId: FOOTBALL_PARKING_LAYERS.FP_STREET_GRASS_AREAS,
-    name: 'Street/Grass Areas',
-    url: `${eventUrl}/6`
-  },
-  FP_GAMEDAY_SHUTTLE: {
-    id: FOOTBALL_PARKING_LAYERS.FP_GAMEDAY_SHUTTLE,
-    layerId: FOOTBALL_PARKING_LAYERS.FP_GAMEDAY_SHUTTLE,
-    name: 'Downtown Bryan Shuttle Stop',
-    url: `${eventUrl}/7`
-  },
-  TS_BIKE_RACKS: {
-    id: FOOTBALL_PARKING_LAYERS.TS_BIKE_RACKS,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_BIKE_RACKS,
-    name: 'Bike Racks',
-    url: `${bikeLayersUrl}/0`
-  },
-  TS_BIKE_LANES: {
-    id: FOOTBALL_PARKING_LAYERS.TS_BIKE_LANES,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_BIKE_LANES,
-    name: 'Bike Lanes',
-    url: `${bikeLayersUrl}/2`
-  },
-  TS_CITY_BIKE_LANES_ROUTES: {
-    id: FOOTBALL_PARKING_LAYERS.TS_CITY_BIKE_LANES_ROUTES,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_CITY_BIKE_LANES_ROUTES,
-    name: 'City Bike Lanes and Routes',
-    url: `${bikeLayersUrl}/3`
-  },
-  TS_BIKE_DISMOUNT_ZONES: {
-    id: FOOTBALL_PARKING_LAYERS.TS_BIKE_DISMOUNT_ZONES,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_BIKE_DISMOUNT_ZONES,
-    name: 'Bike Dismount Zones',
-    url: `${bikeLayersUrl}/5`
-  },
-  TS_SHUTTLE_STOPS_ON: {
-    id: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_ON,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_ON,
-    name: 'On-Campus Shuttle Stops',
-    url: `${shuttleLayersUrl}/0`
-  },
-  TS_SHUTTLE_STOPS_OFF: {
-    id: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_OFF,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_OFF,
-    name: 'Off-Campus Shuttle Stops',
-    url: `${shuttleLayersUrl}/0`
-  },
-  TS_SHUTTLE_ROUTES_ON: {
-    id: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_ON,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_ON,
-    name: 'On-Campus Shuttle Routes',
-    url: `${shuttleLayersUrl}/1`
-  },
-  TS_SHUTTLE_ROUTES_OFF: {
-    id: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_OFF,
-    layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_OFF,
-    name: 'Off-Campus Shuttle Routes',
-    url: `${shuttleLayersUrl}/1`
-  }
-};
+/**
+ * The Entry/Exit sub-choice (the second, conditional builder step). Only shown for the modes that have a
+ * meaningfully different arrival vs departure map.
+ */
+enum Direction {
+  ENTRY = 'entry',
+  EXIT = 'exit'
+}
+
+enum FootballBuilderOptions {
+  TRANSPORT_TYPE = 'transport-type',
+  DIRECTION = 'direction'
+}
+
+/**
+ * Shared prop overrides. `native.visible`/`native.listMode` are authoritative because the layer factory
+ * spreads `native` last (see EventService), so effects always drive visibility through `native`.
+ */
+const SHOW: Partial<LayerSource> = { native: { visible: true, listMode: 'show' } };
+const HIDE: Partial<LayerSource> = { native: { visible: false, listMode: 'hide' } };
 
 export const FootballParkingColdLayerSources: LayerSource[] = [
+  // --- RV striping + reserved spaces (RV mode) ---
   {
     type: 'feature',
-    id: FootballParkingEventDefinitions.FP_POIS.id,
-    title: FootballParkingEventDefinitions.FP_POIS.name,
-    url: FootballParkingEventDefinitions.FP_POIS.url,
+    id: FOOTBALL_PARKING_LAYERS.FP_STRIPES,
+    title: 'Stripes',
+    url: `${tsFootballCacheUrl}/0`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'attributes.Notes',
-      description: 'attributes.Notes_1'
+      name: 'attributes.Use_',
+      description: 'attributes.Location'
     },
     native: {
       outFields: ['*'],
       visible: false,
-      minScale: 0
+      listMode: 'hide'
     }
   },
   {
     type: 'feature',
-    id: FootballParkingEventDefinitions.FP_PARKING_LOTS.id,
-    title: FootballParkingEventDefinitions.FP_PARKING_LOTS.name,
-    url: FootballParkingEventDefinitions.FP_PARKING_LOTS.url,
+    id: FOOTBALL_PARKING_LAYERS.FP_RNS_SPACES,
+    title: 'RNS Spaces',
+    url: `${tsFootballCacheUrl}/1`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.RV_SpcNum',
+      description: 'attributes.Spc_Type'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Entry / Exit routes (12th Man, Personal Vehicle, Micromobility, Pedestrian) ---
+  // Base source has no query/visibility; `transport-type` sets the `Type` filter + turns it on, and the
+  // `direction` step appends the `Pre_Post` clause and hides the off-direction layer.
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_ENTRY_ROUTES,
+    title: 'Entry Routes',
+    url: `${tsFootballCacheUrl}/2`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Location',
+      description: 'attributes.Description'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_EXIT_ROUTES,
+    title: 'Exit Routes',
+    url: `${tsFootballCacheUrl}/3`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Location',
+      description: 'attributes.Description'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Street / grass areas (12th Man, RV, Personal Vehicle) ---
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_STREET_GRASS_AREAS,
+    title: 'Street/Grass Areas (Click for details)',
+    url: `${tsFootballCacheUrl}/4`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Name',
+      description: 'attributes.aNote'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Shuttle stops + routes (Shuttle) ---
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_SHUTTLE_STOPS,
+    title: 'Campus Shuttle Stops',
+    url: `${tsFootballCacheUrl}/5`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.StopName}',
+      description: 'For route: {attributes.RouteName}'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_SHUTTLE_ROUTES,
+    title: 'Shuttle Routes',
+    url: `${tsFootballCacheUrl}/6`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: '{attributes.RouteName} ({attributes.RouteNum})'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Micromobility (Bike) ---
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_MICROMOBILITY_PARKING,
+    title: 'Micromobility Parking Area',
+    url: `${tsFootballCacheUrl}/7`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Type',
+      description: 'attributes.BR_Notes'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_BIKE_DISMOUNT_ZONES,
+    title: 'Bike Dismount Zones',
+    url: `${tsFootballCacheUrl}/8`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Name',
+      description: 'attributes.Bike_Notes'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_BIKE_VEO_GEOFENCE,
+    title: 'Bike Veo Geofence',
+    url: `${tsFootballCacheUrl}/9`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Name',
+      description: 'attributes.Type'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_BIKE_LANES,
+    title: 'Bike Lanes',
+    url: `${tsFootballCacheUrl}/10`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Use_',
+      description: 'attributes.Location'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Pedicab (built but kept off the builder/AggieMap until approved) ---
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_STOPS,
+    title: 'Pedicab Drop Off/Pick Up',
+    url: `${tsFootballCacheUrl}/11`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.name',
+      description: 'attributes.description'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_ROUTES,
+    title: 'Pedicab Routes',
+    url: `${tsFootballCacheUrl}/12`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.name',
+      description: 'attributes.description'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_CLOSURES,
+    title: 'Pedicab Closures',
+    url: `${tsFootballCacheUrl}/13`,
+    popupComponent: MarkdownPopupComponent,
+    popupData: {
+      name: 'attributes.Event',
+      description: 'attributes.Notes'
+    },
+    native: {
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide'
+    }
+  },
+
+  // --- Parking lots + gameday parking icons (Hosted/Lots, token-gated, Marcomm-maintained) ---
+  {
+    type: 'feature',
+    id: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
+    title: 'Football Parking Lots',
+    url: `${footballLotsUrl}/${LOTS_POLYGON_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'attributes.LotName',
@@ -129,6 +337,9 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     },
     native: {
       outFields: ['*'],
+      visible: false,
+      listMode: 'hide',
+      // TODO: confirm the Hosted/Lots polygon schema exposes Name / TwelfthMan / Type; adjust if the fields differ.
       labelingInfo: [
         {
           // TwelfthMan lots (treat blank or single space as empty; anything else shows second line)
@@ -202,159 +413,35 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
     }
   },
   {
+    // Same polygon layer as FP_PARKING_LOTS, but scoped to charter lots and titled for the Shuttle map.
     type: 'feature',
-    id: FootballParkingEventDefinitions.FP_STREET_GRASS_AREAS.id,
-    title: FootballParkingEventDefinitions.FP_STREET_GRASS_AREAS.name,
-    url: FootballParkingEventDefinitions.FP_STREET_GRASS_AREAS.url,
+    id: FOOTBALL_PARKING_LAYERS.FP_CHARTER_PARKING,
+    title: 'Charter Bus Parking',
+    url: `${footballLotsUrl}/${LOTS_POLYGON_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
-      name: 'attributes.AreaName',
-      description: 'attributes.aNote'
+      name: 'attributes.LotName',
+      description: 'attributes.Note'
     },
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      visible: false,
+      listMode: 'hide',
+      definitionExpression: "Type = 'Charter'"
     }
   },
   {
     type: 'feature',
-    id: FootballParkingEventDefinitions.FP_GAMEDAY_SHUTTLE.id,
-    title: FootballParkingEventDefinitions.FP_GAMEDAY_SHUTTLE.name,
-    url: FootballParkingEventDefinitions.FP_GAMEDAY_SHUTTLE.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'attributes.RouteName',
-      description: 'attributes.Notes_1'
-    },
-    native: {
-      outFields: ['*']
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_BIKE_RACKS.id,
-    title: FootballParkingEventDefinitions.TS_BIKE_RACKS.name,
-    url: FootballParkingEventDefinitions.TS_BIKE_RACKS.url,
+    id: FOOTBALL_PARKING_LAYERS.FP_GAMEDAY_PARKING,
+    title: 'Gameday Parking',
+    url: `${footballLotsUrl}/${GAMEDAY_PARKING_POINT_LAYER_INDEX}`,
     popupComponent: MarkdownPopupComponent,
     popupData: {
       name: 'attributes.Type',
-      description: 'attributes.BR_Notes'
+      description: 'attributes.Notes'
     },
     native: {
       outFields: ['*'],
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_BIKE_LANES.id,
-    title: FootballParkingEventDefinitions.TS_BIKE_LANES.name,
-    url: FootballParkingEventDefinitions.TS_BIKE_LANES.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'attributes.RouteName',
-      description: 'attributes.Description'
-    },
-    native: {
-      outFields: ['*'],
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_CITY_BIKE_LANES_ROUTES.id,
-    title: FootballParkingEventDefinitions.TS_CITY_BIKE_LANES_ROUTES.name,
-    url: FootballParkingEventDefinitions.TS_CITY_BIKE_LANES_ROUTES.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'attributes.RouteName',
-      description: 'attributes.Description'
-    },
-    native: {
-      outFields: ['*'],
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_BIKE_DISMOUNT_ZONES.id,
-    title: FootballParkingEventDefinitions.TS_BIKE_DISMOUNT_ZONES.name,
-    url: FootballParkingEventDefinitions.TS_BIKE_DISMOUNT_ZONES.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: 'attributes.RouteName',
-      description: 'attributes.Description'
-    },
-    native: {
-      outFields: ['*'],
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_ON.id,
-    title: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_ON.name,
-    url: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_ON.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.RouteName} ({attributes.RouteNum})'
-    },
-    native: {
-      outFields: ['*'],
-      definitionExpression: "Campus = 'On'",
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_OFF.id,
-    title: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_OFF.name,
-    url: FootballParkingEventDefinitions.TS_SHUTTLE_ROUTES_OFF.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.RouteName} ({attributes.RouteNum})'
-    },
-    native: {
-      outFields: ['*'],
-      definitionExpression: "Campus = 'Off'",
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_ON.id,
-    title: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_ON.name,
-    url: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_ON.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.StopName}',
-      description: 'For route: {attributes.RouteName}'
-    },
-    native: {
-      outFields: ['*'],
-      definitionExpression: "Campus = 'On'",
-      visible: false,
-      listMode: 'hide'
-    }
-  },
-  {
-    type: 'feature',
-    id: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_OFF.id,
-    title: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_OFF.name,
-    url: FootballParkingEventDefinitions.TS_SHUTTLE_STOPS_OFF.url,
-    popupComponent: MarkdownPopupComponent,
-    popupData: {
-      name: '{attributes.StopName}',
-      description: 'For route: {attributes.RouteName}'
-    },
-    native: {
-      outFields: ['*'],
-      definitionExpression: "Campus = 'Off'",
       visible: false,
       listMode: 'hide'
     }
@@ -364,9 +451,10 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
 export const FootballParkingConfiguration: EventConfiguration = {
   id: 'gameday-parking',
   name: 'Football Map',
-  applicationName: 'Gameday Transportation Map',
-  shortApplicationName: 'Gameday Map',
+  applicationName: 'Football Transportation Map',
+  shortApplicationName: 'Football Map',
   introductionText: 'Get the best transportation and parking information for game days.',
+  // TODO: confirm the 2026 home schedule dates before release.
   eventDates: [
     '2025-08-30',
     '2025-09-06',
@@ -387,9 +475,9 @@ export const FootballParkingConfiguration: EventConfiguration = {
   },
   toast: {
     id: 'gameday-parking-notification',
-    title: 'Gameday Transportation Map Available',
+    title: 'Football Transportation Map Available',
     message:
-      'Attending the game? Click me to open the Gameday Transportation Map to get the best parking and transportation options for game day!',
+      'Attending the game? Click me to open the Football Transportation Map to get the best parking and transportation options for game day!',
     imgUrl: './assets/images/icons/sports/Football.png',
     imgAltText: 'Football Icon',
     acknowledge: true,
@@ -400,196 +488,190 @@ export const FootballParkingConfiguration: EventConfiguration = {
   }
 };
 
-enum TransportTypes {
-  SHUTTLE = 'shuttle',
-  RV = 'rv',
-  PERSONAL_VEHICLE = 'personal-vehicle',
-  RIDE_SHARE = 'ride-share',
-  BIKE = 'bike'
-}
-
 export const FootballParkingOptions: SpecialEventOptions = [
   {
-    value: 'transport-type',
+    value: FootballBuilderOptions.TRANSPORT_TYPE,
     label: 'Transportation Type',
     description:
       'To provide you with the most relevant and accurate transportation and parking information, please select your mode of transportation on game day. This will help us tailor the map and information to your needs.',
     shortDescription: 'Transportation Type',
     choices: [
       {
-        value: TransportTypes.SHUTTLE,
+        value: TransportType.TWELFTH_MAN,
+        label: '12th Man'
+      },
+      {
+        value: TransportType.SHUTTLE,
         label: 'Shuttle'
       },
       {
-        value: TransportTypes.RV,
+        value: TransportType.RV,
         label: 'RV'
       },
       {
-        value: TransportTypes.PERSONAL_VEHICLE,
+        value: TransportType.PERSONAL_VEHICLE,
         label: 'Personal Vehicle'
       },
       {
-        value: TransportTypes.BIKE,
-        label: 'Bike'
+        value: TransportType.MICROMOBILITY,
+        label: 'Micromobility'
+      },
+      {
+        value: TransportType.PEDESTRIAN,
+        label: 'Pedestrian'
+      }
+      // Pedicab is wired below but hidden from the builder until approved to appear on AggieMap.
+      // {
+      //   value: TransportType.PEDICAB,
+      //   label: 'Pedicab'
+      // }
+    ],
+    effects: {
+      layers: [
+        // RV
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_STRIPES,
+          conversions: [{ input: TransportType.RV, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_RNS_SPACES,
+          conversions: [{ input: TransportType.RV, propOverrides: SHOW }]
+        },
+        // Entry routes: shown (with a vehicle filter) for the vehicle-based modes; direction adds Pre_Post.
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_ENTRY_ROUTES,
+          conversions: [
+            { input: TransportType.TWELFTH_MAN, expression: "Type = 'Vehicle'", propOverrides: SHOW },
+            { input: TransportType.PERSONAL_VEHICLE, expression: "Type = 'Vehicle'", propOverrides: SHOW }
+          ]
+        },
+        // Exit routes: filtered per mode; Pedestrian is fully self-contained (no direction step).
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_EXIT_ROUTES,
+          conversions: [
+            { input: TransportType.TWELFTH_MAN, expression: "Type = 'Vehicle'", propOverrides: SHOW },
+            { input: TransportType.PERSONAL_VEHICLE, expression: "Type = 'Vehicle'", propOverrides: SHOW },
+            { input: TransportType.MICROMOBILITY, expression: "Type = 'Cyclist'", propOverrides: SHOW },
+            {
+              input: TransportType.PEDESTRIAN,
+              expression: "Type = 'Pedestrian' AND Pre_Post = 'Post-Game'",
+              propOverrides: SHOW
+            }
+          ]
+        },
+        // Street / grass areas
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_STREET_GRASS_AREAS,
+          conversions: [
+            { input: TransportType.TWELFTH_MAN, propOverrides: SHOW },
+            { input: TransportType.RV, propOverrides: SHOW },
+            { input: TransportType.PERSONAL_VEHICLE, propOverrides: SHOW }
+          ]
+        },
+        // Shuttle
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_SHUTTLE_STOPS,
+          conversions: [{ input: TransportType.SHUTTLE, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_SHUTTLE_ROUTES,
+          conversions: [{ input: TransportType.SHUTTLE, propOverrides: SHOW }]
+        },
+        // Micromobility
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_MICROMOBILITY_PARKING,
+          conversions: [{ input: TransportType.MICROMOBILITY, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_BIKE_DISMOUNT_ZONES,
+          conversions: [{ input: TransportType.MICROMOBILITY, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_BIKE_VEO_GEOFENCE,
+          conversions: [{ input: TransportType.MICROMOBILITY, propOverrides: SHOW }]
+        },
+        {
+          // Bike lanes only appear on the micromobility ENTRY map; the direction step hides them on exit.
+          layerId: FOOTBALL_PARKING_LAYERS.FP_BIKE_LANES,
+          conversions: [{ input: TransportType.MICROMOBILITY, propOverrides: SHOW }]
+        },
+        // Pedicab (hidden mode)
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_STOPS,
+          conversions: [{ input: TransportType.PEDICAB, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_ROUTES,
+          conversions: [{ input: TransportType.PEDICAB, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_PEDICAB_CLOSURES,
+          conversions: [{ input: TransportType.PEDICAB, propOverrides: SHOW }]
+        },
+        // Parking lots (per-mode filter)
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
+          conversions: [
+            { input: TransportType.TWELFTH_MAN, expression: "Type = 'Reserved Athletic'", propOverrides: SHOW },
+            { input: TransportType.RV, expression: "Type = 'RV'", propOverrides: SHOW },
+            { input: TransportType.PERSONAL_VEHICLE, propOverrides: SHOW }
+          ]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_CHARTER_PARKING,
+          conversions: [{ input: TransportType.SHUTTLE, propOverrides: SHOW }]
+        },
+        {
+          layerId: FOOTBALL_PARKING_LAYERS.FP_GAMEDAY_PARKING,
+          conversions: [{ input: TransportType.PERSONAL_VEHICLE, propOverrides: SHOW }]
+        }
+      ]
+    }
+  },
+  {
+    value: FootballBuilderOptions.DIRECTION,
+    label: 'Direction',
+    description:
+      'Are you arriving at the game (Entry) or leaving afterward (Exit)? Choose one to see the routes tailored to your trip.',
+    shortDescription: 'Direction',
+    uiType: 'binary',
+    // Only the modes with a meaningfully different arrival vs departure map ask for a direction.
+    visibleWhen: {
+      setting: FootballBuilderOptions.TRANSPORT_TYPE,
+      equalsAnyOf: [TransportType.TWELFTH_MAN, TransportType.PERSONAL_VEHICLE, TransportType.MICROMOBILITY]
+    },
+    choices: [
+      {
+        value: Direction.ENTRY,
+        label: 'Entry'
+      },
+      {
+        value: Direction.EXIT,
+        label: 'Exit'
       }
     ],
     effects: {
       layers: [
         {
-          layerId: FOOTBALL_PARKING_LAYERS.FP_POIS,
+          // Entry map: keep Entry Routes (adding the pre-game clause), hide Exit Routes.
+          layerId: FOOTBALL_PARKING_LAYERS.FP_ENTRY_ROUTES,
           conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              expression: "Notes IN ('Loading Zone', 'Road Closed')"
-            },
-            {
-              input: TransportTypes.RV,
-              expression: "Notes NOT IN ('Cashier', 'Disabled', 'GPresale')"
-            },
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                visible: false,
-                listMode: 'hide'
-              }
-            }
+            { input: Direction.ENTRY, expression: "Pre_Post = 'Pre-Game'" },
+            { input: Direction.EXIT, propOverrides: HIDE }
           ]
         },
         {
-          layerId: FOOTBALL_PARKING_LAYERS.FP_PARKING_LOTS,
+          // Exit map: keep Exit Routes (adding the post-game clause), hide Entry Routes.
+          layerId: FOOTBALL_PARKING_LAYERS.FP_EXIT_ROUTES,
           conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              expression: "Type = 'Charter'"
-            },
-            {
-              input: TransportTypes.RV,
-              expression: "Type = 'RV'"
-            },
-            {
-              input: TransportTypes.PERSONAL_VEHICLE,
-              expression: "Type NOT IN ('RV', 'Charter')"
-            },
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                visible: false,
-                listMode: 'hide'
-              }
-            }
+            { input: Direction.EXIT, expression: "Pre_Post = 'Post-Game'" },
+            { input: Direction.ENTRY, propOverrides: HIDE }
           ]
         },
         {
-          layerId: FOOTBALL_PARKING_LAYERS.FP_STREET_GRASS_AREAS,
-          conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              propOverrides: {
-                visible: false
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.FP_GAMEDAY_SHUTTLE,
-          conversions: [
-            {
-              input: TransportTypes.RV,
-              propOverrides: {
-                visible: false
-              }
-            },
-            {
-              input: TransportTypes.PERSONAL_VEHICLE,
-              propOverrides: {
-                visible: false
-              }
-            },
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                visible: false,
-                listMode: 'hide'
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_BIKE_LANES,
-          conversions: [
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_CITY_BIKE_LANES_ROUTES,
-          conversions: [
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_BIKE_DISMOUNT_ZONES,
-          conversions: [
-            {
-              input: TransportTypes.BIKE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_ON,
-          conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_ROUTES_OFF,
-          conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_ON,
-          conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
-        },
-        {
-          layerId: FOOTBALL_PARKING_LAYERS.TS_SHUTTLE_STOPS_OFF,
-          conversions: [
-            {
-              input: TransportTypes.SHUTTLE,
-              propOverrides: {
-                native: { visible: true, listMode: 'show' }
-              }
-            }
-          ]
+          // Bike lanes are entry-only; hide them on the micromobility exit map.
+          layerId: FOOTBALL_PARKING_LAYERS.FP_BIKE_LANES,
+          conversions: [{ input: Direction.EXIT, propOverrides: HIDE }]
         }
       ]
     }
@@ -609,6 +691,17 @@ export const FootballParkingEvent: AggiemapCustomMapConfiguration = {
     source: 'internal',
     type: 'event',
     mapType: 'athletics',
-    keywords: ['football', 'gameday', 'parking', 'shuttles', 'transportation', 'bike']
+    keywords: [
+      'football',
+      'gameday',
+      'parking',
+      'shuttles',
+      'transportation',
+      'bike',
+      'micromobility',
+      'pedestrian',
+      '12th man',
+      'rv'
+    ]
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -13,10 +13,15 @@ import {
  * Data comes from two services:
  *
  * 1. `TSFootball_Cache` (all transportation layers except the parking lots / gameday parking icons).
- * 2. `Hosted/Lots` (the parking-lot polygons + gameday parking point icons that Marcomm edits on game days).
+ * 2. `Hosted/Lots_view` (the parking-lot polygons + gameday parking point icons that Marcomm edits on game days).
  *
- * NOTE: `tsFootballCacheUrl` is pinned to the **dev** host until `TSFootball_Cache` is promoted to prod.
- * TODO: revert `tsFootballCacheUrl` to the prod host (`gis.tamu.edu`) once the cache is published there.
+ * NOTE on the transportation source: the spec calls for `Hosted/Football_view/FeatureServer`, but that
+ * service returns "Token Required" for anonymous users (prod AND dev), which would pop an ArcGIS sign-in
+ * on AggieMap — the same problem that forced the public `Lots_view`. Until a PUBLIC view of the football
+ * transportation layers exists, the only anonymously-readable source is the dev `TSFootball_Cache`
+ * MapServer, whose 14 sublayers (0–13) match the spec's layer names exactly.
+ * TODO: point `tsFootballCacheUrl` at the public `Football_view` (or a prod cache) once one is shared
+ * publicly — and re-verify sublayer indices + field casing against it, as they may differ from the cache.
  */
 const tsFootballCacheUrl = 'https://gis.dev.tamu.edu/arcgis/rest/services/TS/TSFootball_Cache/MapServer';
 const footballLotsUrl = 'https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots_view/FeatureServer';
@@ -457,16 +462,17 @@ export const FootballParkingConfiguration: EventConfiguration = {
   applicationName: 'Football Transportation Map',
   shortApplicationName: 'Football Map',
   introductionText: 'Get the best transportation and parking information for game days.',
-  // TODO: confirm the 2026 home schedule dates before release.
+  // 2026 home schedule (7 home dates at Kyle Field), per the SEC-released schedule:
+  // 9/5 Missouri State, 9/12 Arizona State, 9/19 Kentucky, 10/3 Arkansas, 10/17 The Citadel,
+  // 11/14 Tennessee, 11/27 Texas (Black Friday). https://12thman.com/news/2025/12/11/2026-texas-am-football-schedule-announced
   eventDates: [
-    '2025-08-30',
-    '2025-09-06',
-    '2025-09-27',
-    '2025-10-04',
-    '2025-10-11',
-    '2025-11-15',
-    '2025-11-22',
-    '2025-12-20'
+    '2026-09-05',
+    '2026-09-12',
+    '2026-09-19',
+    '2026-10-03',
+    '2026-10-17',
+    '2026-11-14',
+    '2026-11-27'
   ],
   scheduleUrl: 'https://12thman.com/sports/football/schedule',
   mapCenter: [-96.34344, 30.61011],

--- a/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
+++ b/libs/ts/events/ngx/src/lib/interfaces/special-event.interface.ts
@@ -233,6 +233,32 @@ export interface SpecialEventOption {
    */
   uiType?: 'default' | 'date-card-grid' | 'grouped-card-grid' | 'binary';
 
+  /**
+   * Optional visibility condition. When present, this option is only shown as a builder step (and only
+   * treated as required) when another option's saved value is one of `equalsAnyOf`.
+   *
+   * This enables conditional/branching builder flows without affecting events that omit it. For example,
+   * an Entry/Exit `direction` step can be shown only for the transportation modes that have both directions:
+   *
+   * ```
+   * visibleWhen: { setting: 'transport-type', equalsAnyOf: ['12th-man', 'personal-vehicle', 'micromobility'] }
+   * ```
+   *
+   * The referenced `setting` should generally appear earlier in the options array so its value is already
+   * chosen by the time this option would be shown.
+   */
+  visibleWhen?: {
+    /**
+     * The `value` (key) of another {@link SpecialEventOption} whose saved selection gates this option.
+     */
+    setting: string;
+
+    /**
+     * This option is only visible/required when the gating setting's saved value is one of these.
+     */
+    equalsAnyOf: Array<string | number | boolean>;
+  };
+
   choices: Array<EventAccommodationOption>;
 
   effects: {

--- a/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/builder/modules/accommodations/accommodations.component.ts
@@ -22,7 +22,6 @@ export class AccommodationsComponent implements OnInit {
   public savedOptionValue: Observable<string | boolean | number | null>;
 
   public accommodation$: Observable<SpecialEventOption>;
-  public nextAccommodation$: Observable<SpecialEventOption | null>;
 
   private _eventOptions$: BehaviorSubject<SpecialEventOptions>;
   private _accommodationIndex$: Observable<number>;
@@ -51,7 +50,12 @@ export class AccommodationsComponent implements OnInit {
         if (params['accommodation']) {
           return of(params['accommodation']);
         } else {
-          const firstAccommodation = Object.values(options)[0];
+          // Land on the first option that is actually visible for the current settings so conditional
+          // flows never open on a step that should be skipped.
+          const settings = this.eventSettingsService.settings();
+          const firstAccommodation =
+            Object.values(options).find((option) => this.eventSettingsService.isOptionVisible(option, settings)) ??
+            Object.values(options)[0];
 
           return this.router.navigate([firstAccommodation.value], {
             relativeTo: this.route,
@@ -73,17 +77,6 @@ export class AccommodationsComponent implements OnInit {
     this.accommodation$ = combineLatest([this._eventOptions$, this._accommodationIndex$]).pipe(
       map(([options, index]) => {
         return options[index];
-      }),
-      shareReplay(1)
-    );
-
-    this.nextAccommodation$ = combineLatest([this._eventOptions$, this._accommodationIndex$]).pipe(
-      map(([options, index]) => {
-        if (index < options.length - 1) {
-          return options[index + 1];
-        } else {
-          return null;
-        }
       }),
       shareReplay(1)
     );
@@ -116,18 +109,25 @@ export class AccommodationsComponent implements OnInit {
       if (hasRet) {
         return this.router.navigate(['review'], { relativeTo: this.route.parent?.parent });
       } else {
-        if (this.nextAccommodation$) {
-          return this.nextAccommodation$.pipe(take(1)).subscribe((res) => {
-            if (res === null || res === undefined) {
-              return this.router.navigate(['review'], { relativeTo: this.route.parent?.parent });
-            }
+        // Determine the next step after the option just saved. Settings are read fresh (post-save) so a
+        // gating selection is reflected when deciding which conditional steps remain visible.
+        return this._accommodationIndex$.pipe(take(1)).subscribe((index) => {
+          const options = this._eventOptions$.value;
+          const settings = this.eventSettingsService.settings();
 
-            // Navigate to the next accommodation in the builder flow
-            return this.router.navigate(['accommodations', res?.value], { relativeTo: this.route.parent?.parent });
+          const nextAccommodation = options
+            .slice(index + 1)
+            .find((option) => this.eventSettingsService.isOptionVisible(option, settings));
+
+          if (!nextAccommodation) {
+            return this.router.navigate(['review'], { relativeTo: this.route.parent?.parent });
+          }
+
+          // Navigate to the next visible accommodation in the builder flow
+          return this.router.navigate(['accommodations', nextAccommodation.value], {
+            relativeTo: this.route.parent?.parent
           });
-        } else {
-          return this.router.navigate(['review'], { relativeTo: this.route.parent?.parent });
-        }
+        });
       }
     } else {
       throw new Error('Error saving accommodation selection.');

--- a/libs/ts/events/ngx/src/lib/services/event/event.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/event/event.service.ts
@@ -37,6 +37,13 @@ export class EventService {
   public settings: EventSettings;
   public eventOptions: SpecialEventOptions;
 
+  /**
+   * The subset of `eventOptions` that are visible for the current settings. Conditionally-hidden options
+   * (see `SpecialEventOption.visibleWhen`) must not contribute layer effects, otherwise a stale selection
+   * for a step that no longer applies to the chosen mode would leak into the rendered map.
+   */
+  public visibleOptions: SpecialEventOptions;
+
   public specialEventLayerReferences: Array<string>;
 
   private _map: esri.Map;
@@ -60,6 +67,7 @@ export class EventService {
 
     this.eventOptions = this.eventSettingsService.eventOptions();
     this.settings = this.eventSettingsService.settings() || {};
+    this.visibleOptions = this.eventSettingsService.getVisibleOptions(this.settings);
     this.specialEventLayerReferences = Object.entries(this.eventSettingsService.eventLayerReferences())
       .map(([, value]) => value)
       .reverse();
@@ -81,7 +89,7 @@ export class EventService {
         .map((ref) => this.getLayerSourceCopy(ref))
         .map((source) => {
           // Determine the list of options that list the current source as an effect target
-          const specialEventOptionsTargetingSource = this.eventOptions.filter((o) => {
+          const specialEventOptionsTargetingSource = this.visibleOptions.filter((o) => {
             return o.effects.layers?.some((layer) => layer.layerId === source.id);
           });
 
@@ -197,7 +205,7 @@ export class EventService {
       // Handle nested groups before applying effects to the immediate child.
       this.applyEffectsToGroupChildren(child);
 
-      const optionsTargetingChild = this.eventOptions.filter((o) =>
+      const optionsTargetingChild = this.visibleOptions.filter((o) =>
         o.effects.layers?.some((layer) => layer.layerId === child.id)
       );
 
@@ -273,7 +281,7 @@ export class EventService {
       return;
     }
 
-    for (const option of this.eventOptions) {
+    for (const option of this.visibleOptions) {
       const settingValue = this.settings[option.value];
 
       if (settingValue === undefined) {

--- a/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
@@ -11,6 +11,7 @@ import {
   AggiemapCustomMapConfiguration,
   EventSettings,
   ResolvedEventSettings,
+  SpecialEventOption,
   SpecialEventOptions
 } from '../../interfaces/special-event.interface';
 import { EventDefinitions } from '../../definitions/all.definitions';
@@ -161,6 +162,30 @@ export class EventSettingsService {
     }
   }
 
+  /**
+   * Determines whether an option should be shown as a builder step (and treated as required) given the
+   * current settings. Options without a `visibleWhen` condition are always visible. Options with one are
+   * only visible when the gating setting's saved value is one of the configured `equalsAnyOf` values.
+   */
+  public isOptionVisible(option: SpecialEventOption, settings: EventSettings | null | undefined): boolean {
+    if (!option.visibleWhen) {
+      return true;
+    }
+
+    const gatingValue = settings?.[option.visibleWhen.setting];
+
+    return option.visibleWhen.equalsAnyOf.some((candidate) => candidate === gatingValue);
+  }
+
+  /**
+   * Returns the event options that are currently visible given the provided settings (defaults to the
+   * settings in storage). Used to drive conditional builder flows so hidden steps are neither shown,
+   * required, nor summarized.
+   */
+  public getVisibleOptions(settings: EventSettings | null | undefined = this.settings()): SpecialEventOptions {
+    return this.eventOptions().filter((option) => this.isOptionVisible(option, settings));
+  }
+
   public saveAccommodation(accommodationKey: string, accommodationValue: string | boolean | number) {
     const existing = this.store.getStorageObjectKeyValue<EventSettings>({
       primaryKey: this._settingsPrimaryKey,
@@ -190,7 +215,9 @@ export class EventSettingsService {
     let changed = false;
 
     const merged = options.reduce((acc, option) => {
-      if (acc[option.value] === undefined && option.choices.length > 0) {
+      // Evaluate visibility against the accumulating settings so a gating option (listed earlier) can
+      // determine whether a dependent, conditionally-visible option should receive a default value.
+      if (this.isOptionVisible(option, acc) && acc[option.value] === undefined && option.choices.length > 0) {
         acc[option.value] = option.choices[0].value;
         changed = true;
       }
@@ -248,8 +275,10 @@ export class EventSettingsService {
    * This is used for UI representation of the settings.
    */
   public getMergedSettings() {
-    const options = this.eventOptions();
     const settings = this.settings();
+    // Only summarize options that are currently visible so conditionally-hidden steps (e.g. an
+    // Entry/Exit direction that doesn't apply to the selected mode) don't render as blank rows.
+    const options = this.getVisibleOptions(settings);
 
     return options.reduce((merged, option) => {
       if (settings && settings[option.value] !== undefined) {
@@ -296,8 +325,9 @@ export class EventSettingsService {
   }
 
   public accommodationsValid() {
-    const options = this.eventOptions();
     const settings = this.settings();
+    // A conditionally-hidden option is not required, so validity is measured against visible options only.
+    const options = this.getVisibleOptions(settings);
 
     return options.every((opt) => {
       return settings?.[opt.value] !== undefined;


### PR DESCRIPTION
**Issue 1: Rename GameDay to Football on the builder**

<img width="1706" height="604" alt="image" src="https://github.com/user-attachments/assets/a9e16c2c-2869-4513-96c7-baf85683358c" />


**Issue 2: Rename/add sections to builder from 4 to 7 cards
Sections need to be: 12th Man, Shuttle, RV, Personal Vehicle, Micromobility (rename for Bike), Pedestrian, Pedicabs (Not 100% on this one, waiting to hear so keep it hidden for now if possible)**

<img width="1769" height="1830" alt="image" src="https://github.com/user-attachments/assets/d96f3634-56bd-4311-a804-045de045ebb7" />

Pedicabs map is ready to go, just hidden until further notice.

**Issue 3: Add sections in the builder for those that need 2
Sections that need Entry/Exit in builder**

12th man
Personal vehicle
Micromobility

<img width="1799" height="1033" alt="image" src="https://github.com/user-attachments/assets/8dac4c7f-e0c9-4a56-828d-0bac125bcc49" />


**Issue 4: Connect new layers for the map**
All layers except Gameday Parking & Parking Lots are located here: https://gis.tamu.edu/arcgis/rest/services/Hosted/Football_view/FeatureServer

Gameday Parking & Parking lots are located here: https://gis.tamu.edu/arcgis/rest/services/Hosted/Lots_view/FeatureServer

Done.

**Issue 5: Map setup**
12th man

**12th man entry map layers:**

Entry Routes (using Query: Type = Vehicle and Pre_Post = Pre-Game)
Street/Grass Areas (Click for details)
Football Parking Lots (using Query: Type = Reserved Athletic) - from other rest service
12th man entry map:

<img width="3523" height="1910" alt="image" src="https://github.com/user-attachments/assets/993190f9-e1cb-4bbd-9693-f148105a254c" />


**12th man exit map layers:**
Exit Routes (using Query: Type = Vehicle and Pre_Post = Post-Game)
Street/Grass Areas (Click for details)
Football Parking Lots (using Query: Type = Reserved Athletic) - from other rest service
12th man exit map:

<img width="3777" height="2041" alt="image" src="https://github.com/user-attachments/assets/ba08e904-2737-4310-acba-56f70e852957" />

**Shuttle Map**

Shuttle map layers:

Football Parking Lots (using Query: Type = Charter) and name Charter Bus Parking
Campus Shuttle Stops
Shuttle Routes
Shuttle map:

<img width="3216" height="2032" alt="image" src="https://github.com/user-attachments/assets/30e244ca-6f6b-4554-9dd5-6654caa68174" />

Charter Bus layer is off by default.


**RV**

RV map layers;

Stripes
RNS Spaces
Street/Grass Areas (Click for details)
Football Parking Lots (using Query: Type = RV)
RV map:

<img width="3193" height="2000" alt="image" src="https://github.com/user-attachments/assets/4203421a-0e71-4ada-8038-eaef684c0fb4" />


RV map zoomed in on a specific parking lot to show numbers/lines:

<img width="2851" height="2013" alt="image" src="https://github.com/user-attachments/assets/aac75788-74f0-4b7e-aa84-9f1987d3d1f7" />


**Personal Vehicle**

Personal Vehicle entry map layers:

Gameday Parking
Entry Routes
Street/Grass Areas (Click for details)
Football Parking Lots
Personal vehicle entry map (zoomed in to show detail):

<img width="3550" height="2003" alt="image" src="https://github.com/user-attachments/assets/e486ebde-dc6f-46fb-b3cc-2eac886c3d48" />


**Personal Vehicle Exit map layers:**

Gameday Parking
Exit Routes
Street/Grass Areas (click for details)
Football Parking Lots
Personal vehicle exit map (zoomed in to show detail):

<img width="3306" height="1969" alt="image" src="https://github.com/user-attachments/assets/6f398975-33e6-435a-b1bb-9823c9665f9c" />

**Micromobility maps**

Micromobility entry map layers:

Micromobility parking area
Bike Dismount Zones
Bike Veo Geofence
Bike Lanes
Micromobility entry map:

<img width="3417" height="1989" alt="image" src="https://github.com/user-attachments/assets/2f8444a0-710b-48ff-a518-4f9e19e11e74" />
Micromobility exit map layers:

**Micromobility parking area**
Exit routes (using Query: Type = Cyclist)
Bike Dismount Zones
Bike Veo Geofence
Micromobility exit map (zoomed in to show detail):

<img width="3099" height="2017" alt="image" src="https://github.com/user-attachments/assets/88359d91-a8bd-448d-8116-efc622788f9d" />
Pedestrian Exit Map

Layers:
Exit Routes (using Query: Type = Pedestrian and Pre_Post = Post-Game)

**Pedestrian exit map:**

<img width="2858" height="1888" alt="image" src="https://github.com/user-attachments/assets/d8807b0e-2fee-497a-995e-6cce0e54348b" />

Closes #861 