### PR TITLE
fix(ts-events-angular): hatch street closures

### DIFF
--- a/libs/ts/events/ngx/src/lib/definitions/april-ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/april-ring-day.definitions.ts
@@ -1,4 +1,4 @@
-import { LayerSource } from '@tamu-gisc/common/types';
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
 import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
@@ -26,6 +26,79 @@ const aprilRingDayDateConversions = (startField: string, endField: string) =>
   }));
 
 const eventUrl = Connections.ringDayUrl;
+
+const simpleFillSymbol = (
+  color: number[],
+  outlineColor: number[],
+  outlineWidth: number,
+  style: 'solid' | 'backward-diagonal' | 'diagonal-cross' = 'solid'
+) => ({
+  type: 'simple-fill',
+  style,
+  color,
+  outline:
+    outlineWidth > 0
+      ? {
+          type: 'simple-line',
+          style: 'solid',
+          color: outlineColor,
+          width: outlineWidth
+        }
+      : null
+});
+
+// Preserve the hosted layer categories while replacing its solid closure fill with the Move-In hatch.
+const ringDayAreaRenderer = {
+  type: 'unique-value',
+  field: 'type',
+  uniqueValueInfos: [
+    {
+      value: 'Accessible',
+      label: 'Accessible Path',
+      symbol: simpleFillSymbol([0, 112, 255, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Event Parking',
+      label: 'Event Parking',
+      symbol: simpleFillSymbol([0, 197, 255, 255], [0, 112, 255, 255], 2)
+    },
+    {
+      value: 'Sales',
+      label: 'Aggie Ring Day Marketplace',
+      symbol: simpleFillSymbol([56, 168, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Ticketed Area',
+      label: 'Ticketed Area',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [233, 196, 106, 255], 1, 'backward-diagonal')
+    },
+    {
+      value: 'Gathering Area',
+      label: 'Gathering Area',
+      symbol: simpleFillSymbol([115, 0, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Closure',
+      label: 'Lot or Street Closure',
+      symbol: simpleFillSymbol([230, 0, 0, 255], [230, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: 'The Williams Alumni Center',
+      label: 'The Williams Alumni Center',
+      symbol: simpleFillSymbol([137, 68, 68, 255], [115, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: '$5 Event Parking',
+      label: '$10 Event Parking',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Lot Specific Permit Required',
+      label: 'Lot Specific Permit Required',
+      symbol: simpleFillSymbol([244, 162, 97, 255], [110, 110, 110, 255], 0.7)
+    }
+  ]
+} as unknown as NonNullable<NonNullable<FeatureLayerSourceProperties['native']>['renderer']>;
 
 const AprilRingDayEventDefinitions = {
   RD_AREAS: {
@@ -62,7 +135,8 @@ export const AprilRingDayColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: ringDayAreaRenderer
     }
   },
   {

--- a/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/baseball-parking.definitions.ts
@@ -1,4 +1,4 @@
-import { LayerSource } from '@tamu-gisc/common/types';
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
 import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
@@ -27,6 +27,21 @@ enum BaseballMapMode {
 }
 
 const eventUrl = Connections.baseballParkingUrl;
+
+const streetClosureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    style: 'diagonal-cross',
+    color: [230, 0, 0, 255],
+    outline: {
+      type: 'simple-line',
+      style: 'solid',
+      color: [230, 0, 0, 255],
+      width: 1
+    }
+  }
+} as unknown as NonNullable<NonNullable<FeatureLayerSourceProperties['native']>['renderer']>;
 
 export const BaseballParkingColdLayerSources: LayerSource[] = [
   {
@@ -67,7 +82,8 @@ export const BaseballParkingColdLayerSources: LayerSource[] = [
     url: `${eventUrl}/2`,
     popupComponent: MarkdownPopupComponent,
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: streetClosureRenderer
     }
   },
   {

--- a/libs/ts/events/ngx/src/lib/definitions/november-ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/november-ring-day.definitions.ts
@@ -1,4 +1,4 @@
-import { LayerSource } from '@tamu-gisc/common/types';
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
 import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
@@ -25,6 +25,79 @@ const novemberRingDayDateConversions = (startField: string, endField: string) =>
   }));
 
 const eventUrl = Connections.ringDayUrl;
+
+const simpleFillSymbol = (
+  color: number[],
+  outlineColor: number[],
+  outlineWidth: number,
+  style: 'solid' | 'backward-diagonal' | 'diagonal-cross' = 'solid'
+) => ({
+  type: 'simple-fill',
+  style,
+  color,
+  outline:
+    outlineWidth > 0
+      ? {
+          type: 'simple-line',
+          style: 'solid',
+          color: outlineColor,
+          width: outlineWidth
+        }
+      : null
+});
+
+// Preserve the hosted layer categories while replacing its solid closure fill with the Move-In hatch.
+const ringDayAreaRenderer = {
+  type: 'unique-value',
+  field: 'type',
+  uniqueValueInfos: [
+    {
+      value: 'Accessible',
+      label: 'Accessible Path',
+      symbol: simpleFillSymbol([0, 112, 255, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Event Parking',
+      label: 'Event Parking',
+      symbol: simpleFillSymbol([0, 197, 255, 255], [0, 112, 255, 255], 2)
+    },
+    {
+      value: 'Sales',
+      label: 'Aggie Ring Day Marketplace',
+      symbol: simpleFillSymbol([56, 168, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Ticketed Area',
+      label: 'Ticketed Area',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [233, 196, 106, 255], 1, 'backward-diagonal')
+    },
+    {
+      value: 'Gathering Area',
+      label: 'Gathering Area',
+      symbol: simpleFillSymbol([115, 0, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Closure',
+      label: 'Lot or Street Closure',
+      symbol: simpleFillSymbol([230, 0, 0, 255], [230, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: 'The Williams Alumni Center',
+      label: 'The Williams Alumni Center',
+      symbol: simpleFillSymbol([137, 68, 68, 255], [115, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: '$5 Event Parking',
+      label: '$10 Event Parking',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Lot Specific Permit Required',
+      label: 'Lot Specific Permit Required',
+      symbol: simpleFillSymbol([244, 162, 97, 255], [110, 110, 110, 255], 0.7)
+    }
+  ]
+} as unknown as NonNullable<NonNullable<FeatureLayerSourceProperties['native']>['renderer']>;
 
 const NovemberRingDayEventDefinitions = {
   RD_AREAS: {
@@ -61,7 +134,8 @@ export const NovemberRingDayColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: ringDayAreaRenderer
     }
   },
   {

--- a/libs/ts/events/ngx/src/lib/definitions/october-ring-day.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/october-ring-day.definitions.ts
@@ -1,4 +1,4 @@
-import { LayerSource } from '@tamu-gisc/common/types';
+import { FeatureLayerSourceProperties, LayerSource } from '@tamu-gisc/common/types';
 import { Connections } from '@tamu-gisc/aggiemap/ngx/common';
 
 import { MarkdownPopupComponent } from '../modules/popups/markdown-popup/markdown-popup.component';
@@ -26,6 +26,79 @@ const ringDayDateConversions = (startField: string, endField: string) =>
   }));
 
 const eventUrl = Connections.ringDayUrl;
+
+const simpleFillSymbol = (
+  color: number[],
+  outlineColor: number[],
+  outlineWidth: number,
+  style: 'solid' | 'backward-diagonal' | 'diagonal-cross' = 'solid'
+) => ({
+  type: 'simple-fill',
+  style,
+  color,
+  outline:
+    outlineWidth > 0
+      ? {
+          type: 'simple-line',
+          style: 'solid',
+          color: outlineColor,
+          width: outlineWidth
+        }
+      : null
+});
+
+// Preserve the hosted layer categories while replacing its solid closure fill with the Move-In hatch.
+const ringDayAreaRenderer = {
+  type: 'unique-value',
+  field: 'type',
+  uniqueValueInfos: [
+    {
+      value: 'Accessible',
+      label: 'Accessible Path',
+      symbol: simpleFillSymbol([0, 112, 255, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Event Parking',
+      label: 'Event Parking',
+      symbol: simpleFillSymbol([0, 197, 255, 255], [0, 112, 255, 255], 2)
+    },
+    {
+      value: 'Sales',
+      label: 'Aggie Ring Day Marketplace',
+      symbol: simpleFillSymbol([56, 168, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Ticketed Area',
+      label: 'Ticketed Area',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [233, 196, 106, 255], 1, 'backward-diagonal')
+    },
+    {
+      value: 'Gathering Area',
+      label: 'Gathering Area',
+      symbol: simpleFillSymbol([115, 0, 0, 255], [110, 110, 110, 255], 0)
+    },
+    {
+      value: 'Closure',
+      label: 'Lot or Street Closure',
+      symbol: simpleFillSymbol([230, 0, 0, 255], [230, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: 'The Williams Alumni Center',
+      label: 'The Williams Alumni Center',
+      symbol: simpleFillSymbol([137, 68, 68, 255], [115, 0, 0, 255], 1, 'diagonal-cross')
+    },
+    {
+      value: '$5 Event Parking',
+      label: '$10 Event Parking',
+      symbol: simpleFillSymbol([233, 196, 106, 255], [110, 110, 110, 255], 0.7)
+    },
+    {
+      value: 'Lot Specific Permit Required',
+      label: 'Lot Specific Permit Required',
+      symbol: simpleFillSymbol([244, 162, 97, 255], [110, 110, 110, 255], 0.7)
+    }
+  ]
+} as unknown as NonNullable<NonNullable<FeatureLayerSourceProperties['native']>['renderer']>;
 
 const RingDayEventDefinitions = {
   RD_AREAS: {
@@ -62,7 +135,8 @@ export const RingDayColdLayerSources: LayerSource[] = [
     visible: true,
     listMode: 'show',
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: ringDayAreaRenderer
     }
   },
   {

--- a/libs/ts/events/ngx/src/lib/definitions/t-camp.definitions.ts
+++ b/libs/ts/events/ngx/src/lib/definitions/t-camp.definitions.ts
@@ -20,6 +20,21 @@ export enum T_CAMP_LAYERS {
 
 const tCampUrl = Connections.tCampUrl;
 
+const streetClosureRenderer = {
+  type: 'simple',
+  symbol: {
+    type: 'simple-fill',
+    style: 'diagonal-cross',
+    color: [230, 0, 0, 255],
+    outline: {
+      type: 'simple-line',
+      style: 'solid',
+      color: [230, 0, 0, 255],
+      width: 1
+    }
+  }
+} as unknown as NonNullable<NonNullable<FeatureLayerSourceProperties['native']>['renderer']>;
+
 // Every feature in the service carries a rich, pre-formatted HTML `description` along with a `name`,
 // so a single name/description popup works for all four layers.
 const popup = {
@@ -92,7 +107,8 @@ export const TCampColdLayerSources: LayerSource[] = [
     listMode: 'show',
     ...popup,
     native: {
-      outFields: ['*']
+      outFields: ['*'],
+      renderer: streetClosureRenderer
     }
   },
   {
@@ -135,8 +151,7 @@ export const TCampConfiguration: EventConfiguration = {
   name: 'T Camp',
   applicationName: 'T Camp Parking & Transportation Map',
   shortApplicationName: 'T Camp Map',
-  introductionText:
-    'Find parking, entry routes, and closures for T Camp. Use the map to plan your drop-off and pickup.',
+  introductionText: 'Find parking, entry routes, and closures for T Camp. Use the map to plan your drop-off and pickup.',
   eventDates: [],
   scheduleUrl: 'https://transport.tamu.edu/Parking/Events/camp.aspx',
   // The Williams Alumni Center sits ~570m southwest of the lots, so the initial view has to cover the


### PR DESCRIPTION
Replace solid closure fills with the red diagonal-cross symbology used by Move-In.

Preserve all existing area categories for April, October, and November Ring Day, and add explicit closure renderers for T-Camp and Baseball Parking.

Keep each renderer self-contained in its event definition for straightforward maintenance.

Closes #924