### PR TITLE
fix(aggiemap-ngx-common): Correct summer parking service

### DIFF
--- a/libs/aggiemap/ngx/common/src/lib/connections.ts
+++ b/libs/aggiemap/ngx/common/src/lib/connections.ts
@@ -23,7 +23,7 @@ function createConnections(gisHost: string): IComposedConnections {
     avpParkingUrl: `https://${tsgisHost}/arcgis/rest/services/TS_Events/AnyValidPermitParking/MapServer`,
     baseballParkingUrl: `https://${tsgisHost}/arcgis/rest/services/Hosted/BaseballParking_view/FeatureServer`,
     bigEventUrl: `https://${tsgisHost}/arcgis/rest/services/Hosted/Big_Event_view/FeatureServer`,
-    breakSummerParkingUrl: `https://${gisHost}/arcgis/rest/services/TS/SummerBreakParking/MapServer`,
+    breakSummerParkingUrl: `https://${tsgisHost}/arcgis/rest/services/TS_Events/SummerBreakParking/MapServer`,
     businessParkingUrl: `https://${tsgisHost}/arcgis/rest/services/TS_Events/BusinessParking/MapServer`,
     contractorParkingUrl: `https://${tsgisHost}/arcgis/rest/services/TS_Events/ContractorParking/MapServer`,
     crossCountryParkingUrl: `https://${tsgisHost}/arcgis/rest/services/Hosted/CrossCountryParking_view/FeatureServer`,


### PR DESCRIPTION
Use the Transportation Services host and active TS_Events service path for Break/Summer Parking.\n\nFixes #919\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>