### PR TITLE
fix(aggiemap-angular): Show full RNS space numbers on Campus Main Parking Map

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/definitions/main.definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions/main.definitions.ts
@@ -15,6 +15,7 @@ export enum MAIN_MAP_LAYERS {
   SURFACE_LOTS = 'surface-lots-layer',
   VISITOR_PARKING = 'visitor-parking-layer',
   TRANSPORTATION_PARKING = 'transportation-parking-layer',
+  RNS_SPACES = 'rns-spaces-layer',
   ACESSIBLE_ENTRANCES = 'accessible-entrances-layer',
   EMERGENCY_PHONES = 'emergency-phones-layer',
   BIKE_RACKS = 'bike-racks-layer',
@@ -47,6 +48,7 @@ export interface IComposedIDefinitions {
   SURFACE_LOTS: IDefinition;
   VISITOR_PARKING: IDefinition;
   TRANSPORTATION_PARKING: IDefinition;
+  RNS_SPACES: IDefinition;
   ACESSIBLE_ENTRANCES: IDefinition;
   EMERGENCY_PHONES: IDefinition;
   BIKE_RACKS: IDefinition;
@@ -127,6 +129,12 @@ export function MainMapDefinitions(connections: IComposedConnections): IComposed
       name: 'Transportation Parking',
       url: `${connections.tsMainUrl}/6`,
       popupComponent: Popups.ParkingKioskPopupComponent
+    },
+    RNS_SPACES: {
+      id: 'rns-spaces',
+      layerId: MAIN_MAP_LAYERS.RNS_SPACES,
+      name: 'RNS Spaces',
+      url: `${connections.tsMainUrl}/7`
     },
     ACESSIBLE_ENTRANCES: {
       id: 'accessible-entrances',
@@ -355,6 +363,91 @@ export function MainMapLayerSources(
       visible: false,
       native: {
         ...commonLayerProps
+      }
+    },
+    {
+      // Reserved Numbered Space (RNS) labels. Points are invisible; only the number
+      // labels render, so each reserved/numbered space shows its number when zoomed in.
+      type: 'feature',
+      id: definitions.RNS_SPACES.layerId,
+      title: definitions.RNS_SPACES.name,
+      url: definitions.RNS_SPACES.url,
+      listMode: 'hide',
+      visible: true,
+      layerIndex: 3,
+      native: {
+        ...commonLayerProps,
+        legendEnabled: false,
+        renderer: {
+          type: 'simple',
+          symbol: {
+            type: 'simple-marker',
+            style: 'circle',
+            size: 0,
+            color: [0, 0, 0, 0],
+            outline: { width: 0, color: [0, 0, 0, 0] }
+          }
+        },
+        labelsVisible: true,
+        labelingInfo: [
+          {
+            // Department-reserved spaces: "DEPT. RESERVED" + the space number.
+            where: `Anno_Type IS NULL OR Anno_Type NOT IN ('Serv', 'M/C', 'H/C', '2HR Timed', 'Loading')`,
+            labelExpressionInfo: {
+              expression: `
+                if ($feature.DeptSpc_YN != 1) { return ''; }
+                var num = Trim(Text($feature.RNS_Num));
+                if (num == null || num == '' || num == 'null') { num = Trim(Text($feature.Spc_ID_Num)); }
+                if (num == null || num == '' || num == 'null') { return 'DEPT. RESERVED'; }
+                return 'DEPT. RESERVED' + TextFormatting.NewLine + num;
+              `
+            },
+            labelPlacement: 'center-center',
+            symbol: {
+              type: 'text',
+              color: [80, 0, 0, 255],
+              haloColor: [255, 255, 255, 235],
+              haloSize: 1,
+              font: { size: 8, family: 'Arial', weight: 'bold' }
+            },
+            minScale: 1200,
+            maxScale: 0,
+            deconflictionStrategy: 'none'
+          },
+          {
+            // All other reserved/numbered spaces: show whichever space-number field is
+            // populated. RNS_Num is authoritative (the only populated field for reserved
+            // spaces in many lots, e.g. Lot 96 '9608'); VisSpcNum/RV_SpcNum/Spc_ID_Num
+            // are fallbacks for visitor/RV/other numbered spaces.
+            where: `Anno_Type IS NULL OR Anno_Type NOT IN ('Serv', 'M/C', '2HR Timed', 'Loading')`,
+            labelExpressionInfo: {
+              expression: `
+                if ($feature.Anno_Type == 'H/C') { return ''; }
+                if ($feature.DeptSpc_YN == 1) { return ''; }
+                var rnsNum = Trim(Text($feature.RNS_Num));
+                if (rnsNum != null && rnsNum != '' && rnsNum != 'null') { return rnsNum; }
+                var visNum = Trim(Text($feature.VisSpcNum));
+                if (visNum != null && visNum != '' && visNum != 'null') { return visNum; }
+                var rvNum = Trim(Text($feature.RV_SpcNum));
+                if (rvNum != null && rvNum != '' && rvNum != 'null') { return rvNum; }
+                var spcId = Trim(Text($feature.Spc_ID_Num));
+                if (spcId != null && spcId != '' && spcId != 'null') { return spcId; }
+                return '';
+              `
+            },
+            labelPlacement: 'center-center',
+            symbol: {
+              type: 'text',
+              color: [50, 50, 50, 255],
+              haloColor: [255, 255, 255, 235],
+              haloSize: 1,
+              font: { size: 9, family: 'Arial', weight: 'normal' }
+            },
+            minScale: 1200,
+            maxScale: 0,
+            deconflictionStrategy: 'none'
+          }
+        ]
       }
     },
     {

--- a/libs/aggiemap/ngx/common/src/lib/definitions/main.definitions.ts
+++ b/libs/aggiemap/ngx/common/src/lib/definitions/main.definitions.ts
@@ -406,8 +406,8 @@ export function MainMapLayerSources(
             symbol: {
               type: 'text',
               color: [80, 0, 0, 255],
-              haloColor: [255, 255, 255, 235],
-              haloSize: 1,
+              haloColor: [255, 255, 255, 255],
+              haloSize: 1.5,
               font: { size: 8, family: 'Arial', weight: 'bold' }
             },
             minScale: 1200,
@@ -438,9 +438,9 @@ export function MainMapLayerSources(
             labelPlacement: 'center-center',
             symbol: {
               type: 'text',
-              color: [50, 50, 50, 255],
-              haloColor: [255, 255, 255, 235],
-              haloSize: 1,
+              color: [30, 30, 30, 255],
+              haloColor: [255, 255, 255, 255],
+              haloSize: 1.5,
               font: { size: 9, family: 'Arial', weight: 'normal' }
             },
             minScale: 1200,

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -462,7 +462,10 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
           labelExpressionInfo: {
             expression: `
               if ($feature.DeptSpc_YN != 1) { return ''; }
-              var num = Trim(Text($feature.Spc_ID_Num));
+              // RNS_Num is the authoritative reserved-space number (e.g. '9640'); Spc_ID_Num
+              // is only a fallback since it is empty in many lots.
+              var num = Trim(Text($feature.RNS_Num));
+              if (num == null || num == '' || num == 'null') { num = Trim(Text($feature.Spc_ID_Num)); }
               if (num == null || num == '' || num == 'null') { return 'DEPT. RESERVED'; }
               return 'DEPT. RESERVED' + TextFormatting.NewLine + num;
             `
@@ -487,10 +490,18 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             expression: `
               if ($feature.Anno_Type == 'H/C') { return ''; }
               if ($feature.DeptSpc_YN == 1) { return ''; }
-              var spcId = Trim(Text($feature.Spc_ID_Num));
-              if (spcId != null && spcId != '' && spcId != 'null') { return spcId; }
+              // Show whichever space-number field is populated, in priority order. RNS_Num is
+              // the reserved-numbered-space value and must win (it is the only populated field
+              // for reserved spaces in many lots, e.g. Lot 96 '9608'/Lot 97 '97024'). VisSpcNum
+              // is the visitor-space number, RV_SpcNum the RV number, and Spc_ID_Num a fallback.
+              var rnsNum = Trim(Text($feature.RNS_Num));
+              if (rnsNum != null && rnsNum != '' && rnsNum != 'null') { return rnsNum; }
+              var visNum = Trim(Text($feature.VisSpcNum));
+              if (visNum != null && visNum != '' && visNum != 'null') { return visNum; }
               var rvNum = Trim(Text($feature.RV_SpcNum));
               if (rvNum != null && rvNum != '' && rvNum != 'null') { return rvNum; }
+              var spcId = Trim(Text($feature.Spc_ID_Num));
+              if (spcId != null && spcId != '' && spcId != 'null') { return spcId; }
               return '';
             `
           },
@@ -504,7 +515,7 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
               weight: 'normal'
             }
           },
-          minScale: 400,
+          minScale: 1200,
           maxScale: 0,
           deconflictionStrategy: 'none'
         }

--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -301,6 +301,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 42.428047,
             color: [255, 255, 255, 255],
+            haloColor: [38, 38, 38, 255],
+            haloSize: 1.5,
             font: {
               family: 'Arial',
               size: 10,
@@ -323,6 +325,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 311.18826944,
             color: [255, 255, 255, 255],
+            haloColor: [38, 38, 38, 255],
+            haloSize: 1.5,
             font: {
               size: 10,
               family: 'Arial',
@@ -345,6 +349,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 42.35101,
             color: [255, 255, 255, 255],
+            haloColor: [38, 38, 38, 255],
+            haloSize: 1.5,
             font: {
               size: 7,
               family: 'Arial',
@@ -367,6 +373,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 310.998628,
             color: [255, 255, 255, 255],
+            haloColor: [38, 38, 38, 255],
+            haloSize: 1.5,
             font: {
               size: 7,
               family: 'Arial',
@@ -387,6 +395,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 40,
             color: [27, 94, 32, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1.5,
             font: {
               size: 6,
               family: 'Arial',
@@ -407,6 +417,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 310,
             color: [27, 94, 32, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1.5,
             font: {
               size: 6,
               family: 'Arial',
@@ -427,6 +439,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 40,
             color: [230, 115, 0, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1.5,
             font: {
               size: 10,
               family: 'Arial',
@@ -447,6 +461,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
             type: 'text',
             angle: 310,
             color: [230, 115, 0, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1.5,
             font: {
               size: 10,
               family: 'Arial',
@@ -474,6 +490,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
           symbol: {
             type: 'text',
             color: [80, 0, 0, 255],
+            haloColor: [255, 255, 255, 255],
+            haloSize: 1.5,
             font: {
               size: 8,
               family: 'Arial',
@@ -509,6 +527,8 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
           symbol: {
             type: 'text',
             color: [255, 255, 255, 255],
+            haloColor: [38, 38, 38, 255],
+            haloSize: 1.5,
             font: {
               size: 9,
               family: 'Arial',


### PR DESCRIPTION
This PR shows the full RNS space numbers on the Campus Main Parking Map and the homepage map.

Lot 97 example:

<img width="3636" height="1993" alt="image" src="https://github.com/user-attachments/assets/c3ceb8e7-779e-42dc-a911-5d6310a8f0df" />

Closes #886