### PR TITLE
fix(aggiemap-angular): Fix links to lots 77 and 97 

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.spec.ts
@@ -214,4 +214,27 @@ describe('SearchSources', () => {
       transformations: ['UPPER']
     });
   });
+
+  it('should resolve parking lot deep links to the lot itself rather than one of its sub-areas', () => {
+    const result = SearchSources(connections, definitions);
+    const parkingLot = result.find((source) => source.source === 'parking-lot');
+
+    expect(parkingLot?.urlQueryParam).toBe('lot');
+    expect(parkingLot?.urlQueryParamAliases).toEqual(['Lot']);
+
+    // `?lot=077` (zero-padded, as TS parking map links are) has to match on FAC_CODE; `?lot=77`
+    // matches on Name. Dropping either key makes one of the two link styles unresolvable.
+    expect(parkingLot?.queryParams?.where).toEqual({
+      keys: ['LotName', 'Name', 'FAC_CODE'],
+      operators: ['LIKE', 'LIKE', 'LIKE'],
+      wildcards: ['includes', 'includes', 'includes'],
+      transformations: ['UPPER', 'UPPER', 'UPPER']
+    });
+
+    // Multiple polygons share a lot's name and facility code. Without an explicit ordering the
+    // service answers in OBJECTID order and `features[0]` lands on whichever loading, restricted,
+    // or visitor sub-area was digitized first — the Lot 77 and Lot 97 deep link defect.
+    expect(parkingLot?.queryParams?.orderByFields).toBe('AggieMap DESC, CIT_CODE ASC');
+    expect(parkingLot?.scoringKeys).toEqual(['attributes.Name', 'attributes.FAC_CODE', 'attributes.LotName']);
+  });
 });

--- a/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
+++ b/libs/aggiemap/ngx/common/src/lib/search-sources/search-sources.ts
@@ -225,19 +225,38 @@ export function SearchSources(
       popupComponent: Popups.BuildingPopupComponent,
       searchActive: true
     },
+    // A single parking facility is stored as several polygons — the lot proper plus its loading,
+    // restricted, and visitor sub-areas — all sharing a `FAC_CODE` and, often, a `LotName`. They are
+    // told apart by `CIT_CODE` (the facility code plus a two-digit sub-code, where `00` is the lot
+    // itself; this is the identifier TS parking map links use, e.g. `?cit=07700`).
+    //
+    // `?lot=` deep links resolve to `features[0]`, so an ambiguous match has to be ordered rather
+    // than left in the service's default `OBJECTID` order — otherwise the sub-area that happens to
+    // have been digitized first wins. `?lot=077` landed on the Lot 77 loading zone and `?lot=097`
+    // on the Lot 97 visitor section for exactly this reason.
+    //
+    // `AggieMap DESC` drops the sub-areas flagged as not shown on this map below the ones that are,
+    // and `CIT_CODE ASC` then prefers the lot itself over its sub-areas — together resolving a bare
+    // lot number to the same polygon the TS parking map's `?cit=<lot>00` link points at.
     PARKING_LOT: {
       source: 'parking-lot',
       name: 'Parking Lot',
       url: `${connections.basemapUrl}/9`,
       queryParams: {
         ...commonQueryParams,
+        orderByFields: 'AggieMap DESC, CIT_CODE ASC',
         where: {
-          keys: ['LotName', 'Name'],
-          operators: ['LIKE', 'LIKE'],
-          wildcards: ['includes', 'includes'],
-          transformations: ['UPPER', 'UPPER']
+          // `FAC_CODE` is matched alongside the display names so the zero-padded facility number
+          // used by TS links (`?lot=077`) resolves as readily as the unpadded `Name` (`?lot=77`).
+          keys: ['LotName', 'Name', 'FAC_CODE'],
+          operators: ['LIKE', 'LIKE', 'LIKE'],
+          wildcards: ['includes', 'includes', 'includes'],
+          transformations: ['UPPER', 'UPPER', 'UPPER']
         }
       },
+      // Ranks an exact identifier match above the partial ones the `includes` wildcards let through,
+      // so `?lot=100` cannot settle on `Lot 1001` when `Lot 100` exists.
+      scoringKeys: ['attributes.Name', 'attributes.FAC_CODE', 'attributes.LotName'],
       featuresLocation: 'features',
       displayTemplate: '{attributes.LotName}',
       popupComponent: Popups.ParkingLotPopupComponent,

--- a/libs/ui-kits/ngx/search/src/lib/services/search.service.ts
+++ b/libs/ui-kits/ngx/search/src/lib/services/search.service.ts
@@ -643,6 +643,18 @@ export interface SearchSourceQueryParamsProperties {
   spatialRel?: string | 'esriSpatialRelIntersects';
 
   /**
+   * Comma-delimited list of fields (each optionally suffixed with `ASC`/`DESC`) used to sort the
+   * features returned by the service.
+   *
+   * Without it, a service returns features in `OBJECTID` order, which makes the "first" feature of
+   * an ambiguous match arbitrary. Provide this for any source whose `resultRecordCount` truncates
+   * results or whose consumers select `features[0]` (e.g. URL parameter feature selection).
+   *
+   * Example: `'AggieMap DESC, CIT_CODE ASC'`
+   */
+  orderByFields?: string;
+
+  /**
    * Where clause properties that dictate how the search query will be constructed.
    */
   where?: SearchSourceWhereProperties;


### PR DESCRIPTION
This PR fixes an issue where links directly to lots 77 and 97 took users to incorrect lots.

Lot 77 link working: https://aggiemap.tamu.edu/?lot=077
<img width="2774" height="1786" alt="image" src="https://github.com/user-attachments/assets/77685051-03b5-40c5-ad1f-70ff5d84c73d" />

Lot 97 link working: https://aggiemap.tamu.edu/?lot=097
<img width="2990" height="1912" alt="image" src="https://github.com/user-attachments/assets/b8b29724-157e-4306-94d7-7131524ff8c5" />

Closes #862