### PR TITLE
fix(aggiemap-angular): Shared links to lots now drill down to lots

### DIFF
--- a/libs/ts/events/ngx/src/lib/guards/settings/settings.guard.ts
+++ b/libs/ts/events/ngx/src/lib/guards/settings/settings.guard.ts
@@ -34,7 +34,11 @@ export class SettingsGuard implements CanActivate {
 
     try {
       // Call event settings service to update and set/overwrite any settings in local storage.
-      if (queryParamsKeySize && queryParamsKeySize > 0) {
+      //
+      // Only params keyed to a configurable option count as settings. A link that carries just a
+      // feature deep-link (e.g. `?feature=Move-In Lots:34815`) would otherwise be read as an empty
+      // set of selections and wipe whatever the visitor already had saved.
+      if (this.ess.hasSettingsQueryParams(queryParams)) {
         this.ess.setSettingsFromQueryParams(queryParams);
 
         this.anl.eventTrack.next({
@@ -49,6 +53,9 @@ export class SettingsGuard implements CanActivate {
       } else if (appSettings) {
         return of(true).pipe(delay(100)); // Add artificial delay to allow settings to be set before proceeding.
       }
+
+      // Nothing to restore from either source; the map handles the unconfigured case.
+      return true;
     } catch (err) {
       this.ns.toast({
         id: 'special-events-settings-error',
@@ -58,7 +65,5 @@ export class SettingsGuard implements CanActivate {
 
       return this.router.parseUrl('/builder');
     }
-
-    return false;
   }
 }

--- a/libs/ts/events/ngx/src/lib/modules/popups/base-event-popup/base-event-popup.component.ts
+++ b/libs/ts/events/ngx/src/lib/modules/popups/base-event-popup/base-event-popup.component.ts
@@ -1,3 +1,4 @@
+import { inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { Angulartics2 } from 'angulartics2';
@@ -8,9 +9,13 @@ import { EsriMapService } from '@tamu-gisc/maps/esri';
 import { TripPlannerService } from '@tamu-gisc/maps/feature/trip-planner';
 import { SearchSource } from '@tamu-gisc/ui-kits/ngx/search';
 
+import { EventSettingsService } from '../../../services/settings/event-settings.service';
+
 import esri = __esri;
 
 export abstract class BaseEventPopupComponent extends BaseDirectionsComponent {
+  private readonly _eventSettingsService = inject(EventSettingsService);
+
   constructor(
     router: Router,
     route: ActivatedRoute,
@@ -39,9 +44,32 @@ export abstract class BaseEventPopupComponent extends BaseDirectionsComponent {
     const params = new URLSearchParams(window.location.search);
 
     this._clearExistingFeatureParams(params);
+    this._applyEventSettingParams(params);
     params.set('feature', `${layerId}:${objectId}`);
 
     return `?${params.toString()}`;
+  }
+
+  /**
+   * Builder selections are persisted in local storage rather than in the map url, so a link copied
+   * from a popup would otherwise carry only the feature reference. Without the selections, the
+   * recipient lands on an unconfigured map and gets bounced into the builder instead of the shared
+   * feature. Stamping the current selections onto the link lets the settings guard restore them.
+   *
+   * Any setting already present in the url wins, as it is what the current map is actually showing.
+   */
+  private _applyEventSettingParams(params: URLSearchParams): void {
+    const settingParams = this._eventSettingsService.queryParamsFromSettings;
+
+    if (!settingParams) {
+      return;
+    }
+
+    settingParams.forEach((value, key) => {
+      if (!params.has(key)) {
+        params.set(key, value);
+      }
+    });
   }
 
   private _clearExistingFeatureParams(params: URLSearchParams): void {

--- a/libs/ts/events/ngx/src/lib/services/event/event.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/event/event.service.ts
@@ -487,8 +487,8 @@ export class EventService {
       return;
     }
 
-    const layer = this._map.findLayerById(layerId) as esri.FeatureLayer | undefined;
-    const source = sources.find((candidate) => candidate.id === layerId);
+    const layer = this.findMapLayerById(layerId) as esri.FeatureLayer | undefined;
+    const source = this.findLayerSourceById(sources, layerId);
 
     if (!layer || !source) {
       console.warn(`EventService.selectFeatureFromUrl: Layer '${layerId}' not found.`);
@@ -523,6 +523,48 @@ export class EventService {
       shouldShowPopup: true,
       popupComponent: this.getPopupComponent(source)
     });
+  }
+
+  /**
+   * Resolves a layer by id anywhere on the map, including layers nested inside a group layer.
+   *
+   * `Map.findLayerById` only looks at top-level operational layers, so a feature belonging to a
+   * grouped layer (e.g. the move-in parking lots, which live under a `Parking Lots` group) could
+   * not be resolved from a shared `feature=` link.
+   */
+  private findMapLayerById(layerId: string): esri.Layer | undefined {
+    if (!this._map) {
+      return undefined;
+    }
+
+    const topLevel = this._map.findLayerById(layerId);
+
+    if (topLevel) {
+      return topLevel;
+    }
+
+    return this._map.allLayers?.find((layer) => layer.id === layerId);
+  }
+
+  /**
+   * Resolves a layer source by id, walking nested group sources. The counterpart to
+   * `findMapLayerById` for the definition side of a grouped layer.
+   */
+  private findLayerSourceById(sources: LayerSource[], layerId: string): LayerSource | undefined {
+    for (const source of sources) {
+      if (source.id === layerId) {
+        return source;
+      }
+
+      const children = (source as { sources?: LayerSource[] }).sources;
+      const nested = children ? this.findLayerSourceById(children, layerId) : undefined;
+
+      if (nested) {
+        return nested;
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
+++ b/libs/ts/events/ngx/src/lib/services/settings/event-settings.service.ts
@@ -483,13 +483,18 @@ export class EventSettingsService {
 
   /**
    * Returns true when the provided query params include a supported feature deep-link
-   * such as `?lot=43`, allowing maps to open directly without builder selections.
+   * such as `?lot=43` or the generic `?feature=<layerId>:<objectId>` emitted by popup share links,
+   * allowing maps to open directly without builder selections.
    */
   public hasFeatureSelectionQueryParams(params?: Params): boolean {
     const queryParams = params ?? this.at.snapshot.queryParams;
 
     if (!queryParams) {
       return false;
+    }
+
+    if (this._hasQueryParamValue(queryParams, 'feature')) {
+      return true;
     }
 
     const searchSources = this.env.value('SearchSources') as SearchSource[] | null | undefined;
@@ -505,15 +510,33 @@ export class EventSettingsService {
 
       const parameterKeys = [searchSource.urlQueryParam, ...(searchSource.urlQueryParamAliases || [])];
 
-      return parameterKeys.some((key) => {
-        const value = queryParams[key];
-
-        if (Array.isArray(value)) {
-          return value.some((entry) => `${entry}`.trim().length > 0);
-        }
-
-        return value !== undefined && value !== null && `${value}`.trim().length > 0;
-      });
+      return parameterKeys.some((key) => this._hasQueryParamValue(queryParams, key));
     });
+  }
+
+  /**
+   * Returns true when the provided query params carry at least one builder selection, i.e. a param
+   * keyed to one of the event's configurable options. Used to determine whether the url should be
+   * treated as the authoritative source of settings; params like `?feature=` or `?basemap=` are not
+   * selections and must not be mistaken for them.
+   */
+  public hasSettingsQueryParams(params?: Params): boolean {
+    const queryParams = params ?? this.at.snapshot.queryParams;
+
+    if (!queryParams) {
+      return false;
+    }
+
+    return this.eventOptions().some((option) => this._hasQueryParamValue(queryParams, option.value));
+  }
+
+  private _hasQueryParamValue(params: Params, key: string): boolean {
+    const value = params[key];
+
+    if (Array.isArray(value)) {
+      return value.some((entry) => `${entry}`.trim().length > 0);
+    }
+
+    return value !== undefined && value !== null && `${value}`.trim().length > 0;
   }
 }


### PR DESCRIPTION
This PR fixes an issue where shared links to different lots did not drill down to the lot itself. This PR makes shared links zoom to the respective lot.

<img width="3317" height="1822" alt="image" src="https://github.com/user-attachments/assets/2d0d3eac-de52-490b-98a7-d9c9bcc43fa2" />


Closes #840 

