### PR TITLE
fix(aggiemap-angular) Move recommended route layers to top on Summer Commencement map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/graduation-summer.definitions.ts
@@ -11,8 +11,9 @@ import {
 import esri = __esri;
 
 export enum SUMMER_COMMENCEMENT_LAYERS {
-  PARKING_LOTS = 'summer-commencement-parking-lots',
-  TRAFFIC_FLOW = 'summer-commencement-traffic-flow'
+  // Enum order drives draw order (first = top). Recommended Route above Parking Lots so its arrows show.
+  TRAFFIC_FLOW = 'summer-commencement-traffic-flow',
+  PARKING_LOTS = 'summer-commencement-parking-lots'
 }
 
 const eventUrl = Connections.summerCommencementUrl;


### PR DESCRIPTION
This PR moves the recommeneded route layers to the top of the Summer Commencement map.

<img width="3226" height="2037" alt="image" src="https://github.com/user-attachments/assets/8cbe3d65-5cf9-4d56-853b-d2edb022fdab" />


Closes #879 