### PR TITLE
fix(aggiemap-angular): Remove unnecessary RV Lot labels from Main Campus Map

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/main-parking.definitions.ts
@@ -528,8 +528,13 @@ export const TsMainParkingColdLayerSources: LayerSource[] = [
               if (rnsNum != null && rnsNum != '' && rnsNum != 'null') { return rnsNum; }
               var visNum = Trim(Text($feature.VisSpcNum));
               if (visNum != null && visNum != '' && visNum != 'null') { return visNum; }
-              var rvNum = Trim(Text($feature.RV_SpcNum));
-              if (rvNum != null && rvNum != '' && rvNum != 'null') { return rvNum; }
+              // RV_SpcNum is only trustworthy on true RV spaces (Anno_Type = 'RV'). Some lots
+              // (e.g. 100e) have stray values in this field on regular (Reg) spaces, which
+              // showed up as bogus space numbers across lots that have no RV parking at all.
+              if ($feature.Anno_Type == 'RV') {
+                var rvNum = Trim(Text($feature.RV_SpcNum));
+                if (rvNum != null && rvNum != '' && rvNum != 'null') { return rvNum; }
+              }
               var spcId = Trim(Text($feature.Spc_ID_Num));
               if (spcId != null && spcId != '' && spcId != 'null') { return spcId; }
               return '';


### PR DESCRIPTION
This PR removes the RV lots from the Main Campus map while also keeping them on the actual RV lots.

<img width="3774" height="2031" alt="image" src="https://github.com/user-attachments/assets/951c1d50-9d02-4a7c-97a3-09cb61c5a8e9" />

Also keeps them where they're supposed to go, i.e. Lot 100d

<img width="2313" height="1826" alt="image" src="https://github.com/user-attachments/assets/c8e74f21-0190-430b-aa41-8b6cd50185eb" />

Closes #917