### PR TITLE
fix(aggiemap-angular) Event ordering by season (#900)

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/aggie-family-parade.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/aggie-family-parade.definitions.ts
@@ -119,6 +119,7 @@ export const AggieFamilyParadeTs: AggiemapCustomMapConfiguration = {
     description: 'Parade route and points of interest for the Aggie Family Parade.',
     source: 'internal',
     type: 'event',
+    columnKey: 'spring',
     keywords: ['aggie', 'family', 'parade', 'route', '150']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -257,7 +257,7 @@ export const BaseballParkingTs: AggiemapCustomMapConfiguration = {
   type: 'general-map',
   discover: {
     id: 'baseball-parking',
-    name: 'Baseball Map',
+    name: BaseballParkingConfiguration.name,
     description: 'Baseball event parking with optional accessibility-focused view.',
     source: 'internal',
     type: 'parking',

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -130,7 +130,7 @@ export const BaseballParkingColdLayerSources: LayerSource[] = [
 export const BaseballParkingConfiguration: EventConfiguration = {
   id: 'baseball-parking',
   name: 'Baseball',
-  applicationName: 'Baseball Parking Map',
+  applicationName: 'Baseball Parking',
   shortApplicationName: 'Baseball Parking',
   introductionText: 'Parking and access information for Texas A&M baseball home games.',
   eventDates: [

--- a/libs/ts/events/ngx/src/lib/definitions/beef-cattle-vendor.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/beef-cattle-vendor.definitions.ts
@@ -197,6 +197,7 @@ export const BeefCattleTs: AggiemapCustomMapConfiguration = {
     source: 'internal',
     type: 'event',
     mapType: 'campus',
+    columnKey: 'summer',
     keywords: ['beef cattle', 'beef cattle vendor', 'vendor load in', 'vendor', 'loading', 'unloading', 'routes']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/cross-country-parking.definitions.ts
@@ -108,9 +108,9 @@ export const CrossCountryParkingColdLayerSources: LayerSource[] = [
 
 export const CrossCountryParkingConfiguration: EventConfiguration = {
   id: 'cross-country-parking',
-  name: 'Cross Country Map',
-  applicationName: 'Cross Country Parking Map',
-  shortApplicationName: 'Cross Country Parking Map',
+  name: 'Cross Country',
+  applicationName: 'Cross Country Parking',
+  shortApplicationName: 'Cross Country Parking',
   introductionText: 'Parking and transportation information for Texas A&M cross country events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/mens-cross-country/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/fire-school.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/fire-school.definitions.ts
@@ -136,6 +136,7 @@ export const FireSchoolTs: AggiemapCustomMapConfiguration = {
     source: 'internal',
     type: 'event',
     mapType: 'campus',
+    columnKey: 'summer',
     keywords: ['fire school', 'municipal fire school', 'vendor show', 'vendor', 'parking', 'road closures', 'route']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/football-parking.definitions.ts
@@ -636,9 +636,9 @@ export const FootballParkingColdLayerSources: LayerSource[] = [
 
 export const FootballParkingConfiguration: EventConfiguration = {
   id: 'gameday-parking',
-  name: 'Football Map',
-  applicationName: 'Football Transportation Map',
-  shortApplicationName: 'Football Map',
+  name: 'Football',
+  applicationName: 'Football Transportation',
+  shortApplicationName: 'Football',
   introductionText: 'Get the best transportation and parking information for game days.',
   // 2026 home schedule (7 home dates at Kyle Field), per the SEC-released schedule:
   // 9/5 Missouri State, 9/12 Arizona State, 9/19 Kentucky, 10/3 Arkansas, 10/17 The Citadel,

--- a/libs/ts/events/ngx/src/lib/definitions/games-of-texas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/games-of-texas.definitions.ts
@@ -172,6 +172,7 @@ export const GamesOfTexasTs: AggiemapCustomMapConfiguration = {
     source: 'internal',
     type: 'event',
     mapType: 'campus',
+    columnKey: 'summer',
     keywords: ['games of texas', 'parking', 'transportation', 'routes', 'event']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/indoor-track-parking.definitions.ts
@@ -172,9 +172,9 @@ export const IndoorTrackParkingColdLayerSources: LayerSource[] = [
 
 export const IndoorTrackParkingConfiguration: EventConfiguration = {
   id: 'indoor-track-parking',
-  name: 'Indoor Track Map',
-  applicationName: 'Indoor Track Parking Map',
-  shortApplicationName: 'Indoor Track Parking Map',
+  name: 'Indoor Track',
+  applicationName: 'Indoor Track Parking',
+  shortApplicationName: 'Indoor Track Parking',
   introductionText: 'Parking and transportation information for Texas A&M indoor track events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/track-and-field/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/maroon-white-game.definitions.ts
@@ -188,8 +188,8 @@ export const MaroonWhiteGameColdLayerSources: LayerSource[] = [
 export const MaroonWhiteGameConfiguration: EventConfiguration = {
   id: 'maroon-white-game-2026',
   name: 'Maroon & White Game',
-  applicationName: 'Maroon & White Game Transportation Map',
-  shortApplicationName: 'Maroon & White Game Map',
+  applicationName: 'Maroon & White Game Transportation',
+  shortApplicationName: 'Maroon & White Game',
   introductionText: 'Get the best parking information for',
   eventDates: ['2026-04-18'],
   scheduleUrl: 'https://12thman.com/sports/football/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/mens-basketball.definitions.ts
@@ -106,9 +106,9 @@ export const MensBasketball_ColdLayerSources: LayerSource[] = [
 
 export const MensBasketball_Configuration: EventConfiguration = {
   id: 'mens-basketball',
-  name: "Men's Basketball Map",
-  applicationName: "Men's Basketball Parking Map",
-  shortApplicationName: "Men's Basketball Parking Map",
+  name: "Men's Basketball",
+  applicationName: "Men's Basketball Parking",
+  shortApplicationName: "Men's Basketball Parking",
   eventDates: [
     '2025-11-03',
     '2025-11-06',

--- a/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/nsc-parking.definitions.ts
@@ -94,6 +94,7 @@ export const NscParkingTs: AggiemapCustomMapConfiguration = {
     description: 'Parking lot information for New Student Conference (NSC) permits.',
     source: 'internal',
     type: 'event',
+    columnKey: 'summer',
     keywords: ['nsc', 'new student conference', 'parking', 'permit']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/outdoor-track-parking.definitions.ts
@@ -123,9 +123,9 @@ export const OutdoorTrackParkingColdLayerSources: LayerSource[] = [
 
 export const OutdoorTrackParkingConfiguration: EventConfiguration = {
   id: 'outdoor-track-parking',
-  name: 'Outdoor Track Map',
-  applicationName: 'Outdoor Track Parking Map',
-  shortApplicationName: 'Outdoor Track Parking Map',
+  name: 'Outdoor Track',
+  applicationName: 'Outdoor Track Parking',
+  shortApplicationName: 'Outdoor Track Parking',
   introductionText: 'Parking and transportation information for Texas A&M outdoor track events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/track-and-field/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/savannah-bananas.definitions.ts
@@ -181,8 +181,8 @@ export const SavannahBananasParkingColdLayerSources: LayerSource[] = [
 export const SavannahBananasParkingConfiguration: EventConfiguration = {
   id: 'savannah-bananas-parking',
   name: 'Banana Ball',
-  applicationName: 'Banana Ball Transportation Map',
-  shortApplicationName: 'Banana Ball Map',
+  applicationName: 'Banana Ball Transportation',
+  shortApplicationName: 'Banana Ball',
   introductionText: 'Parking and transportation info for Savannah Bananas vs Texas Tailgaters at Kyle Field.',
   eventDates: ['2026-05-02'],
   scheduleUrl: 'https://app.12thman.com/bananaball',

--- a/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/soccer-parking.definitions.ts
@@ -158,9 +158,9 @@ export const SoccerParkingColdLayerSources: LayerSource[] = [
 
 export const SoccerParkingConfiguration: EventConfiguration = {
   id: 'soccer-parking',
-  name: 'Soccer Map',
-  applicationName: 'Soccer Parking Map',
-  shortApplicationName: 'Soccer Parking Map',
+  name: 'Soccer',
+  applicationName: 'Soccer Parking',
+  shortApplicationName: 'Soccer Parking',
   introductionText: 'Parking and transportation information for Texas A&M soccer events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/womens-soccer/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-parking.definitions.ts
@@ -120,9 +120,9 @@ export const SoftballParkingColdLayerSources: LayerSource[] = [
 
 export const SoftballParkingConfiguration: EventConfiguration = {
   id: 'softball-parking',
-  name: 'Softball Map',
-  applicationName: 'Softball Parking Map',
-  shortApplicationName: 'Softball Parking Map',
+  name: 'Softball',
+  applicationName: 'Softball Parking',
+  shortApplicationName: 'Softball Parking',
   introductionText: 'Parking and transportation information for Texas A&M softball games.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/softball/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/softball-regionals.definitions.ts
@@ -99,9 +99,9 @@ export const SoftballLayerSources: LayerSource[] = [
 
 export const SoftballConfiguration: EventConfiguration = {
   id: 'softball-regionals-2025',
-  name: 'Softball Regionals Map',
-  applicationName: 'Softball Regionals Event Map',
-  shortApplicationName: 'Softball Regionals Map',
+  name: 'Softball Regionals',
+  applicationName: 'Softball Regionals Event',
+  shortApplicationName: 'Softball Regionals',
   introductionText: 'Get the best transportation and parking information for Softball Regionals.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/softball/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/swimming-parking.definitions.ts
@@ -155,9 +155,9 @@ export const SwimmingParkingColdLayerSources: LayerSource[] = [
 
 export const SwimmingParkingConfiguration: EventConfiguration = {
   id: 'swimming-parking',
-  name: 'Swimming Map',
-  applicationName: 'Swimming Parking Map',
-  shortApplicationName: 'Swimming Parking Map',
+  name: 'Swimming',
+  applicationName: 'Swimming Parking',
+  shortApplicationName: 'Swimming Parking',
   introductionText: 'Parking and transportation information for Texas A&M swimming events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/swimdive/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/t-camp.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/t-camp.definitions.ts
@@ -162,6 +162,7 @@ export const TCampTs: AggiemapCustomMapConfiguration = {
     source: 'internal',
     type: 'event',
     mapType: 'campus',
+    columnKey: 'summer',
     keywords: ['t camp', 'tcamp', 'transfer camp', 'new student', 'parking', 'transportation', 'closures', 'entry route']
   }
 };

--- a/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/tennis-parking.definitions.ts
@@ -53,9 +53,9 @@ export const TennisParkingColdLayerSources: LayerSource[] = [
 
 export const TennisParkingConfiguration: EventConfiguration = {
   id: 'tennis-parking',
-  name: 'Tennis Map',
-  applicationName: 'Tennis Parking Map',
-  shortApplicationName: 'Tennis Parking Map',
+  name: 'Tennis',
+  applicationName: 'Tennis Parking',
+  shortApplicationName: 'Tennis Parking',
   introductionText: 'Parking and transportation information for Texas A&M tennis events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/mens-tennis/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/troubadour-festival.definitions.ts
@@ -67,6 +67,7 @@ export const TroubadourTs: AggiemapCustomMapConfiguration = {
     name: TroubadourConfiguration.name,
     description: 'Transportation and parking information for Troubadour Festival.',
     source: 'internal',
+    visible: false,
     type: 'event',
     columnKey: 'spring',
     keywords: ['troubadour', 'festival', 'parking', 'transportation']

--- a/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/volleyball-parking.definitions.ts
@@ -164,9 +164,9 @@ export const VolleyballParkingColdLayerSources: LayerSource[] = [
 
 export const VolleyballParkingConfiguration: EventConfiguration = {
   id: 'volleyball-parking',
-  name: 'Volleyball Map',
-  applicationName: 'Volleyball Parking Map',
-  shortApplicationName: 'Volleyball Parking Map',
+  name: 'Volleyball',
+  applicationName: 'Volleyball Parking',
+  shortApplicationName: 'Volleyball Parking',
   introductionText: 'Parking and transportation information for Texas A&M volleyball events.',
   eventDates: [],
   scheduleUrl: 'https://12thman.com/sports/womens-volleyball/schedule',

--- a/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/womens-basketball.definitions.ts
@@ -132,9 +132,9 @@ export const WomensBasketball_ColdLayerSources: LayerSource[] = [
 
 export const WomensBasketball_Configuration: EventConfiguration = {
   id: 'womens-basketball',
-  name: "Women's Basketball Map",
-  applicationName: "Women's Basketball Parking Map",
-  shortApplicationName: "Women's Basketball Parking Map",
+  name: "Women's Basketball",
+  applicationName: "Women's Basketball Parking",
+  shortApplicationName: "Women's Basketball Parking",
   eventDates: [
     '2025-11-05',
     '2025-11-13',


### PR DESCRIPTION
This fixes the event season association so the events are in the correct columns. 

This fixes and closes #900 